### PR TITLE
Increment the impression type better

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -817,10 +817,13 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
         """Add to the number of times this action has been performed, stored in the DB."""
         assert impression_type in IMPRESSION_TYPES
         day = get_ad_day().date()
+
+        # Ensure that an impression object exists for today
         impression, _ = self.impressions.get_or_create(publisher=publisher, date=day)
 
-        setattr(impression, impression_type, models.F(impression_type) + 1)
-        impression.save()
+        AdImpression.objects.filter(pk=impression.pk).update(
+            **{impression_type: models.F(impression_type) + 1}
+        )
 
     def _record_base(self, request, model, publisher, url):
         ip_address = get_client_ip(request)


### PR DESCRIPTION
- This increments the impression type without changing anything else on the object
- Note: this will not update the "updated" timestamp but I think that's OK

Previously, this resulted in a query like:
```sql
UPDATE "adserver_adimpression" SET 
  "created" = '2019-12-11T06:46:16.843018+00:00'::timestamptz, 
  "modified" = '2019-12-11T20:48:18.806025+00:00'::timestamptz, 
  "date" = '2019-12-11'::date, "offers" = ("adserver_adimpression"."offers" + 1), 
  "views" = 9,   -- This is a problem!!
  "clicks" = 1,  -- This is also a problem!!
  "publisher_id" = 2, 
  "advertisement_id" = 671 
WHERE "adserver_adimpression"."id" = 152446; 
```

The new query will be:

```sql
UPDATE "adserver_adimpression" SET 
  "offers" = ("adserver_adimpression"."offers" + 1) 
WHERE "adserver_adimpression"."id" = 152446;
```