### PR TITLE
Improvements to the first screen after login

### DIFF
--- a/adserver/templates/adserver/reports/advertiser-flight.html
+++ b/adserver/templates/adserver/reports/advertiser-flight.html
@@ -81,6 +81,13 @@
          </dd>
        {% endif %}
     </dl>
+
+    <p>
+      <a href="{% url 'flight_detail' advertiser.slug flight.slug %}" class="btn btn-sm btn-outline-secondary" role="button" aria-pressed="true">
+        <span class="fa fa-cog mr-1" aria-hidden="true"></span>
+        <span>{% trans 'Manage flight & ads' %}</span>
+      </a>
+    </p>
   </section>
 
   <section class="mt-5">

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -130,6 +130,45 @@ class TestReportViews(TestCase):
         self.assertContains(response, self.advertiser1.name)
         self.assertContains(response, self.publisher1.name)
 
+    def test_advertiser_redirect(self):
+        url = reverse("dashboard-home")
+        self.client.force_login(self.user)
+        self.user.advertisers.add(self.advertiser1)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        # If a user has access to 2 advertisers (or a publisher and an advertiser) don't redirect
+        self.user.advertisers.add(self.advertiser2)
+        response = self.client.get(url)
+        self.assertContains(response, self.advertiser1.name)
+        self.assertContains(response, self.advertiser2.name)
+
+        self.user.advertisers.remove(self.advertiser2)
+        self.user.publishers.add(self.publisher1)
+        response = self.client.get(url)
+        self.assertContains(response, self.advertiser1.name)
+        self.assertContains(response, self.publisher1.name)
+
+    def test_publisher_redirect(self):
+        url = reverse("dashboard-home")
+        self.client.force_login(self.user)
+        self.user.publishers.add(self.publisher1)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        self.user.publishers.add(self.publisher2)
+        response = self.client.get(url)
+        self.assertContains(response, self.publisher1.name)
+        self.assertContains(response, self.publisher2.name)
+
     def test_all_advertiser_report_access(self):
         url = reverse("all_advertisers_report")
 

--- a/adserver/urls.py
+++ b/adserver/urls.py
@@ -7,6 +7,7 @@ from .views import AdvertisementCreateView
 from .views import AdvertisementDetailView
 from .views import AdvertisementUpdateView
 from .views import AdvertiserFlightReportView
+from .views import AdvertiserMainView
 from .views import AdvertiserReportView
 from .views import AdViewProxyView
 from .views import AllAdvertiserReportView
@@ -19,6 +20,7 @@ from .views import do_not_track
 from .views import do_not_track_policy
 from .views import FlightDetailView
 from .views import FlightListView
+from .views import PublisherMainView
 from .views import PublisherReportView
 
 
@@ -45,6 +47,11 @@ urlpatterns = [
         r"^advertiser/all/report/$",
         AllAdvertiserReportView.as_view(),
         name="all_advertisers_report",
+    ),
+    url(
+        r"^advertiser/(?P<advertiser_slug>[-a-zA-Z0-9_]+)/$",
+        AdvertiserMainView.as_view(),
+        name="advertiser_main",
     ),
     url(
         r"^advertiser/(?P<advertiser_slug>[-a-zA-Z0-9_]+)/report/$",
@@ -96,6 +103,11 @@ urlpatterns = [
         r"^publisher/all/report/$",
         AllPublisherReportView.as_view(),
         name="all_publishers_report",
+    ),
+    url(
+        r"^publisher/(?P<publisher_slug>[-a-zA-Z0-9_]+)/$",
+        PublisherMainView.as_view(),
+        name="publisher_main",
     ),
     url(
         r"^publisher/(?P<publisher_slug>[-a-zA-Z0-9_]+)/report/$",


### PR DESCRIPTION
* Adds a couple new URLs `/advertiser/<slug>` and `/publisher/<slug>` which currently just redirect. Longer term I could envision screens that give overviews before letting advertisers or publishers dive deeper into reports and such.
* If a publisher or advertiser logs in and has access to exactly one publisher or exactly one advertiser, simply redirect to that advertiser's/publisher's details. Don't show the intermediate screen to select the one advertiser/publisher.