### PR TITLE
Allow targeting mobile or non-mobile traffic

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -610,6 +610,19 @@ class Flight(TimeStampedModel, IndestructibleModel):
 
         return True
 
+    def show_to_mobile(self, is_mobile):
+        """Check if a flight is valid for this traffic based on mobile/non-mobile."""
+        if not self.targeting_parameters:
+            return True
+
+        mobile_traffic_targeting = self.targeting_parameters.get("mobile_traffic")
+        if mobile_traffic_targeting == "exclude" and is_mobile:
+            return False
+        if mobile_traffic_targeting == "only" and not is_mobile:
+            return False
+
+        return True
+
     def sold_days(self):
         # Add one to count both the start and end day
         return max(0, (self.end_date - self.start_date).days) + 1

--- a/adserver/templates/adserver/advertiser/flight-detail.html
+++ b/adserver/templates/adserver/advertiser/flight-detail.html
@@ -80,6 +80,9 @@
            {% if flight.targeting_parameters.include_keywords %}
              <li>{% blocktrans with value=flight.targeting_parameters.include_keywords|join:", " %}Include keywords: {{ value }}{% endblocktrans %}</li>
            {% endif %}
+           {% if flight.targeting_parameters.mobile_traffic %}
+             <li>{% blocktrans with value=flight.targeting_parameters.mobile_traffic %}Mobile traffic: {{ value }}{% endblocktrans %}</li>
+           {% endif %}
          </ul>
        </dd>
      {% endif %}

--- a/adserver/templates/adserver/reports/advertiser-flight.html
+++ b/adserver/templates/adserver/reports/advertiser-flight.html
@@ -77,6 +77,9 @@
              {% if flight.targeting_parameters.include_keywords %}
                <li>{% blocktrans with value=flight.targeting_parameters.include_keywords|join:", " %}Include keywords: {{ value }}{% endblocktrans %}</li>
              {% endif %}
+             {% if flight.targeting_parameters.mobile_traffic %}
+               <li>{% blocktrans with value=flight.targeting_parameters.mobile_traffic %}Mobile traffic: {{ value }}{% endblocktrans %}</li>
+             {% endif %}
            </ul>
          </dd>
        {% endif %}

--- a/adserver/tests/test_validators.py
+++ b/adserver/tests/test_validators.py
@@ -31,6 +31,8 @@ class TestValidators(TestCase):
         validator({"exclude_keywords": ["django", "vuejs"]})
         validator({"include_state_provinces": ["CA", "ID", "OR"]})
         validator({"include_metro_codes": [1, 2]})
+        validator({"mobile_traffic": "exclude"})
+        validator({"mobile_traffic": "only"})
 
         # Unknown (old) parameters - these raise an error
         self.assertRaises(
@@ -58,3 +60,4 @@ class TestValidators(TestCase):
             ValidationError, validator, {"include_state_provinces": ["USA"]}
         )
         self.assertRaises(ValidationError, validator, {"include_metro_codes": ["USA"]})
+        self.assertRaises(ValidationError, validator, {"mobile_traffic": "unknown"})

--- a/adserver/validators.py
+++ b/adserver/validators.py
@@ -15,12 +15,15 @@ class TargetingParametersValidator(BaseValidator):
     code = "targeting-validator"
     limit_value = None  # required for classes extending BaseValidator
 
+    mobile_traffic_values = ("exclude", "only")
+
     messages = {
         "invalid_type": _("Value must be a dict, not %(type)s"),
         "unknown_key": _("%(key)s is not a valid targeting parameter"),
         "country_code": _("%(code)s is not a valid country code"),
         "state_province_code": _("%(code)s is not a valid state/province code"),
         "metro_code": _("%(code)s is not a valid metro code"),
+        "mobile": _(f"%(value)s must be one of {mobile_traffic_values}"),
         "str": _("%(word)s must be a string"),
     }
 
@@ -31,6 +34,7 @@ class TargetingParametersValidator(BaseValidator):
         "exclude_countries": "_validate_country_codes",
         "include_keywords": "_validate_strs",
         "exclude_keywords": "_validate_strs",
+        "mobile_traffic": "_validate_mobile",
     }
 
     def __init__(self, message=None):
@@ -76,6 +80,10 @@ class TargetingParametersValidator(BaseValidator):
                 raise ValidationError(
                     self.messages["metro_code"], params={"code": code}
                 )
+
+    def _validate_mobile(self, value):
+        if value not in self.mobile_traffic_values:
+            raise ValidationError(self.messages["mobile"], params={"value": value})
 
     def _validate_strs(self, words):
         for word in words:


### PR DESCRIPTION
This allows the targeting parameters to be:

    {"mobile_traffic": "exclude"}

OR

    {"mobile_traffic": "only"}

to exclude mobile traffic or to target only mobile traffic.

Fixes: #188