### PR TITLE
Additional logging when flight has no ads

### DIFF
--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -320,6 +320,10 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
         if weighted_ad_choices:
             chosen_ad = random.choice(weighted_ad_choices)
         else:
-            log.warning("Chosen flight has no live ads! flight=%s", flight)
+            log.warning(
+                "Chosen flight has no matching live ads! flight=%s, ad_types=%s",
+                flight,
+                ad_types,
+            )
 
         return chosen_ad


### PR DESCRIPTION
I've seen this message pop up in the logs a few times and I'm pretty sure I know what causes it but I think additional logging is useful here.

My current theory is:

* This only applies when when the theme supports fixed footer ads only
* The flight has a fixed footer ad but it is not live
* The flight is chosen as a candidate for display but since there are not live fixed footer ads, it shows nothing