### PR TITLE
Add celery setup to Heroku procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,3 @@
 web: newrelic-admin run-program gunicorn config.wsgi --log-file -
+celeryworker: celery worker --app=config.celery_app.app --loglevel=INFO --without-gossip --without-mingle --without-heartbeat --max-tasks-per-child 1000
+celerybeat: celery beat --app=config.celery_app.app --loglevel=INFO


### PR DESCRIPTION
This change will allow scaling celery workers and celery beat.

**Note:** There are no current periodic tasks so celerybeat will most likely not be run in production until it is needed.

## Testing locally

Celery is already run as part of the docker compose setup. However, to test this Heroku integration part locally, you can set the `CELERY_BROKER_URL` and run `heroku local celeryworker` or `heroku local celerybeat`.