### PR TITLE
Add Sentry for error monitoring

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -94,6 +94,18 @@ CELERY_BROKER_URL = env("CELERY_BROKER_URL")
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 
 
+# Sentry settings for error monitoring
+# https://docs.sentry.io/platforms/python/django/
+# --------------------------------------------------------------------------
+SENTRY_DSN = env.bool("SENTRY_DSN", default=None)
+if SENTRY_DSN:
+    # pylint: disable=import-error
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
+    sentry_sdk.init(dsn=SENTRY_DSN, integrations=[DjangoIntegration()])
+
+
 # Production ad server specific settings
 # https://read-the-docs-ethical-ad-server.readthedocs-hosted.com/en/latest/install/configuration.html
 # --------------------------------------------------------------------------

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -19,3 +19,4 @@ azure-storage-blob==1.3.1
 
 # Logging and monitoring
 newrelic==5.4.0.132
+sentry-sdk==0.13.4


### PR DESCRIPTION
## Summary
- Lower CPU target tracking from 60% → 50% so ASG scales out before instances get saturated
- Raise max web instances from 6 → 10 for more headroom during traffic spikes
- Raise min web instances from 2 → 3 to maintain baseline capacity
- Reduce gunicorn workers from 6 → 4 per instance to reduce CPU contention on 2 vCPU c6i.large boxes
- Remove unused `WEB_CONCURRENCY` env var from all supervisor configs

## Context
We observed instances hitting load averages of 6+ on 2 vCPU boxes, with all 6 gunicorn workers pinned at ~33% CPU each. The scaling policy wasn't adding instances fast enough (60% target) and the max of 6 didn't leave enough room.

With 4 workers on 2 cores, each worker gets ~50% of a core instead of ~33%, so individual requests complete faster even under load. The higher min (3) keeps baseline capacity at 12 total workers (4×3), same as before (6×2). The 50% CPU target keeps roughly half the workers idle on average, leaving headroom for traffic spikes while new instances boot.

## Deploy notes
- Terraform changes (scaling policy, min/max size) can be applied immediately
- Gunicorn worker change requires an AMI rebuild + rolling deploy