### PR TITLE
Re-add the proxy views for click/view metric collection

### DIFF
--- a/adserver/api/serializers.py
+++ b/adserver/api/serializers.py
@@ -2,7 +2,6 @@
 from rest_framework import serializers
 
 from ..constants import ALL_CAMPAIGN_TYPES
-from ..models import Advertisement
 from ..models import Advertiser
 from ..models import Publisher
 
@@ -71,27 +70,12 @@ class AdDecisionSerializer(serializers.Serializer):
 
         raise serializers.ValidationError("Invalid publisher")
 
+    def validate_keywords(self, keywords):
+        if keywords:
+            # Lowercase all the keywords
+            keywords = [k.lower() for k in keywords]
 
-class AdTrackingSerializer(serializers.Serializer):
-
-    """A serializer for data that tracks views and clicks."""
-
-    # Required fields
-    advertisement = serializers.SlugField(required=True)
-    nonce = serializers.CharField(required=True)
-    url = serializers.URLField(required=True)
-
-    # Used to pass the actual ad viewer's data for targeting purposes
-    user_ip = serializers.IPAddressField(required=False)
-    user_ua = serializers.CharField(required=False)
-
-    def validate_advertisement(self, advertisement_slug):
-        # Resolve the slug into the actual ad
-        advertisement = Advertisement.objects.filter(slug=advertisement_slug).first()
-        if not advertisement:
-            raise serializers.ValidationError("Invalid advertisement")
-
-        return advertisement
+        return keywords
 
 
 class PublisherSerializer(serializers.HyperlinkedModelSerializer):

--- a/adserver/api/urls.py
+++ b/adserver/api/urls.py
@@ -4,16 +4,10 @@ from rest_framework import routers
 
 from .views import AdDecisionView
 from .views import AdvertiserViewSet
-from .views import ClickTrackingView
 from .views import PublisherViewSet
-from .views import ViewTrackingView
 
 
-urlpatterns = [
-    url(r"^decision/$", AdDecisionView.as_view(), name="decision"),
-    url(r"^track/view/$", ViewTrackingView.as_view(), name="view-tracking"),
-    url(r"^track/click/$", ClickTrackingView.as_view(), name="click-tracking"),
-]
+urlpatterns = [url(r"^decision/$", AdDecisionView.as_view(), name="decision")]
 
 router = routers.SimpleRouter()
 router.register(r"advertisers", AdvertiserViewSet, base_name="advertisers")

--- a/adserver/api/views.py
+++ b/adserver/api/views.py
@@ -2,29 +2,20 @@
 import logging
 from datetime import timedelta
 
-from django.conf import settings
 from django.utils import timezone
 from rest_framework import status
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from user_agents import parse
 
-from ..constants import CLICKS
-from ..constants import VIEWS
 from ..decisionengine import get_ad_decision_backend
 from ..models import Advertiser
 from ..models import Publisher
-from ..utils import analytics_event
-from ..utils import get_client_ip
-from ..utils import get_client_user_agent
-from ..utils import is_blacklisted_user_agent
 from ..utils import parse_date_string
 from .mixins import GeoIpMixin
 from .permissions import PublisherPermission
 from .serializers import AdDecisionSerializer
-from .serializers import AdTrackingSerializer
 from .serializers import AdvertiserSerializer
 from .serializers import PublisherSerializer
 
@@ -49,7 +40,7 @@ class AdDecisionView(GeoIpMixin, APIView):
 
         :param string publisher: **Required**. The slug of the publisher
         :param array placements: **Required**. Various possible ad placements where an ad could go
-        :param array keywords: Keywords that identify the page where the ad will go
+        :param array keywords: Case-insensitive strings that describe the page where the ad will go for targeting
         :param array campaign_types: Limit the ad results to certain campaign types
         :param string user_ip: User's IP address used for targeting
             (the requestor's IP will be used if not present)
@@ -110,177 +101,6 @@ class AdDecisionView(GeoIpMixin, APIView):
             ad, placement = backend.get_ad_and_placement()
 
             return Response(self._prepare_response(ad, placement, publisher))
-
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-class BaseTrackingView(GeoIpMixin, APIView):
-
-    """A base API class for tracking ad impressions."""
-
-    permission_classes = (PublisherPermission,)
-
-    log_level = logging.DEBUG
-    impression_type = VIEWS
-
-    def _get_response_data(self, message):
-        data = None
-
-        if settings.DEBUG or settings.TESTING:
-            # Only return the reason an impression was tracked or not in DEBUG mode
-            # Otherwise users may attempt to brute force ad impressions
-            data = {"message": message}
-
-        return data
-
-    def _ignore_tracking_reason(self, request, advertisement, nonce, publisher):
-        """Returns a reason this impression should not be tracked or `None` if this *should* be tracked."""
-        reason = None
-
-        ip_address = get_client_ip(request)
-        user_agent = get_client_user_agent(request)
-        parsed_ua = parse(user_agent)
-
-        valid_nonce = advertisement.is_valid_nonce(self.impression_type, nonce)
-
-        if not valid_nonce:
-            log.log(self.log_level, "Old or nonexistent impression nonce")
-            reason = "Old/Nonexistent nonce"
-        elif parsed_ua.is_bot:
-            log.log(self.log_level, "Bot impression. User Agent: [%s]", user_agent)
-            reason = "Bot impression"
-        elif ip_address in settings.INTERNAL_IPS:
-            log.log(
-                self.log_level, "Internal IP impression. User Agent: [%s]", user_agent
-            )
-            reason = "Internal IP"
-        elif parsed_ua.os.family == "Other" and parsed_ua.browser.family == "Other":
-            # This is probably a bot/proxy server/prefetcher/etc.
-            log.log(self.log_level, "Unknown user agent impression [%s]", user_agent)
-            reason = "Unrecognized user agent"
-        elif request.user.is_staff:
-            log.log(self.log_level, "Ignored staff user ad impression")
-            reason = "Staff impression"
-        elif is_blacklisted_user_agent(user_agent):
-            log.log(
-                self.log_level, "Blacklisted user agent impression [%s]", user_agent
-            )
-            reason = "Blacklisted impression"
-        elif not publisher:
-            log.log(self.log_level, "Ad impression for unknown publisher")
-            reason = "Unknown publisher"
-
-        return reason
-
-
-class ViewTrackingView(BaseTrackingView):
-
-    """
-    Track an ad view.
-
-    .. http:post:: /api/v1/track/view/
-
-        :param string advertisement: **Required** the slug of the ad
-        :param string nonce: **Required** the nonce returned from the decision API
-        :param string url: **Required** the referrer for the ad view
-        :param string user_ip: User's IP address used for targeting
-            (the requestor's IP will be used if not present)
-        :param string user_ua: User's user agent used for targeting
-            (the requestor's UA will be used if not present)
-    """
-
-    def post(self, request):
-        """Handle tracking an ad view."""
-        serializer = AdTrackingSerializer(data=request.data)
-        if serializer.is_valid():
-            advertisement = serializer.validated_data["advertisement"]
-            nonce = serializer.validated_data["nonce"]
-            url = serializer.validated_data["url"]
-            publisher = advertisement.get_publisher(nonce)
-
-            self.check_object_permissions(request, publisher)
-
-            ignore_reason = self._ignore_tracking_reason(
-                request, advertisement, nonce, publisher
-            )
-            if not ignore_reason:
-                log.debug("Billed ad view")
-                advertisement.invalidate_nonce(self.impression_type, nonce)
-                advertisement.track_view(request, publisher, url)
-
-            message = ignore_reason or "Billed view"
-            return Response(
-                self._get_response_data(message), status=status.HTTP_202_ACCEPTED
-            )
-
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-class ClickTrackingView(BaseTrackingView):
-
-    """
-    Track an ad click.
-
-    .. http:post:: /api/v1/track/click/
-
-        :param string advertisement: **Required** the slug of the ad
-        :param string nonce: **Required** the nonce returned from the decision API
-        :param string url: **Required** the referrer for the ad view
-        :param string user_ip: User's IP address used for targeting
-            (the requestor's IP will be used if not present)
-        :param string user_ua: User's user agent used for targeting
-            (the requestor's UA will be used if not present)
-    """
-
-    log_level = logging.WARNING
-    impression_type = CLICKS
-
-    def send_click_to_analytics(self, request, advertisement, event_action):
-        """Send click data to analytics."""
-        ip_address = get_client_ip(request)
-        user_agent = get_client_user_agent(request)
-
-        event_category = "Advertisement"
-        event_label = advertisement.slug
-
-        # The event_value is in US cents (eg. for $2 CPC, the value is 200)
-        # CPMs are too small to register
-        event_value = int(advertisement.flight.cpc * 100)
-
-        analytics_event(
-            event_category=event_category,
-            event_action=event_action,
-            event_label=event_label,
-            event_value=event_value,
-            ua=user_agent,
-            uip=ip_address,  # will be anonymized
-        )
-
-    def post(self, request):
-        """Handle tracking an ad click."""
-        serializer = AdTrackingSerializer(data=request.data)
-        if serializer.is_valid():
-            advertisement = serializer.validated_data["advertisement"]
-            nonce = serializer.validated_data["nonce"]
-            url = serializer.validated_data["url"]
-            publisher = advertisement.get_publisher(nonce)
-
-            self.check_object_permissions(request, publisher)
-
-            ignore_reason = self._ignore_tracking_reason(
-                request, advertisement, nonce, publisher
-            )
-            if not ignore_reason:
-                log.info("Billed ad click")
-                advertisement.invalidate_nonce(self.impression_type, nonce)
-                advertisement.track_click(request, publisher, url)
-
-            message = ignore_reason or "Billed click"
-            self.send_click_to_analytics(request, advertisement, message)
-
-            return Response(
-                self._get_response_data(message), status=status.HTTP_202_ACCEPTED
-            )
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -115,8 +115,10 @@ class BaseAdDecisionBackend:
 
         # Specifying the ad or campaign slug skips filtering by live or date
         if self.ad_slug:
+            log.debug("Restricting ad decision ad_slug=%s", self.ad_slug)
             advertisements = advertisements.filter(slug=self.ad_slug)
         elif self.campaign_slug:
+            log.debug("Restricting ad decision campaign=%s", self.campaign_slug)
             advertisements = advertisements.filter(
                 flight__campaign__slug=self.campaign_slug
             )

--- a/adserver/urls.py
+++ b/adserver/urls.py
@@ -2,7 +2,9 @@
 from django.conf.urls import include
 from django.conf.urls import url
 
+from .views import AdClickProxyView
 from .views import AdvertiserReportView
+from .views import AdViewProxyView
 from .views import AllAdvertiserReportView
 from .views import AllPublisherReportView
 from .views import dashboard
@@ -18,6 +20,17 @@ urlpatterns = [
     url(r"^\.well-known/dnt-policy.txt$", do_not_track_policy, name="dnt-policy"),
     # Ad API
     url(r"^api/v1/", include("adserver.api.urls", namespace="api")),
+    # View & Click proxies
+    url(
+        r"^proxy/view/(?P<advertisement_id>\d+)/(?P<nonce>\w+)/$",
+        AdViewProxyView.as_view(),
+        name="view-proxy",
+    ),
+    url(
+        r"^proxy/click/(?P<advertisement_id>\d+)/(?P<nonce>\w+)/$",
+        AdClickProxyView.as_view(),
+        name="click-proxy",
+    ),
     # Advertiser and publisher reports
     url(
         r"^advertiser/all/report/$",

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -140,11 +140,20 @@ def anonymize_user_agent(user_agent):
     return user_agent
 
 
-def is_click_ratelimited(request, ratelimits=settings.ADSERVER_CLICK_RATELIMITS):
+def is_click_ratelimited(request, ratelimits=None):
     """Returns ``True`` if this user is rate limited from clicking ads and ``False`` otherwise."""
+    if ratelimits is None:
+        # Explicitly set the rate limits ONLY if the parameter is `None`
+        # If it is an empty list, there's simply no rate limiting
+        ratelimits = settings.ADSERVER_CLICK_RATELIMITS
+
     for rate in ratelimits:
         if is_ratelimited(
-            request, group="ad.click", key="ip", rate=rate, increment=True
+            request,
+            group="ad.click",
+            key=lambda _, req: get_client_ip(req),
+            rate=rate,
+            increment=True,
         ):
             return True
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -326,6 +326,7 @@ ADSERVER_PRIVACY_POLICY_URL = None
 ADSERVER_CLICK_RATELIMITS = []
 ADSERVER_BLACKLISTED_USER_AGENTS = []
 ADSERVER_RECORD_VIEWS = True  # False in prod by default
+ADSERVER_HTTPS = False  # Should be True in most production setups
 
 with open(os.path.join(BASE_DIR, "package.json")) as fd:
     ADSERVER_VERSION = json.load(fd)["version"]

--- a/docs/user-guide/api.rst
+++ b/docs/user-guide/api.rst
@@ -23,13 +23,6 @@ Ad decision
 .. autoclass:: adserver.api.views.AdDecisionView
 
 
-Impression tracking
--------------------
-
-.. autoclass:: adserver.api.views.ViewTrackingView
-.. autoclass:: adserver.api.views.ClickTrackingView
-
-
 Publisher APIs
 --------------
 


### PR DESCRIPTION
- Remove the click/view metric collection API endpoints
- Adds proxy views for metric collection on clicks and views. These will be exposed directly to users (see screenshot). The nonce is a one-time hash to make sure views/clicks aren't replayed.
  * `/proxy/click/<ad_id>/<nonce>/`
  * `/proxy/view/<ad_id>/<nonce>/`
- This is essentially how RTD's ads work now

## Screenshot

![Screen Shot 2019-11-21 at 11 03 31 PM](https://user-images.githubusercontent.com/185043/69404868-2bb23500-0cb3-11ea-82be-3f56aaa2c673.png)
