### PR TITLE
This sets the environment correctly when using docker in dev

### DIFF
--- a/.envs/local/django
+++ b/.envs/local/django
@@ -1,6 +1,6 @@
 # General
 # ------------------------------------------------------------------------------
-USE_DOCKER=yes
+USE_DOCKER=true
 IPYTHONDIR=/app/.ipython
 MEDIA_URL=http://localhost:5000/media/
 

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -4,7 +4,7 @@ from .base import env
 
 # Set the local IPs which are needed for Django Debug Toolbar
 INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
-if env("USE_DOCKER", default=False) == "yes":
+if env.bool("USE_DOCKER", default=False):
     import socket
 
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())


### PR DESCRIPTION
- This makes sure that the INTERNAL_IPS setting is correct
- That setting is needed for Django Debug Toolbar