### PR TITLE
Index the date fields on ad impressions, clicks, views, and offers

### DIFF
--- a/adserver/migrations/0034_add_impression_date_index.py
+++ b/adserver/migrations/0034_add_impression_date_index.py
@@ -1,0 +1,51 @@
+"""
+Indexes the impression and offer/click/view tables.
+
+This migration indexes a few potentially *VERY LARGE* tables.
+As a result, it is probably best faked and run concurrently.
+
+https://www.postgresql.org/docs/9.1/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY
+
+CREATE INDEX CONCURRENTLY "adserver_adimpression_date_2d0c27df" ON "adserver_adimpression" ("date");
+CREATE INDEX CONCURRENTLY "adserver_click_date_e4990df6" ON "adserver_click" ("date");
+CREATE INDEX CONCURRENTLY "adserver_offer_date_727b287b" ON "adserver_offer" ("date");
+CREATE INDEX CONCURRENTLY "adserver_placementimpression_date_a840af08" ON "adserver_placementimpression" ("date");
+CREATE INDEX CONCURRENTLY "adserver_view_date_a6d72ef8" ON "adserver_view" ("date");
+"""
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('adserver', '0033_add_keyword_placement_impressions'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='adimpression',
+            name='date',
+            field=models.DateField(db_index=True, verbose_name='Date'),
+        ),
+        migrations.AlterField(
+            model_name='click',
+            name='date',
+            field=models.DateTimeField(db_index=True, verbose_name='Impression date'),
+        ),
+        migrations.AlterField(
+            model_name='offer',
+            name='date',
+            field=models.DateTimeField(db_index=True, verbose_name='Impression date'),
+        ),
+        migrations.AlterField(
+            model_name='placementimpression',
+            name='date',
+            field=models.DateField(db_index=True, verbose_name='Date'),
+        ),
+        migrations.AlterField(
+            model_name='view',
+            name='date',
+            field=models.DateTimeField(db_index=True, verbose_name='Impression date'),
+        ),
+    ]

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1409,7 +1409,7 @@ class BaseImpression(TimeStampedModel, models.Model):
 
     """Statistics for tracking."""
 
-    date = models.DateField(_("Date"))
+    date = models.DateField(_("Date"), db_index=True)
 
     # Offers include cases where the server returned an ad
     # but the client didn't load it
@@ -1513,7 +1513,7 @@ class AdBase(TimeStampedModel, IndestructibleModel):
 
     """A base class for data on ad views and clicks."""
 
-    date = models.DateTimeField(_("Impression date"))
+    date = models.DateTimeField(_("Impression date"), db_index=True)
 
     publisher = models.ForeignKey(
         Publisher, null=True, blank=True, on_delete=models.PROTECT


### PR DESCRIPTION
This migration indexes a few potentially *VERY LARGE* tables.
As a result, it is probably best faked and run concurrently.

https://www.postgresql.org/docs/9.1/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY