### PR TITLE
Don't auto-migrate Django when running locally

### DIFF
--- a/docker-compose/local/django/start
+++ b/docker-compose/local/django/start
@@ -5,5 +5,6 @@ set -o pipefail
 set -o nounset
 
 
-python manage.py migrate
+# Don't auto-migrate locally because this can cause weird issues when testing migrations
+# python manage.py migrate
 python manage.py runserver 0.0.0.0:5000


### PR DESCRIPTION
This was causing weird issues when I didn't want to have migrations run.