### PR TITLE
Remove request logging

### DIFF
--- a/docker-compose/production/django/start
+++ b/docker-compose/production/django/start
@@ -20,4 +20,4 @@ python /app/manage.py collectstatic --noinput
 #python /app/manage.py migrate
 
 # Start the app listening on port 5000
-newrelic-admin run-program /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --max-requests=10000 --timeout=120 --log-level debug --log-file -
+newrelic-admin run-program /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --max-requests=10000 --timeout=120 --log-file -


### PR DESCRIPTION
This removes simple logs like:

    [2020-07-16 16:50:32 +0000] [83262] [DEBUG] GET /

from the stdout log. This results in an absolutely massive amount of not so useful logs. All errors and logs that meet Django's logging criteria are still outputted.

The [default log-level](https://docs.gunicorn.org/en/stable/settings.html#loglevel) in gunicorn is INFO