### PR TITLE
Add API token management

### DIFF
--- a/adserver/templates/adserver/accounts/api-token.html
+++ b/adserver/templates/adserver/accounts/api-token.html
@@ -1,0 +1,50 @@
+{% extends "adserver/dashboard.html" %}
+
+{% load i18n %}
+{% load static %}
+{% load humanize %}
+
+
+{% block title %}{% trans "API Token Management" %}{% endblock %}
+
+
+{% block breadcrumbs %}
+<li class="breadcrumb-item">
+  <a href="{% url 'dashboard-home' %}">{% trans 'Home' %}</a>
+</li>
+<li class="breadcrumb-item active">{% trans 'API Token Management' %}</li>
+{% endblock breadcrumbs %}
+
+
+{% block content_container %}
+
+<h1>{% block heading %}{% trans "API Token Management" %}{% endblock heading %}</h1>
+
+<p>{% trans 'API tokens allow you to use the ad server API to download reports.' %}</p>
+
+{% if not object_list %}
+  <form method="post" action="{% url 'api_token_create' %}">
+    {% csrf_token %}
+    <input type="submit" class="btn btn-primary" value="{% trans "Generate API Token" %}">
+  </form>
+{% else %}
+  {% for token in object_list %}
+    {% if forloop.first %}
+      {# Currently there's only 1 API token per user so limit to 1 #}
+      <form method="post" action="{% url 'api_token_delete' %}">
+        {% csrf_token %}
+        <div class="form-group row">
+          <label for="api_token" class="col-sm-2 col-form-label">API token</label>
+          <div class="col-sm-10">
+            <input type="text" readonly class="form-control-plaintext text-monospace" id="api_token" value="{{ token.key }}">
+            <small class="form-text text-muted">{% blocktrans with token_create=token.created %}Created {{ token_create }}{% endblocktrans %}</small>
+          </div>
+        </div>
+        <input type="submit" class="btn btn-danger" value="{% trans "Revoke token" %}">
+        <small class="form-text text-muted">{% trans "After revoking, you can regenerate a new token." %}</small>
+      </form>
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+{% endblock content_container %}

--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -20,6 +20,11 @@
             </a>
             <div class="dropdown-divider"></div>
           {% endif %}
+          <a class="dropdown-item" href="{% url 'api_token_list' %}">
+            <span class="fa fa-cog fa-fw mr-2 text-muted" aria-hidden="true"></span>
+            <span>{% trans 'API token' %}</span>
+          </a>
+          <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="{% url 'account_change_password' %}">
             <span class="fa fa-key fa-fw mr-2 text-muted" aria-hidden="true"></span>
             <span>{% trans 'Change password' %}</span>

--- a/adserver/tests/test_account_extras.py
+++ b/adserver/tests/test_account_extras.py
@@ -1,0 +1,58 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django_dynamic_fixture import get
+from rest_framework.authtoken.models import Token
+
+
+class TestApiTokenMangementViews(TestCase):
+
+    """Test the API token management (list, create, delete) views."""
+
+    def setUp(self):
+        self.user = get(
+            get_user_model(), email="test1@example.com", username="test-user"
+        )
+
+        self.list_view = reverse("api_token_list")
+        self.create_view = reverse("api_token_create")
+        self.delete_view = reverse("api_token_delete")
+
+        self.client.force_login(self.user)
+
+    def test_logged_out(self):
+        self.client.logout()
+
+        resp = self.client.get(self.list_view)
+
+        # Redirected to login
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(resp["location"].startswith("/accounts/login/"))
+
+    def test_list_view(self):
+        resp = self.client.get(self.list_view)
+        self.assertContains(resp, "Generate API Token")
+
+        token = Token.objects.create(user=self.user)
+
+        resp = self.client.get(self.list_view)
+        self.assertContains(resp, "Revoke token")
+        self.assertContains(resp, token.key)
+
+    def test_create_view(self):
+        resp = self.client.post(self.create_view, data={}, follow=True)
+        self.assertContains(resp, "API token created successfully")
+
+        self.assertTrue(Token.objects.filter(user=self.user).exists())
+
+    def test_delete_view(self):
+        # Token doesn't exist yet
+        resp = self.client.post(self.delete_view, data={})
+        self.assertEqual(resp.status_code, 404)
+
+        Token.objects.create(user=self.user)
+
+        resp = self.client.post(self.delete_view, data={}, follow=True)
+        self.assertContains(resp, "API token revoked")
+
+        self.assertFalse(Token.objects.filter(user=self.user).exists())

--- a/adserver/urls.py
+++ b/adserver/urls.py
@@ -11,6 +11,9 @@ from .views import AdvertiserReportView
 from .views import AdViewProxyView
 from .views import AllAdvertiserReportView
 from .views import AllPublisherReportView
+from .views import ApiTokenCreateView
+from .views import ApiTokenDeleteView
+from .views import ApiTokenListView
 from .views import dashboard
 from .views import do_not_track
 from .views import do_not_track_policy
@@ -103,5 +106,17 @@ urlpatterns = [
         r"^publisher/(?P<publisher_slug>[-a-zA-Z0-9_]+)/report\.csv$",
         PublisherReportView.as_view(export=True),
         name="publisher_report_export",
+    ),
+    # User account management
+    url(r"^accounts/api-token/$", ApiTokenListView.as_view(), name="api_token_list"),
+    url(
+        r"^accounts/api-token/create/$",
+        ApiTokenCreateView.as_view(),
+        name="api_token_create",
+    ),
+    url(
+        r"^accounts/api-token/delete/$",
+        ApiTokenDeleteView.as_view(),
+        name="api_token_delete",
     ),
 ]


### PR DESCRIPTION
This is a feature requested by an advertiser so it seemed worth adding. This code is heavily borrowed from the API token management in RTD.

I'd like to add a link to the docs on the API once the ad server is opened up (#92)