### PR TITLE
Migrate PlacementImpressions to a Celery task

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1067,20 +1067,6 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
             **{impression_type: models.F(impression_type) + 1}
         )
 
-        # Only store div_id when publisher has it enabled, and old defaults aren't present
-        if (
-            div_id
-            and ad_type_slug
-            and publisher.record_placements
-            and not re.search(r"rtd-\w{8}|ad_\w{8}", div_id)
-        ):
-            placement_impression, _ = self.placement_impressions.get_or_create(
-                publisher=publisher, date=day, div_id=div_id, ad_type_slug=ad_type_slug
-            )
-            PlacementImpression.objects.filter(pk=placement_impression.pk).update(
-                **{impression_type: models.F(impression_type) + 1}
-            )
-
         # Update the denormalized fields on the Flight
         if impression_type == VIEWS:
             Flight.objects.filter(pk=self.flight_id).update(

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -3,7 +3,6 @@ import datetime
 import html
 import logging
 import math
-import re
 import uuid
 from collections import Counter
 from collections import defaultdict

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -2,6 +2,7 @@
 import datetime
 import logging
 
+from celery.utils.iso8601 import parse_iso8601
 from django.db.models import Count
 
 from .constants import CLICKS
@@ -67,6 +68,10 @@ def daily_update_placements(day=None):
     """
     start_date = get_ad_day()
     if day:
+        log.info("Got day: %s", day)
+        if not isinstance(day, (datetime.datetime, datetime.date)):
+            log.info("Converting day from string")
+            day = parse_iso8601(day)
         start_date = day.replace(hour=0, minute=0, second=0, microsecond=0)
     end_date = start_date + datetime.timedelta(days=1)
 

--- a/adserver/templates/adserver/reports/publisher.html
+++ b/adserver/templates/adserver/reports/publisher.html
@@ -25,6 +25,9 @@
     This report shows all of the billable traffic for your site.
     You can filter it to better understand what is going on with your traffic.
   </p>
+  <em>
+  This report updates close to real-time.
+  </em>
 </section>
 {% endblock explainer %}
 

--- a/adserver/templates/adserver/reports/publisher_geo.html
+++ b/adserver/templates/adserver/reports/publisher_geo.html
@@ -42,6 +42,9 @@
     We charge different rates based on the geo,
     so it will let you understand a bit more about how your traffic is monetizing.
   </p>
+  <em>
+  This report updates periodically. All previous days data is complete.
+  </em>
 </section>
 {% endblock explainer %}
 

--- a/adserver/templates/adserver/reports/publisher_placement.html
+++ b/adserver/templates/adserver/reports/publisher_placement.html
@@ -43,6 +43,11 @@
     You can use this to optomize the different placement on your site,
     and better understand how each one is working to be able to improve them.
   </p>
+  <p>
+  <em>
+  This report updates periodically. All previous days data is complete.
+  </em>
+  </p>
 </section>
 {% endblock explainer %}
 

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -1058,13 +1058,6 @@ class AdvertisingIntegrationTests(BaseApiTest):
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.views, 1)
 
-        # Verify a PlacementImpression was written
-        placement_impression = self.ad.placement_impressions.filter(
-            publisher=self.publisher1
-        ).first()
-        self.assertEqual(placement_impression.offers, 1)
-        self.assertEqual(placement_impression.views, 1)
-
         # Make sure we're writing ads for ad network views
         self.assertTrue(
             View.objects.filter(

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest import mock
 
 from django.contrib.auth import get_user_model
@@ -412,7 +413,7 @@ class TestReportViews(TestCase):
         get(Offer, publisher=self.publisher1, div_id="ad_23453464", viewed=True)
 
         # Update reporting
-        daily_update_placements()
+        daily_update_placements(day=datetime.datetime.utcnow().isoformat())
 
         # All reports
         response = self.client.get(url)

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -19,6 +19,7 @@ from ..models import Flight
 from ..models import Offer
 from ..models import Publisher
 from ..tasks import daily_update_geos
+from ..tasks import daily_update_placements
 
 
 class TestReportViews(TestCase):
@@ -404,6 +405,14 @@ class TestReportViews(TestCase):
     def test_publisher_placement_report_contents(self):
         self.client.force_login(self.staff_user)
         url = reverse("publisher_placement_report", args=[self.publisher1.slug])
+
+        get(Offer, publisher=self.publisher1, div_id="p1", viewed=True)
+        get(Offer, publisher=self.publisher1, div_id="p2", viewed=True)
+        get(Offer, publisher=self.publisher1, div_id="p2", viewed=True)
+        get(Offer, publisher=self.publisher1, div_id="ad_23453464", viewed=True)
+
+        # Update reporting
+        daily_update_placements()
 
         # All reports
         response = self.client.get(url)

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -41,4 +41,8 @@ CELERYBEAT_SCHEDULE = {
         "task": "adserver.tasks.daily_update_geos",
         "schedule": crontab(minute="*/5"),
     },
+    "every-day-generate-placement-index": {
+        "task": "adserver.tasks.daily_update_placements",
+        "schedule": crontab(minute="*/5"),
+    },
 }

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -36,7 +36,7 @@ CELERY_TASK_ALWAYS_EAGER = False
 CELERY_BROKER_URL = env("CELERY_BROKER_URL", default=env("REDIS_URL", default=None))
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 
-CELERYBEAT_SCHEDULE = {
+CELERY_BEAT_SCHEDULE = {
     "every-day-generate-geo-index": {
         "task": "adserver.tasks.daily_update_geos",
         "schedule": crontab(minute="*/5"),

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -114,11 +114,11 @@ if env.bool("REDIS_SSL", default=False):
     CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": ssl.CERT_REQUIRED}
 
 CELERY_BEAT_SCHEDULE = {
-    "every-day-generate-geo-index": {
+    "every-hour-generate-geo-index": {
         "task": "adserver.tasks.daily_update_geos",
         "schedule": crontab(minute="15"),
     },
-    "every-day-generate-placement-index": {
+    "every-hour-generate-placement-index": {
         "task": "adserver.tasks.daily_update_placements",
         "schedule": crontab(minute="45"),
     },

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -116,7 +116,11 @@ if env.bool("REDIS_SSL", default=False):
 CELERY_BEAT_SCHEDULE = {
     "every-day-generate-geo-index": {
         "task": "adserver.tasks.daily_update_geos",
-        "schedule": crontab(minute="*/30"),
+        "schedule": crontab(minute="15"),
+    },
+    "every-day-generate-placement-index": {
+        "task": "adserver.tasks.daily_update_placements",
+        "schedule": crontab(minute="45"),
     },
 }
 


### PR DESCRIPTION
This moves our only other in process index into a celery task. We now only
update the ``Offer`` and ``AdImrpession`` table on the AdDecision api.