### PR TITLE
Ignore all known users

### DIFF
--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -1028,12 +1028,18 @@ class TestProxyViews(BaseApiTest):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp["X-Adserver-Reason"], "Internal IP")
 
-    def test_view_tracking_staff(self):
+    def test_view_tracking_known_user(self):
         self.client.force_login(self.staff_user)
         resp = self.client.get(self.url)
 
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp["X-Adserver-Reason"], "Staff impression")
+        self.assertEqual(resp["X-Adserver-Reason"], "Known user impression")
+
+        self.client.force_login(self.user)
+        resp = self.client.get(self.url)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["X-Adserver-Reason"], "Known user impression")
 
     def test_view_tracking_bot(self):
         bot_ua = (

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -344,9 +344,9 @@ class BaseProxyView(View):
             # This is probably a bot/proxy server/prefetcher/etc.
             log.log(self.log_level, "Unknown user agent impression [%s]", user_agent)
             reason = "Unrecognized user agent"
-        elif request.user.is_staff:
-            log.log(self.log_level, "Ignored staff user ad impression")
-            reason = "Staff impression"
+        elif not request.user.is_anonymous:
+            log.log(self.log_level, "Ignored known user ad impression")
+            reason = "Known user impression"
         elif is_blocklisted_user_agent(user_agent):
             log.log(self.log_level, "Blocked user agent impression [%s]", user_agent)
             reason = "Blocked UA impression"

--- a/docs/user-guide/getting-started.rst
+++ b/docs/user-guide/getting-started.rst
@@ -63,10 +63,12 @@ Clicks
 
     * This isn't a duplicate click
     * The user isn't rate limited
-    * The user agent isn't banned or a known "bot"
+    * The user agent is a browser, not a known "bot",
+      and not one of the :ref:`install/configuration:ADSERVER_BLOCKLISTED_USER_AGENTS`
     * The flight targeting (which is rechecked) matches
-    * The user is not logged in as a staff account
-    * The IP doesn't come from an :ref:`install/configuration:INTERNAL_IPS`
+    * The user is not logged in as an advertiser, publisher, or staff
+    * The IP isn't one of the :ref:`install/configuration:INTERNAL_IPS` or a known proxy
+    * The referrer is valid and isn't one of the :ref:`install/configuration:ADSERVER_BLOCKLISTED_REFERRERS`
 
 Views
     Just like clicks are stored each time an ad is clicked, it is possible to do the same each time an ad is viewed.


### PR DESCRIPTION
Previously we were ignoring staff but with this change we will ignore all known users. I think this is the right move
so advertisers or publishers impressions don't count. It might make the verification step for publishers a little trickier.