### PR TITLE
Show the remaining flight value

### DIFF
--- a/adserver/admin.py
+++ b/adserver/admin.py
@@ -229,11 +229,8 @@ class FlightMixin:
     def value_remaining(self, obj):
         return "${:.2f}".format(obj.value_remaining())
 
-    def total_value(self, obj):
-        total = 0.0
-        total += float(obj.cpm * obj.total_views) / 1000.0
-        total += float(obj.cpc * obj.total_clicks)
-        return "${:.2f}".format(total)
+    def projected_total_value(self, obj):
+        return "${:.2f}".format(obj.projected_total_value())
 
     def ctr(self, obj):
         clicks = obj.total_clicks
@@ -282,7 +279,7 @@ class FlightAdmin(RemoveDeleteMixin, FlightMixin, admin.ModelAdmin):
     list_select_related = ("campaign",)
     readonly_fields = (
         "value_remaining",
-        "total_value",
+        "projected_total_value",
         "total_clicks",
         "total_views",
         "clicks_today",
@@ -320,8 +317,7 @@ class FlightsInline(FlightMixin, admin.TabularInline):
         "sold_impressions",
         "cpc",
         "cpm",
-        "clicks_remaining",
-        "views_remaining",
+        "value_remaining",
         "total_clicks",
         "total_views",
         "ctr",

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -639,10 +639,16 @@ class Flight(TimeStampedModel, IndestructibleModel):
         return max(0, self.sold_impressions - self.total_views)
 
     def value_remaining(self):
-        """Value remaining on this ad flight."""
+        """Value ($) remaining on this ad flight."""
         value_clicks_remaining = float(self.clicks_remaining() * self.cpc)
         value_views_remaining = float(self.views_remaining() * self.cpm) / 1000.0
         return value_clicks_remaining + value_views_remaining
+
+    def projected_total_value(self):
+        """Total value ($) assuming all sold impressions and clicks are delivered."""
+        projected_value_clicks = float(self.sold_clicks * self.cpc)
+        projected_value_views = float(self.sold_impressions * self.cpm) / 1000.0
+        return projected_value_clicks + projected_value_views
 
     def daily_reports(
         self, start_date=None, end_date=None, name_filter=None, inactive=True

--- a/adserver/templates/adserver/advertiser/flight-detail.html
+++ b/adserver/templates/adserver/advertiser/flight-detail.html
@@ -37,7 +37,7 @@
     {% endif %}
     {% if flight.campaign.campaign_type == 'paid' and flight.live %}
       <dt>{% trans 'Value remaining' %}</dt>
-      <dd>${{ flight.value_remaining|floatformat:2 }}</dd>
+      <dd>${{ flight.value_remaining|floatformat:2 }} / ${{ flight.projected_total_value|floatformat:2 }}</dd>
     {% endif %}
     {% if flight.cpc %}
       <dt>{% trans 'Cost per click (CPC)' %}</dt>

--- a/adserver/templates/adserver/reports/advertiser.html
+++ b/adserver/templates/adserver/reports/advertiser.html
@@ -97,7 +97,7 @@
       {% endif %}
       {% if flight.campaign.campaign_type == 'paid' and flight.live %}
         <dt>{% trans 'Value remaining' %}</dt>
-        <dd>${{ flight.value_remaining|floatformat:2 }}</dd>
+        <dd>${{ flight.value_remaining|floatformat:2 }} / ${{ flight.projected_total_value|floatformat:2 }}</dd>
       {% endif %}
       {% if flight.cpc %}
         <dt>{% trans 'Cost per click (CPC)' %}</dt>

--- a/adserver/tests.py
+++ b/adserver/tests.py
@@ -573,8 +573,26 @@ class TestAdModels(TestCase):
             self.ad.incr(VIEWS, self.publisher)
 
         self.flight.refresh_from_db()
-
         self.assertAlmostEqual(self.flight.value_remaining(), 5.0 - (25 * 0.05))
+
+    def test_projected_total_value(self):
+        self.assertAlmostEqual(self.flight.projected_total_value(), 1000 * 2)
+
+        # Clicks don't affect the projected total value
+        self.ad.incr(CLICKS, self.publisher)
+        self.ad.incr(CLICKS, self.publisher)
+        self.ad.incr(CLICKS, self.publisher)
+
+        self.flight.refresh_from_db()
+        self.assertAlmostEqual(self.flight.projected_total_value(), 1000 * 2)
+
+        self.flight.cpm = 50.0
+        self.flight.cpc = 0
+        self.flight.sold_clicks = 0
+        self.flight.sold_impressions = 100
+        self.flight.save()
+
+        self.assertAlmostEqual(self.flight.projected_total_value(), 5.0)
 
 
 class DecisionEngineTests(TestCase):


### PR DESCRIPTION
This raises the figure of how much money is remaining on their ad buy directly to advertisers. Longer term, we want advertisers to top-up their ad buys themselves but in the short term just letting advertisers know that their flight is almost done is enough.