### PR TITLE
Use Django dev for Intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,8 +143,8 @@ html_context = {"css_files": ["_static/css/custom.css"]}
 
 intersphinx_mapping = {
     "django": (
-        "https://docs.djangoproject.com/en/1.11/",
-        "https://docs.djangoproject.com/en/1.11/_objects/",
+        "https://docs.djangoproject.com/en/dev/",
+        "https://docs.djangoproject.com/en/dev/_objects/",
     ),
     "python": ("https://docs.python.org/3.6/", None),
 }

--- a/docs/install/configuration.rst
+++ b/docs/install/configuration.rst
@@ -97,6 +97,8 @@ DATABASE_URL
 This will set the address of the database used by the ad server.
 While any database supported by Django will work, PostgreSQL is preferred
 (eg. ``psql://username:password@127.0.0.1:5432/database``)
+See Django's :doc:`database documentation <django:ref/databases>`
+and the :ref:`DATABASES setting <django:ref/settings:database>` for details.
 
 
 DEBUG
@@ -113,6 +115,7 @@ DEFAULT_FILE_STORAGE
 Adjusts Django's ``DEFAULT_FILE_STORAGE`` setting.
 Defaults to ``storages.backends.azure_storage.AzureStorage`` which
 can be used to storage uploaded ad images in Azure.
+See Django's :doc:`storage documentation <django:ref/files/storage>` for details.
 
 
 ENFORCE_HOST


### PR DESCRIPTION
Unfortunately, Django 2.2 can't be used because it didn't have autosectionlabel included so a number of headings can't be linked to.