### PR TITLE
Add total breakdown to All publishers report

### DIFF
--- a/adserver/templates/adserver/reports/all-publishers.html
+++ b/adserver/templates/adserver/reports/all-publishers.html
@@ -70,6 +70,19 @@
           </tr>
         </thead>
         <tbody>
+          {% for date, day in days.items %}
+            {% if day.views > 0 or day.clicks > 0 %}
+            <tr>
+              <td>{{ date }}</td>
+              <td class="text-right">{{ day.views|intcomma }}</td>
+              <td class="text-right">{{ day.clicks|intcomma }}</td>
+              <td class="text-right">${{ day.ecpm|floatformat:2 }}</td>
+              <td class="text-right">{{ day.ctr|floatformat:3 }}%</td>
+              <td class="text-right">${{ day.revenue|floatformat:2|intcomma }}</td>
+              <td class="text-right">${{ day.our_revenue|floatformat:2|intcomma }}</td>
+            </tr>
+            {% endif %}
+          {% endfor %}
           <tr>
             <td><strong>{{ start_date|date:"M j, Y" }} - {{ end_date|date:"M j, Y" }}</strong></td>
             <td class="text-right"><strong>{{ total_views|intcomma }}</strong></td>

--- a/adserver/templates/adserver/reports/all-publishers.html
+++ b/adserver/templates/adserver/reports/all-publishers.html
@@ -40,7 +40,7 @@
 {% block toc %}
 <section class="mb-5">
   {% if publishers %}
-    <h2>{% trans 'Publishers '%}</h2>
+    <h2>{% trans 'Publishers '%} ({{ publishers|length }})</h2>
     <ul>
     {% for publisher in publishers %}
       <li><a href="#{{ publisher.slug }}">{{ publisher }}</a></li>

--- a/adserver/templates/adserver/reports/all-publishers.html
+++ b/adserver/templates/adserver/reports/all-publishers.html
@@ -41,11 +41,13 @@
 <section class="mb-5">
   {% if publishers %}
     <h2>{% trans 'Publishers '%} ({{ publishers|length }})</h2>
+    <details>
     <ul>
     {% for publisher in publishers %}
       <li><a href="#{{ publisher.slug }}">{{ publisher }}</a></li>
     {% endfor %}
     </ul>
+    </details>
   {% endif %}
 </section>
 {% endblock toc %}

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -1150,6 +1150,9 @@ class AllPublisherReportView(BaseReportView):
                 days[day["date"]]["ctr"] = calculate_ctr(
                     days[day["date"]]["clicks"], days[day["date"]]["views"]
                 )
+                days[day["date"]]["ecpm"] = calculate_ecpm(
+                    days[day["date"]]["revenue"], days[day["date"]]["views"]
+                )
 
         context.update(
             {
@@ -1158,6 +1161,7 @@ class AllPublisherReportView(BaseReportView):
                 "total_clicks": total_clicks,
                 "total_revenue": total_revenue,
                 "our_total_revenue": our_total_revenue,
+                "days": days,
                 "total_views": total_views,
                 "total_ctr": calculate_ctr(total_clicks, total_views),
                 "total_ecpm": calculate_ecpm(total_revenue, total_views),


### PR DESCRIPTION
This will enable us to more easily compare Day over Day metrics across a subset of our stack.