### PR TITLE
Update AdImpression comment to be correct

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1032,7 +1032,7 @@ class AdImpression(BaseImpression):
     """
     Track stats around how successful this ad has been.
 
-    Indexed one per ad per day.
+    Indexed one per ad per day per publisher.
     """
 
     publisher = models.ForeignKey(


### PR DESCRIPTION
- This model is one DB record per unique combination of date, publisher, advertisement
- This mostly only changes if the same ad is shown across publishers