### PR TITLE
Optionally enforce a specific host for all requests

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "enforce_host.EnforceHostMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -62,11 +62,11 @@ if env.bool("ADSERVER_HTTPS", default=False):
     SECURE_HSTS_PRELOAD = True
 
     # Redirect HTTP -> HTTPS
-    # Redirect all requests to SECURE_SSL_HOST if it is set
     # https://devcenter.heroku.com/articles/http-routing#heroku-headers
+    # Optionally enforce a specific host. Other hosts will redirect
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_SSL_REDIRECT = True
-    SECURE_SSL_HOST = env("SECURE_SSL_HOST", default=None)
+    ENFORCE_HOST = env("ENFORCE_HOST", default=None)
 
 
 # Email settings

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,3 +45,6 @@ analytical==0.0.1
 
 jsonfield==2.0.2
 bleach==3.1.0
+
+# Security features
+django-enforce-host==1.0.1


### PR DESCRIPTION
Enforce a specific host for all requests. This gives the correct redirect order of `HTTP -> HTTPS (same host) -> HTTPS (preferred/enforced host)`.