### PR TITLE
Optimize ad template loading

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1073,11 +1073,12 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
 
     def render_ad(self, click_url=None, view_url=None):
         """Render the ad as HTML including any proxy links for collecting view/click metrics."""
-        template = get_template("adserver/advertisement.html")
-
-        # Check if the ad type has a specific template
         if self.ad_type and self.ad_type.template:
+            # Check if the ad type has a specific template
             template = engines["django"].from_string(self.ad_type.template)
+        else:
+            # Otherwise get the default template
+            template = get_template("adserver/advertisement.html")
 
         return template.render(
             {


### PR DESCRIPTION
This is a small change to optimize ad template loading and only load a template when it's absolutely necessary.

In production, we will basically always be loading the template from a string that comes from the DB. In my tests, this was surprisingly pretty fast and took only 2-3ms. In development, loading a template using Django's `get_template` was actually quite slow. I suspect it might be faster in prod due to the cached template loader, but it took ~40ms in dev.