### PR TITLE
Show breakdown report on the Geo/Placement reports by default

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -45,6 +45,7 @@ from .utils import get_client_country
 from .utils import get_client_id
 from .utils import get_client_ip
 from .utils import get_client_user_agent
+from .utils import get_country_name
 from .validators import TargetingParametersValidator
 
 log = logging.getLogger(__name__)  # noqa
@@ -216,6 +217,7 @@ class Publisher(TimeStampedModel, IndestructibleModel):
         div_id=None,
         advertiser=None,
         country=None,
+        report_length=20,
     ):
         """
         Generates a report of clicks, views, & cost for a given time period for the Publisher.
@@ -228,20 +230,30 @@ class Publisher(TimeStampedModel, IndestructibleModel):
             and an aggregated total
         """
         report = {"days": [], "total": {}}
-
+        report_index = "date"
         impressions = AdImpression.objects.filter(publisher=self)
 
         # When passed in from the placement report, div_id will be an empty string, not None
         # So we differentiate between None and "" here
         if div_id is not None:
+            report_index = "div_id"
             impressions = PlacementImpression.objects.filter(publisher=self)
             if div_id:
-                impressions = impressions.filter(div_id=div_id)
+                # Show dates when filtered
+                report_index = "date"
+                impressions = PlacementImpression.objects.filter(
+                    publisher=self, div_id=div_id
+                )
 
         if country is not None:
+            report_index = "country"
             impressions = GeoImpression.objects.filter(publisher=self)
             if country:
-                impressions = impressions.filter(country=country)
+                # Show dates when filtered
+                report_index = "date"
+                impressions = GeoImpression.objects.filter(
+                    publisher=self, country=country
+                )
 
         if start_date:
             impressions = impressions.filter(date__gte=start_date)
@@ -263,30 +275,47 @@ class Publisher(TimeStampedModel, IndestructibleModel):
 
         days = OrderedDict()
         for impression in impressions:
-            if impression.date not in days:
-                days[impression.date] = defaultdict(int)
+            index = getattr(impression, report_index)
 
-            days[impression.date]["date"] = impression.date
-            days[impression.date]["views"] += impression.views
-            days[impression.date]["clicks"] += impression.clicks
-            days[impression.date]["revenue"] += (
+            if index not in days:
+                days[index] = defaultdict(int)
+
+            index_display = index
+            if report_index == "country":
+                index_display = "%s (%s)" % (index, get_country_name(index))
+
+            days[index]["date"] = impression.date
+            days[index]["index"] = index_display
+            days[index]["views"] += impression.views
+            days[index]["clicks"] += impression.clicks
+            days[index]["revenue"] += (
                 impression.clicks * float(impression.advertisement.flight.cpc)
             ) + (impression.views * float(impression.advertisement.flight.cpm) / 1000.0)
-            days[impression.date]["revenue_share"] = days[impression.date][
-                "revenue"
-            ] * (self.revenue_share_percentage / 100.0)
-            days[impression.date]["our_revenue"] = (
-                days[impression.date]["revenue"]
-                - days[impression.date]["revenue_share"]
+            days[index]["revenue_share"] = days[index]["revenue"] * (
+                self.revenue_share_percentage / 100.0
             )
-            days[impression.date]["ctr"] = calculate_ctr(
-                days[impression.date]["clicks"], days[impression.date]["views"]
+            days[index]["our_revenue"] = (
+                days[index]["revenue"] - days[index]["revenue_share"]
             )
-            days[impression.date]["ecpm"] = calculate_ecpm(
-                days[impression.date]["revenue"], days[impression.date]["views"]
+            days[index]["ctr"] = calculate_ctr(
+                days[index]["clicks"], days[index]["views"]
+            )
+            days[index]["ecpm"] = calculate_ecpm(
+                days[index]["revenue"], days[index]["views"]
             )
 
+            if report_index == "country":
+                days[index]["country"] = impression.country
+
         report["days"] = days.values()
+
+        if report_index != "date":
+            # Only include limit in the report
+            report["days"] = sorted(
+                days.values(),
+                key=lambda obj: obj["views"],
+                reverse=True,
+            )[:report_length]
 
         report["total"]["views"] = sum(day["views"] for day in report["days"])
         report["total"]["clicks"] = sum(day["clicks"] for day in report["days"])

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -276,10 +276,8 @@ class Publisher(TimeStampedModel, IndestructibleModel):
         days = OrderedDict()
         for impression in impressions:
             index = getattr(impression, report_index)
-
             if index not in days:
                 days[index] = defaultdict(int)
-
             index_display = index
             if report_index == "country":
                 index_display = "%s (%s)" % (index, get_country_name(index))
@@ -304,13 +302,9 @@ class Publisher(TimeStampedModel, IndestructibleModel):
                 days[index]["revenue"], days[index]["views"]
             )
 
-            if report_index == "country":
-                days[index]["country"] = impression.country
-
         report["days"] = days.values()
-
         if report_index != "date":
-            # Only include limit in the report
+            # Show a truncated list sorted by most views
             report["days"] = sorted(
                 days.values(),
                 key=lambda obj: obj["views"],

--- a/adserver/templates/adserver/reports/publisher.html
+++ b/adserver/templates/adserver/reports/publisher.html
@@ -50,7 +50,7 @@
       <table class="table table-hover">
         <thead>
           <tr>
-            <th><strong>{% trans 'Time Period' %}</strong></th>
+            <th><strong>{% trans 'Report Index' %}</strong></th>
             <th class="text-right"><strong>{% trans 'Total&nbsp;Views' %}</strong></th>
             <th class="text-right"><strong>{% trans 'Total&nbsp;Clicks' %}</strong></th>
             <th class="text-right"><strong>{% blocktrans %}Total&nbsp;<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
@@ -62,7 +62,7 @@
           {% for day in report.days %}
             {% if day.views > 0 or day.clicks > 0 %}
             <tr>
-              <td>{{ day.date }}</td>
+              <td>{{ day.index }}</td>
               <td class="text-right">{{ day.views|intcomma }}</td>
               <td class="text-right">{{ day.clicks|intcomma }}</td>
               <td class="text-right">{{ day.ctr|floatformat:3 }}%</td>

--- a/adserver/templates/adserver/reports/publisher_geo.html
+++ b/adserver/templates/adserver/reports/publisher_geo.html
@@ -43,7 +43,7 @@
     so it will let you understand a bit more about how your traffic is monetizing.
   </p>
   <em>
-  This report updates periodically. All previous days data is complete.
+  This report shows the <strong>top {{ limit }} geos</strong> and updates periodically. All previous days data is complete.
   </em>
 </section>
 {% endblock explainer %}

--- a/adserver/templates/adserver/reports/publisher_placement.html
+++ b/adserver/templates/adserver/reports/publisher_placement.html
@@ -45,7 +45,7 @@
   </p>
   <p>
   <em>
-  This report updates periodically. All previous days data is complete.
+  This report shows the <strong>top {{ limit }} placements</strong> and updates periodically. All previous days data is complete.
   </em>
   </p>
 </section>

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -20,6 +20,7 @@ from django.utils.crypto import get_random_string
 from django.utils.encoding import force_bytes
 from django.utils.encoding import force_text
 from django.utils.http import urlencode
+from django_countries import countries
 from geoip2.errors import AddressNotFoundError
 from ratelimit.utils import is_ratelimited
 from user_agents import parse
@@ -31,6 +32,10 @@ log = logging.getLogger(__name__)  # noqa
 GeolocationTuple = namedtuple(
     "GeolocationTuple", ["country_code", "region_code", "metro_code"]
 )
+
+
+# Put this here so we don't reload it on each call
+COUNTRY_DICT = dict(countries)
 
 
 def analytics_event(**kwargs):
@@ -132,6 +137,10 @@ def get_client_country(request, ip_address=None):
             country = geo_data["country_code"]
 
     return country
+
+
+def get_country_name(country_code):
+    return COUNTRY_DICT.get(country_code)
 
 
 def anonymize_ip_address(ip_address):


### PR DESCRIPTION
This still shows day-by-day data when filtered,
but defaults to a breakdown of the top 20 items.