### PR TITLE
Add an admin action for inviting new users

### DIFF
--- a/adserver/auth/admin.py
+++ b/adserver/auth/admin.py
@@ -1,5 +1,13 @@
 """Django admin configuration for the Ad Server authentication app."""
+from allauth.account.forms import default_token_generator
+from allauth.account.utils import user_pk_to_url_str
+from django.conf import settings
 from django.contrib import admin
+from django.contrib import messages
+from django.contrib.sites.shortcuts import get_current_site
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from .models import User
@@ -10,6 +18,7 @@ class UserAdmin(admin.ModelAdmin):
 
     """Django admin configuration for users."""
 
+    actions = ("invite_user",)
     fieldsets = (
         (None, {"fields": ("email", "name", "password")}),
         (_("Ad server details"), {"fields": ("advertisers", "publishers")}),
@@ -41,3 +50,35 @@ class UserAdmin(admin.ModelAdmin):
     list_filter = ("is_active", "is_staff", "is_superuser")
     readonly_fields = ("password", "updated_date", "created_date")
     search_fields = ("email", "name")
+
+    def get_password_reset_url(self, request, user):
+        temp_key = default_token_generator.make_token(user)
+        path = reverse(
+            "account_reset_password_from_key",
+            kwargs=dict(uidb36=user_pk_to_url_str(user), key=temp_key),
+        )
+        return request.build_absolute_uri(path)
+
+    def invite_user(self, request, queryset):
+        site = get_current_site(request)
+        for user in queryset:
+            if user.last_login:
+                messages.error(
+                    request,
+                    _("No invite sent %(user)s. They have already logged in.")
+                    % {"user": user},
+                )
+            else:
+                activate_url = self.get_password_reset_url(request, user)
+                context = {"user": user, "site": site, "activate_url": activate_url}
+                send_mail(
+                    _("You've been invited to %(name)s") % {"name": site.name},
+                    render_to_string("auth/email/account_invite.txt", context),
+                    settings.DEFAULT_FROM_EMAIL,
+                    [user.email],
+                )
+                messages.success(
+                    request, _("Sent invite to %(user)s.") % {"user": user}
+                )
+
+    invite_user.short_description = _("Invite selected users")

--- a/adserver/auth/templates/auth/email/account_invite.txt
+++ b/adserver/auth/templates/auth/email/account_invite.txt
@@ -1,0 +1,8 @@
+{% load i18n %}{% blocktrans with site_name=site.name user_display=user.get_full_name %}Hello {{ user_display }}!
+
+You're receiving this email because you've been invited to create an account on {{ site_name }}.
+
+To create your account, go to {{ activate_url }}
+
+Thank you from {{ site_name }}!
+{% endblocktrans %}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -271,6 +271,7 @@ ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_AUTHENTICATION_METHOD = "email"
+ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 
 # Celery settings for asynchronous tasks
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -3,24 +3,25 @@
 {% load crispy_forms_tags %}
 
 
-{% block title %}{% trans 'Change Password' %}{% endblock title %}
+{% block title %}{% trans 'Set Password' %}{% endblock title %}
 
 
 {% block content %}
-<h1 class="card-title">{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
+<h1 class="card-title">{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Set Password" %}{% endif %}</h1>
 
 {% if token_fail %}
   {% url 'account_reset_password' as passwd_reset_url %}
   <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
 {% else %}
   {% if form %}
+    {% if form.user %}<p>{% blocktrans with name=form.user.get_full_name %}Set password for {{ name }}{% endblocktrans %}</p>{% endif %}
     <form method="POST" action="{{ action_url }}">
       {% csrf_token %}
       {{ form|crispy }}
-      <input type="submit" value="{% trans 'Change My Password' %}" class="btn btn-primary" />
+      <input type="submit" value="{% trans 'Set My Password' %}" class="btn btn-primary" />
     </form>
   {% else %}
-    <p>{% trans 'Your password is now changed.' %}</p>
+    <p>{% trans 'Your password is now set.' %}</p>
   {% endif %}
 {% endif %}
 {% endblock content %}


### PR DESCRIPTION
This adds an admin action for inviting new users. This action will send the user an email with a password reset token so they can setup their account. Upon resetting their password, they will automatically be logged in. Users who have logged in previously cannot be invited.

~~This PR branches off of #104 and should be merged into that PR or the base should be switched to master after that one is merged.~~

## Screenshot

![Screen Shot 2020-01-20 at 10 57 06 PM](https://user-images.githubusercontent.com/185043/72782272-3700de80-3bd8-11ea-88de-f721e115fe24.png)
