### PR TITLE
Use envvars for geolite2

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -111,4 +111,6 @@ ADSERVER_CLICK_RATELIMITS = env.list(
 
 # GeoIP settings
 # This directory should be the path to GeoLite2-City.mmdb and GeoLite2-Country.mmdb
-GEOIP_PATH = env("GEOIP_PATH", default=GEOIP_PATH)
+GEOIP_PATH = env("GEOIP_GEOLITE2_PATH", default=GEOIP_PATH)
+GEOIP_CITY = env("GEOIP_GEOLITE2_CITY_FILENAME", default=None)
+GEOIP_COUNTRY = env("GEOIP_GEOLITE2_COUNTRY_FILENAME", default=None)


### PR DESCRIPTION
This is a configuration only change which lets us control various GeoIP settings with envvars. Notably, these envvars are the ones set by [this buildpack](https://github.com/danstiner/heroku-buildpack-geoip-geolite2) which I would like to try on Heroku. However, the envvars should allow us a lot of flexibility.

Fixes #52.