### PR TITLE
Advertiser flight improvements

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -558,6 +558,15 @@ class Flight(TimeStampedModel, IndestructibleModel):
             return []
         return self.targeting_parameters.get("exclude_keywords", [])
 
+    @property
+    def state(self):
+        today = get_ad_day().date()
+        if self.live and self.start_date <= today:
+            return _("Current")
+        if self.end_date > today:
+            return _("Upcoming")
+        return _("Past")
+
     def get_include_countries_display(self):
         included_country_codes = self.included_countries
         countries_dict = dict(countries)

--- a/adserver/templates/adserver/advertiser/flight-detail.html
+++ b/adserver/templates/adserver/advertiser/flight-detail.html
@@ -89,7 +89,7 @@
   </dl>
 
   <p>
-    <a href="{% url 'flight_report' advertiser.slug flight.slug %}" class="btn btn-sm btn-outline-secondary" role="button" aria-pressed="true">
+    <a href="{% url 'flight_report' advertiser.slug flight.slug %}?start_date={{ flight.start_date|date:'Y-m-d' }}" class="btn btn-sm btn-outline-secondary" role="button" aria-pressed="true">
       <span class="fa fa-bar-chart mr-1" aria-hidden="true"></span>
       <span>{% trans 'See full report' %}</span>
     </a>
@@ -144,7 +144,8 @@
       </table>
     </div>
   {% else %}
-    <p>{% trans 'There are no ads in this flight' %}</p>
+    {% url 'advertisement_create' advertiser.slug flight.slug as create_ad_url %}
+    <p class="text-center">{% blocktrans %}There are no ads in this flight yet but you can <a href="{{ create_ad_url }}">create one</a>.{% endblocktrans %}</p>
   {% endif %}
 </section>
 

--- a/adserver/templates/adserver/advertiser/flight-list.html
+++ b/adserver/templates/adserver/advertiser/flight-list.html
@@ -20,44 +20,37 @@
 <h1>{% block heading %}{% trans "Manage advertising flights" %}{% endblock heading %}</h1>
 
 
-{% if flight_list %}
-  <div class="table-responsive">
-    <table class="table table-hover">
-      <thead>
-        <tr>
-          <th><strong>{% trans 'Name' %}</strong></th>
-          <th><strong>{% trans 'Start date' %}</strong></th>
-          <th><strong>{% trans 'End date' %}</strong></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for flight in flight_list %}
-          <tr>
-            <td>
-              <a href="{% url 'flight_detail' advertiser.slug flight.slug %}">{{ flight.name }}</a>
-              {% if not flight.live %}
-                <span class="fa fa-eye-slash fa-fw text-muted" aria-hidden="true" data-toggle="tooltip" title="{% trans 'This flight is disabled' %}"></span>
-              {% endif %}
-            </td>
-            <td>{{ flight.start_date }}</td>
-            <td>{{ flight.end_date }}</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-
-  {% if flight_list.paginator.num_pages > 1 %}
-    <nav aria-label="{% trans 'Flight pagination' %}">
-      <ul class="pagination justify-content-center">
-        {% for page_number in flight_list.paginator.page_range %}
-          <li class="page-item {% if page_number == flight_list.number %}active{% endif %}">
-            <a class="page-link" href="?page={{ page_number }}">{{ page_number }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
-  {% endif %}
+{% if flights %}
+  {% regroup flights by state as flight_groups %}
+  {% for state, flight_list in flight_groups %}
+    {% if flight_list %}
+      <div class="table-responsive">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th><strong>{% blocktrans %}{{ state }} flights{% endblocktrans %}</strong></th>
+              <th><strong>{% trans 'Start date' %}</strong></th>
+              <th><strong>{% trans 'End date' %}</strong></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for flight in flight_list %}
+              <tr>
+                <td>
+                  <a href="{% url 'flight_detail' advertiser.slug flight.slug %}">{{ flight.name }}</a>
+                  {% if not flight.live %}
+                    <span class="fa fa-eye-slash fa-fw text-muted" aria-hidden="true" data-toggle="tooltip" title="{% trans 'This flight is disabled' %}"></span>
+                  {% endif %}
+                </td>
+                <td>{{ flight.start_date }}</td>
+                <td>{{ flight.end_date }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% endif %}
+  {% endfor %}
 {% else %}
   <p>{% trans 'You have no flights' %}</p>
 {% endif %}

--- a/adserver/templates/adserver/reports/advertiser.html
+++ b/adserver/templates/adserver/reports/advertiser.html
@@ -19,32 +19,38 @@
 <section class="mb-5">
   {% if flights %}
     <h2>{% trans 'Flight report details' %}</h2>
-    <div class="table-responsive">
-      <table class="table table-hover">
-        <thead>
-          <tr>
-            <th><strong>{% trans 'Flight Name' %}</strong></th>
-            <th><strong>{% trans 'Start date' %}</strong></th>
-            <th><strong>{% trans 'End date' %}</strong></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for flight in flights %}
-            <tr>
-              <td>
-                <a href="{% url 'flight_report' advertiser.slug flight.slug %}?start_date={{ start_date|date:'Y-m-d' }}{% if end_date %}&amp;end_date={{ end_date|date:'Y-m-d' }}{% endif %}">{{ flight.name }}</a>
-                {% if not flight.live %}
-                  <span class="fa fa-eye-slash fa-fw text-muted" aria-hidden="true" data-toggle="tooltip" title="{% trans 'This flight is disabled' %}"></span>
-                {% endif %}
-              </td>
-              <td>{{ flight.start_date }}</td>
-              <td>{{ flight.end_date }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% endif %}
+
+    {% regroup flights by state as flight_groups %}
+    {% for state, flight_list in flight_groups %}
+      {% if flight_list %}
+        <div class="table-responsive">
+          <table class="table table-hover">
+            <thead>
+              <tr>
+                <th><strong>{% blocktrans %}{{ state }} flights{% endblocktrans %}</strong></th>
+                <th><strong>{% trans 'Start date' %}</strong></th>
+                <th><strong>{% trans 'End date' %}</strong></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for flight in flight_list %}
+                <tr>
+                  <td>
+                    <a href="{% url 'flight_report' advertiser.slug flight.slug %}?start_date={{ flight.start_date|date:'Y-m-d' }}">{{ flight.name }}</a>
+                    {% if not flight.live %}
+                      <span class="fa fa-eye-slash fa-fw text-muted" aria-hidden="true" data-toggle="tooltip" title="{% trans 'This flight is disabled' %}"></span>
+                    {% endif %}
+                  </td>
+                  <td>{{ flight.start_date }}</td>
+                  <td>{{ flight.end_date }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
+    {% endfor %}
+  {% endif %}{# /if flights #}
 </section>
 {% endblock toc %}
 

--- a/adserver/tests/test_advertiser_crud.py
+++ b/adserver/tests/test_advertiser_crud.py
@@ -112,15 +112,6 @@ class TestAdvertiserCrudViews(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response["location"].startswith("/accounts/login/"))
 
-        # Trigger pagination of flights
-        for i in range(FlightListView.PER_PAGE * 2):
-            get(
-                Flight,
-                name=f"Test Flight {i}",
-                slug=f"test-flight-{i}",
-                campaign=self.campaign,
-            )
-
         self.client.force_login(self.user)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -11,9 +11,6 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.core.paginator import EmptyPage
-from django.core.paginator import PageNotAnInteger
-from django.core.paginator import Paginator
 from django.http import Http404
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
@@ -137,24 +134,11 @@ class FlightListView(AdvertiserAccessMixin, UserPassesTestMixin, ListView):
 
     model = Flight
     template_name = "adserver/advertiser/flight-list.html"
-    PER_PAGE = 25
 
     def get_context_data(self, **kwargs):  # pylint: disable=arguments-differ
         context = super().get_context_data(**kwargs)
 
-        paginator = Paginator(self.get_queryset(), self.PER_PAGE)
-
-        # Note: Pagination has been greatly simplified in Django 2.x
-        try:
-            flight_list = paginator.page(self.request.GET.get("page"))
-        except PageNotAnInteger:
-            # If page is not an integer, deliver first page.
-            flight_list = paginator.page(1)
-        except EmptyPage:
-            # If page is out of range (e.g. 9999), deliver last page of results.
-            flight_list = paginator.page(paginator.num_pages)
-
-        context.update({"advertiser": self.advertiser, "flight_list": flight_list})
+        context.update({"advertiser": self.advertiser, "flights": self.get_queryset()})
 
         return context
 


### PR DESCRIPTION
- Default flight reporting to the start date of the flight. Clicking on a flight and seeing no results is awkward.
- Prompt users to create an ad if there aren't any.
- Break flights into current, past, and upcoming

Reviewing [without whitespace](https://github.com/readthedocs/ethical-ad-server/pull/203/files?w=1) may be helpful.

## Screenshot

![Screen Shot 2020-07-28 at 11 55 02 AM](https://user-images.githubusercontent.com/185043/88709078-79e0c900-d0c9-11ea-914f-67c6f477434b.png)
