### PR TITLE
Performance workaround for the offer admin

### DIFF
--- a/adserver/admin.py
+++ b/adserver/admin.py
@@ -797,6 +797,13 @@ class OfferAdmin(AdBaseAdmin):
     readonly_fields = AdBaseAdmin.readonly_fields + ("viewed", "clicked")
     list_display = AdBaseAdmin.list_display + ("viewed", "clicked")
 
+    # Without this, the django admin will order by date and PK
+    # resulting in a very expensive query
+    # This is due to how the admin determines that the order should be deterministic.
+    # https://docs.djangoproject.com/en/2.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.ordering
+    # Ordering by a UUID isn't very useful.
+    ordering = ("-pk",)
+
 
 class ClickAdmin(AdBaseAdmin):
 


### PR DESCRIPTION
This isn't an ideal workaround but should get the admin usable. Without this django generates a query with `ORDER BY "adserver_offer"."date" DESC, "adserver_offer"."id"` which is very expensive. Django does this to have a deterministic sort order.

Longer term, the better solution is to have a sortable, unique PK. This could be a date prefixed UUID or something like that. 