### PR TITLE
Fix a bug around clicking an add after 4 hours

### DIFF
--- a/adserver/views.py
+++ b/adserver/views.py
@@ -488,8 +488,13 @@ class AdClickProxyView(BaseProxyView):
     def get_response(self, request, advertisement, publisher):
         # Allows using variables in links such as `?utm_source=${publisher}`
         template = string.Template(advertisement.link)
+
+        publisher_slug = "unknown"
+        if publisher:
+            publisher_slug = publisher.slug
+
         url = template.safe_substitute(
-            publisher=publisher.slug, advertisement=advertisement.slug
+            publisher=publisher_slug, advertisement=advertisement.slug
         )
         return HttpResponseRedirect(url)
 


### PR DESCRIPTION
If a user clicks an ad after ~4 hours, the publisher data won't be available. We don't count these for billing purposes already but the click-through shouldn't fail.