### PR TITLE
Add campaign_type to the ad decision response

### DIFF
--- a/adserver/api/views.py
+++ b/adserver/api/views.py
@@ -62,6 +62,7 @@ class AdDecisionView(GeoIpMixin, APIView):
         :>json string nonce: A one-time nonce used in the URLs so the ad is never double counted
         :>json string display_type: The slug of type of ad (eg. sidebar)
         :>json string div_id: The <div> ID where the ad will be inserted
+        :>json string campaign_type: The type of campaign this as is from (house or paid)
 
     .. http:get:: /api/v1/decision/
 

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -944,6 +944,7 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
             "view_url": view_url,
             "nonce": nonce,
             "display_type": self.ad_type.slug,
+            "campaign_type": self.flight.campaign.campaign_type,
         }
 
     def cache_key(self, impression_type, nonce):

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -406,6 +406,7 @@ class AdDecisionApiTests(BaseApiTest):
         self.assertEqual(resp.status_code, 200, resp.content)
         resp_json = resp.json()
         self.assertEqual(resp_json["id"], "ad-slug", resp_json)
+        self.assertEqual(resp_json["campaign_type"], PAID_CAMPAIGN)
 
         # Try community only
         data["campaign_types"] = [COMMUNITY_CAMPAIGN]
@@ -424,6 +425,7 @@ class AdDecisionApiTests(BaseApiTest):
         self.assertEqual(resp.status_code, 200, resp.content)
         resp_json = resp.json()
         self.assertEqual(resp_json["id"], "ad-slug", resp_json)
+        self.assertEqual(resp_json["campaign_type"], COMMUNITY_CAMPAIGN)
 
         # Try multiple campaign types
         data["campaign_types"] = [PAID_CAMPAIGN, HOUSE_CAMPAIGN]
@@ -442,6 +444,7 @@ class AdDecisionApiTests(BaseApiTest):
         self.assertEqual(resp.status_code, 200, resp.content)
         resp_json = resp.json()
         self.assertEqual(resp_json["id"], "ad-slug", resp_json)
+        self.assertEqual(resp_json["campaign_type"], HOUSE_CAMPAIGN)
 
         # try an invalid campaign type
         data["campaign_types"] = [PAID_CAMPAIGN, HOUSE_CAMPAIGN, "unknown"]


### PR DESCRIPTION
This will allow users to know what type of campaign they are showing.
It is useful for the client to know if we're showing a paid ad or not,
or a house ad and show a fallback.