### PR TITLE
Add a simple “Advertiser” filter to the publisher templates

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -203,7 +203,9 @@ class Publisher(TimeStampedModel, IndestructibleModel):
             return return_keywords
         return []
 
-    def daily_reports(self, start_date=None, end_date=None, campaign_type=None):
+    def daily_reports(
+        self, start_date=None, end_date=None, campaign_type=None, advertiser=None
+    ):
         """
         Generates a report of clicks, views, & cost for a given time period for the Publisher.
 
@@ -222,6 +224,11 @@ class Publisher(TimeStampedModel, IndestructibleModel):
         if campaign_type and campaign_type in ALL_CAMPAIGN_TYPES:
             impressions = impressions.filter(
                 advertisement__flight__campaign__campaign_type=campaign_type
+            )
+
+        if advertiser:
+            impressions = impressions.filter(
+                advertisement__flight__campaign__advertiser__slug=advertiser
             )
 
         impressions = impressions.select_related(

--- a/adserver/templates/adserver/reports/all-publishers.html
+++ b/adserver/templates/adserver/reports/all-publishers.html
@@ -16,15 +16,7 @@
 
 
 {% block additional_filters %}
-<div class="col-lg-2 col-md-4 mb-3">
-  <label class="col-form-label" for="id_campaign_type">{% trans 'Campaign type' %}</label>
-  <select class="form-control" name="campaign_type" id="id_campaign_type">
-    <option>All types</option>
-    {% for slug, type in campaign_types %}
-      <option value="{{ slug }}"{% if campaign_type == slug %} selected{% endif %}>{{ type }}</option>
-    {% endfor %}
-  </select>
-</div>
+
 <div class="col-lg-2 col-md-4 mb-3">
   <label class="col-form-label" for="id_campaign_type">{% trans 'Revenue Share' %}</label>
   <select class="form-control" name="revenue_share_percentage" id="id_revenue_share_percentage">

--- a/adserver/templates/adserver/reports/base.html
+++ b/adserver/templates/adserver/reports/base.html
@@ -43,7 +43,7 @@
 
           {% if advertiser_list %}
           <div class="col-lg-2 col-md-4 mb-3">
-            <label class="col-form-label" for="id_advertiser">{% trans 'Advertisers' %}</label>
+            <label class="col-form-label" for="id_advertiser">{% trans 'Top Advertisers' %}</label>
             <select class="form-control" name="report_advertiser" id="id_advertiser">
               <option value="">All advertisers</option>
               {% for slug, name in advertiser_list %}

--- a/adserver/templates/adserver/reports/base.html
+++ b/adserver/templates/adserver/reports/base.html
@@ -33,7 +33,7 @@
           <div class="col-lg-2 col-md-4 mb-3">
             <label class="col-form-label" for="id_campaign_type">{% trans 'Campaign type' %}</label>
             <select class="form-control" name="campaign_type" id="id_campaign_type">
-              <option>All types</option>
+              <option value="">All types</option>
               {% for slug, type in campaign_types %}
                 <option value="{{ slug }}"{% if campaign_type == slug %} selected{% endif %}>{{ type }}</option>
               {% endfor %}
@@ -45,7 +45,7 @@
           <div class="col-lg-2 col-md-4 mb-3">
             <label class="col-form-label" for="id_advertiser">{% trans 'Advertisers' %}</label>
             <select class="form-control" name="report_advertiser" id="id_advertiser">
-              <option>All advertisers</option>
+              <option value="">All advertisers</option>
               {% for slug, name in advertiser_list %}
                 <option value="{{ slug }}"{% if report_advertiser == slug %} selected{% endif %}>{{ name }}</option>
               {% endfor %}

--- a/adserver/templates/adserver/reports/base.html
+++ b/adserver/templates/adserver/reports/base.html
@@ -28,8 +28,34 @@
             <input class="form-control" name="end_date" id="id_end_date" type="date" value="{% if end_date %}{{ end_date|date:"Y-m-d" }}{% endif %}" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
           </div>
 
+          {# Add filters when we have the data to show them #}
+          {% if campaign_types %}
+          <div class="col-lg-2 col-md-4 mb-3">
+            <label class="col-form-label" for="id_campaign_type">{% trans 'Campaign type' %}</label>
+            <select class="form-control" name="campaign_type" id="id_campaign_type">
+              <option>All types</option>
+              {% for slug, type in campaign_types %}
+                <option value="{{ slug }}"{% if campaign_type == slug %} selected{% endif %}>{{ type }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          {% endif %}
+
+          {% if advertiser_list %}
+          <div class="col-lg-2 col-md-4 mb-3">
+            <label class="col-form-label" for="id_advertiser">{% trans 'Advertisers' %}</label>
+            <select class="form-control" name="report_advertiser" id="id_advertiser">
+              <option>All advertisers</option>
+              {% for slug, name in advertiser_list %}
+                <option value="{{ slug }}"{% if report_advertiser == slug %} selected{% endif %}>{{ name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          {% endif %}
+
           {% block additional_filters %}{% endblock additional_filters %}
         </div>
+
         <button class="btn btn-primary" type="submit">{% trans 'Filter report' %}</button>
       </form>
     </div>

--- a/adserver/templates/adserver/reports/publisher.html
+++ b/adserver/templates/adserver/reports/publisher.html
@@ -15,25 +15,6 @@
 {% endblock breadcrumbs %}
 
 {% block additional_filters %}
-<div class="col-lg-2 col-md-4 mb-3">
-  <label class="col-form-label" for="id_campaign_type">{% trans 'Campaign type' %}</label>
-  <select class="form-control" name="campaign_type" id="id_campaign_type">
-    <option>All types</option>
-    {% for slug, type in campaign_types %}
-      <option value="{{ slug }}"{% if campaign_type == slug %} selected{% endif %}>{{ type }}</option>
-    {% endfor %}
-  </select>
-</div>
-
-<div class="col-lg-2 col-md-4 mb-3">
-  <label class="col-form-label" for="id_advertiser">{% trans 'Advertisers' %}</label>
-  <select class="form-control" name="report_advertiser" id="id_advertiser">
-    <option>All advertisers</option>
-    {% for slug, name in advertiser_list %}
-      <option value="{{ slug }}"{% if report_advertiser == slug %} selected{% endif %}>{{ name }}</option>
-    {% endfor %}
-  </select>
-</div>
 {% endblock additional_filters %}
 
 

--- a/adserver/templates/adserver/reports/publisher.html
+++ b/adserver/templates/adserver/reports/publisher.html
@@ -29,8 +29,8 @@
   <label class="col-form-label" for="id_advertiser">{% trans 'Advertisers' %}</label>
   <select class="form-control" name="report_advertiser" id="id_advertiser">
     <option>All advertisers</option>
-    {% for slug in advertiser_list %}
-      <option value="{{ slug }}"{% if report_advertiser == slug %} selected{% endif %}>{{ slug }}</option>
+    {% for slug, name in advertiser_list %}
+      <option value="{{ slug }}"{% if report_advertiser == slug %} selected{% endif %}>{{ name }}</option>
     {% endfor %}
   </select>
 </div>

--- a/adserver/templates/adserver/reports/publisher.html
+++ b/adserver/templates/adserver/reports/publisher.html
@@ -24,6 +24,16 @@
     {% endfor %}
   </select>
 </div>
+
+<div class="col-lg-2 col-md-4 mb-3">
+  <label class="col-form-label" for="id_advertiser">{% trans 'Advertisers' %}</label>
+  <select class="form-control" name="report_advertiser" id="id_advertiser">
+    <option>All advertisers</option>
+    {% for slug in advertiser_list %}
+      <option value="{{ slug }}"{% if report_advertiser == slug %} selected{% endif %}>{{ slug }}</option>
+    {% endfor %}
+  </select>
+</div>
 {% endblock additional_filters %}
 
 

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -1006,6 +1006,15 @@ class AllPublisherReportView(BaseReportView):
 
         publishers = Publisher.objects.filter(id__in=impressions.values("publisher"))
 
+        advertiser_list = (
+            impressions.order_by("advertisement__flight__campaign__advertiser__slug")
+            .values_list(
+                "advertisement__flight__campaign__advertiser__slug",
+                "advertisement__flight__campaign__advertiser__name",
+            )
+            .distinct()
+        )
+
         if context["revenue_share_percentage"]:
             try:
                 publishers = publishers.filter(
@@ -1020,6 +1029,7 @@ class AllPublisherReportView(BaseReportView):
                 start_date=context["start_date"],
                 end_date=context["end_date"],
                 campaign_type=context["campaign_type"],
+                advertiser=context["report_advertiser"],
             )
             if report["total"]["views"] > 0:
                 publishers_and_reports.append((publisher, report))
@@ -1080,6 +1090,7 @@ class AllPublisherReportView(BaseReportView):
                 "revshare_options": set(
                     str(pub.revenue_share_percentage) for pub in Publisher.objects.all()
                 ),
+                "advertiser_list": advertiser_list,
                 "sort": sort,
             }
         )

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -762,7 +762,10 @@ class PublisherReportView(PublisherAccessMixin, BaseReportView):
             publisher.adimpression_set.order_by(
                 "advertisement__flight__campaign__advertiser__slug"
             )
-            .values_list("advertisement__flight__campaign__advertiser__slug", flat=True)
+            .values_list(
+                "advertisement__flight__campaign__advertiser__slug",
+                "advertisement__flight__campaign__advertiser__name",
+            )
             .distinct()
         )
 

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -1007,6 +1007,8 @@ class AllPublisherReportView(BaseReportView):
         publishers = Publisher.objects.filter(id__in=impressions.values("publisher"))
 
         advertiser_list = (
+            # order_by is required for `distinct()` to work
+            # https://code.djangoproject.com/ticket/16058
             impressions.order_by("advertisement__flight__campaign__advertiser__slug")
             .values_list(
                 "advertisement__flight__campaign__advertiser__slug",

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -759,10 +759,15 @@ class PublisherReportView(PublisherAccessMixin, BaseReportView):
         publisher_slug = kwargs.get("publisher_slug", "")
         publisher = get_object_or_404(Publisher, slug=publisher_slug)
 
+        advertiser_list = publisher.adimpression_set.all()
+
+        if context["start_date"]:
+            advertiser_list = advertiser_list.filter(date__gte=context["start_date"])
+        if context["end_date"]:
+            advertiser_list = advertiser_list.filter(date__lte=context["end_date"])
+
         advertiser_list = (
-            publisher.adimpression_set.values_list(
-                "advertisement__flight__campaign__advertiser"
-            )
+            advertiser_list.values_list("advertisement__flight__campaign__advertiser")
             .annotate(total_views=Sum("views"))
             .order_by("-total_views")
             .filter(total_views__gt=100)
@@ -771,11 +776,6 @@ class PublisherReportView(PublisherAccessMixin, BaseReportView):
                 "advertisement__flight__campaign__advertiser__name",
             )
         )
-
-        if context["start_date"]:
-            advertiser_list = advertiser_list.filter(date__gte=context["start_date"])
-        if context["end_date"]:
-            advertiser_list = advertiser_list.filter(date__lte=context["end_date"])
 
         advertiser_list = advertiser_list[:10]
 

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -769,6 +769,10 @@ class PublisherReportView(PublisherAccessMixin, BaseReportView):
             .distinct()
         )
 
+        # Remove report_advertiser if there's invalid data passed in
+        if context["report_advertiser"] not in advertiser_list:
+            context["report_advertiser"] = None
+
         report = publisher.daily_reports(
             start_date=context["start_date"],
             end_date=context["end_date"],


### PR DESCRIPTION
This is just a stopgap until we have a proper way to show more detailed per-advertiser data in the reports.
I just didn’t want to change up the reporting logic quite yet,
and this was easy enough to get the data we need.