### PR TITLE
Create a "Read the Docs" advertiser

### DIFF
--- a/adserver/management/commands/rtdimport.py
+++ b/adserver/management/commands/rtdimport.py
@@ -182,6 +182,11 @@ class Command(BaseCommand):
     def import_campaigns(self, campaign_data, publishers):
         """Imports campaigns and creates an advertiser for each one."""
         campaigns = 0
+
+        advertiser_readthedocs = Advertiser.objects.create(
+            name="Read the Docs", slug="readthedocs"
+        )
+
         for data in campaign_data:
             campaign_type = data["fields"]["campaign_type"]
 
@@ -191,7 +196,8 @@ class Command(BaseCommand):
                     name=data["fields"]["name"], slug=data["fields"]["slug"]
                 )
             else:
-                advertiser = None
+                # All house and community ads are by Read the Docs
+                advertiser = advertiser_readthedocs
 
             # Campaigns have to be created before the many-many
             # with publishers can be saved

--- a/adserver/test_fixtures/import_dumpfile.json
+++ b/adserver/test_fixtures/import_dumpfile.json
@@ -93,6 +93,18 @@
     }
   },
   {
+    "model": "donate.campaign",
+    "pk": 2,
+    "fields": {
+      "pub_date": "2018-01-16T23:07:26.678Z",
+      "modified_date": "2018-01-16T23:07:57.519Z",
+      "name": "Community Campaign",
+      "slug": "community",
+      "campaign_type": "community",
+      "max_sale_value": null
+    }
+  },
+  {
     "model": "donate.click",
     "pk": 1,
     "fields": {

--- a/adserver/tests.py
+++ b/adserver/tests.py
@@ -1612,10 +1612,10 @@ class TestImporterManagementCommand(TestCase):
         self.assertEqual(Publisher.objects.count(), 2)
         self.assertEqual(Advertisement.objects.count(), 2)
         self.assertEqual(Flight.objects.count(), 1)
-        self.assertEqual(Campaign.objects.count(), 1)
+        self.assertEqual(Campaign.objects.count(), 2)
 
-        # House ads don't generate an advertiser
-        self.assertEqual(Advertiser.objects.count(), 0)
+        # House/Community ads create a single advertiser
+        self.assertEqual(Advertiser.objects.count(), 1)
 
         self.assertEqual(Click.objects.count(), 2)
 


### PR DESCRIPTION
- This will be the advertiser for all imported house/community campaigns
- While this didn't change any numbers in any reports, this makes it easier to see report details on individual ad performance for house and community ads