### PR TITLE
Fix all publishers report to correctly filter campaign type

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -25,6 +25,7 @@ from django_extensions.db.models import TimeStampedModel
 from jsonfield import JSONField
 from user_agents import parse
 
+from .constants import ALL_CAMPAIGN_TYPES
 from .constants import CAMPAIGN_TYPES
 from .constants import CLICKS
 from .constants import IMPRESSION_TYPES
@@ -102,12 +103,13 @@ class Publisher(TimeStampedModel, IndestructibleModel):
         """Simple override."""
         return self.name
 
-    def daily_reports(self, start_date=None, end_date=None):
+    def daily_reports(self, start_date=None, end_date=None, campaign_type=None):
         """
         Generates a report of clicks, views, & cost for a given time period for the Publisher.
 
         :param start_date: the start date to generate the report (or all time)
         :param end_date: the end date for the report (ignored if no `start_date`)
+        :param campaign_type: only return campaigns of a specific type (eg. house, paid)
         :return: A dictionary containing a list of days for the report
             and an aggregated total
         """
@@ -117,6 +119,10 @@ class Publisher(TimeStampedModel, IndestructibleModel):
             impressions = impressions.filter(date__gte=start_date)
             if end_date:
                 impressions = impressions.filter(date__lte=end_date)
+        if campaign_type and campaign_type in ALL_CAMPAIGN_TYPES:
+            impressions = impressions.filter(
+                advertisement__flight__campaign__campaign_type=campaign_type
+            )
         impressions = impressions.select_related(
             "advertisement", "advertisement__flight"
         )

--- a/adserver/templates/adserver/reports/all-publishers.html
+++ b/adserver/templates/adserver/reports/all-publishers.html
@@ -18,10 +18,10 @@
 {% block additional_filters %}
 <div class="col-lg-2 col-md-4 mb-3">
   <label class="col-form-label" for="id_campaign_type">{% trans 'Campaign type' %}</label>
-  <select class="form-control" name="campaign_type" id="id_campaign_type" {% if request.GET.campaign_type %}value="{{ request.GET.campaign_type }}"{% endif %}>
+  <select class="form-control" name="campaign_type" id="id_campaign_type">
     <option>All types</option>
     {% for slug, type in campaign_types %}
-      <option value="{{ slug }}">{{ type }}</option>
+      <option value="{{ slug }}"{% if campaign_type == slug %} selected{% endif %}>{{ type }}</option>
     {% endfor %}
   </select>
 </div>

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -475,16 +475,15 @@ class AllPublisherReportView(BaseReportView):
         impressions = AdImpression.objects.filter(date__gte=context["start_date"])
         if context["end_date"]:
             impressions = impressions.filter(date__lte=context["end_date"])
-        if context["campaign_type"] and context["campaign_type"] in CAMPAIGN_TYPES:
-            impressions = impressions.filter(
-                advertisement__flight__campaign__campaign_type=context["campaign_type"]
-            )
+
         publishers = Publisher.objects.filter(id__in=impressions.values("publisher"))
 
         publishers_and_reports = []
         for publisher in publishers:
             report = publisher.daily_reports(
-                start_date=context["start_date"], end_date=context["end_date"]
+                start_date=context["start_date"],
+                end_date=context["end_date"],
+                campaign_type=context["campaign_type"],
             )
             if report["total"]["views"] > 0:
                 publishers_and_reports.append((publisher, report))


### PR DESCRIPTION
Filtering before getting the list of publishers doesn't work correctly if a publisher has multiple types of ads (house, community, paid).