### PR TITLE
Add a new report for Publishers showing their advertisers

### DIFF
--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -108,6 +108,15 @@
               </li>
               {% endif %}
 
+              {% if request.user.is_staff %}
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'publisher_advertiser_report' publisher.slug %}">
+                  <span class="fa fa-building fa-fw ml-4 text-muted" aria-hidden="true"></span>
+                  <span>{% trans 'Advertisers' %}</span>
+                </a>
+              </li>
+              {% endif %}
+
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'publisher_payouts' publisher.slug %}">
                   <span class="fa fa-dollar fa-fw mr-2 text-muted" aria-hidden="true"></span>

--- a/adserver/templates/adserver/reports/base.html
+++ b/adserver/templates/adserver/reports/base.html
@@ -41,18 +41,6 @@
           </div>
           {% endif %}
 
-          {% if advertiser_list %}
-          <div class="col-lg-2 col-md-4 mb-3">
-            <label class="col-form-label" for="id_advertiser">{% trans 'Top Advertisers' %}</label>
-            <select class="form-control" name="report_advertiser" id="id_advertiser">
-              <option value="">All advertisers</option>
-              {% for slug, name in advertiser_list %}
-                <option value="{{ slug }}"{% if report_advertiser == slug %} selected{% endif %}>{{ name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          {% endif %}
-
           {% block additional_filters %}{% endblock additional_filters %}
         </div>
 

--- a/adserver/templates/adserver/reports/publisher_advertiser.html
+++ b/adserver/templates/adserver/reports/publisher_advertiser.html
@@ -18,6 +18,20 @@
   <li class="breadcrumb-item active">{% trans 'Advertisers' %}</li>
 {% endblock breadcrumbs %}
 
+{% block additional_filters %}
+{{ block.super }}
+
+<div class="col-lg-2 col-md-4 mb-3">
+  <label class="col-form-label" for="id_advertiser">{% trans 'Top Advertisers' %}</label>
+  <select class="form-control" name="report_advertiser" id="id_advertiser">
+    <option value="">All advertisers</option>
+    {% for slug, name in advertiser_list %}
+      <option value="{{ slug }}"{% if report_advertiser == slug %} selected{% endif %}>{{ name }}</option>
+    {% endfor %}
+  </select>
+</div>
+
+{% endblock additional_filters %}
 
 {% block explainer %}
 <section class="mb-5">

--- a/adserver/templates/adserver/reports/publisher_advertiser.html
+++ b/adserver/templates/adserver/reports/publisher_advertiser.html
@@ -1,0 +1,35 @@
+{% extends "adserver/reports/publisher.html" %}
+{% load humanize %}
+{% load i18n %}
+
+
+{% block title %}{% trans 'Advertiser Report' %} - {{ publisher }}{% endblock %}
+
+
+{% block heading %}
+{% blocktrans %}Advertiser Report for {{ publisher }}{% endblocktrans %}
+{% if report_advertiser %}
+{% blocktrans %}filtered by {{ report_advertiser }}{% endblocktrans %}
+{% endif %}
+{% endblock heading %}
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item active">{% trans 'Advertisers' %}</li>
+{% endblock breadcrumbs %}
+
+
+{% block explainer %}
+<section class="mb-5">
+  <h3>About this report</h3>
+  <p>
+    This report shows the top advertisers across your network.
+  </p>
+  <em>
+  This report shows the <strong>top {{ limit }} advertisers</strong> and updates periodically. All previous days data is complete.
+  </em>
+</section>
+{% endblock explainer %}
+
+
+{% block report %}{% endblock report %}

--- a/adserver/templates/adserver/reports/publisher_advertiser.html
+++ b/adserver/templates/adserver/reports/publisher_advertiser.html
@@ -8,8 +8,8 @@
 
 {% block heading %}
 {% blocktrans %}Advertiser Report for {{ publisher }}{% endblocktrans %}
-{% if report_advertiser %}
-{% blocktrans %}filtered by {{ report_advertiser }}{% endblocktrans %}
+{% if advertiser_name %}
+{% blocktrans %}filtered by {{ advertiser_name }}{% endblocktrans %}
 {% endif %}
 {% endblock heading %}
 
@@ -23,7 +23,7 @@
 <section class="mb-5">
   <h3>About this report</h3>
   <p>
-    This report shows the top advertisers on your site.
+    This report shows the top advertisers across your network.
   </p>
   <em>
   This report shows the <strong>top {{ limit }} advertisers</strong> and updates periodically. All previous days data is complete.

--- a/adserver/templates/adserver/reports/publisher_advertiser.html
+++ b/adserver/templates/adserver/reports/publisher_advertiser.html
@@ -23,7 +23,7 @@
 <section class="mb-5">
   <h3>About this report</h3>
   <p>
-    This report shows the top advertisers across your network.
+    This report shows the top advertisers on your site.
   </p>
   <em>
   This report shows the <strong>top {{ limit }} advertisers</strong> and updates periodically. All previous days data is complete.

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -468,3 +468,22 @@ class TestReportViews(TestCase):
         # Invalid country
         response = self.client.get(url, {"country": "foobar"})
         self.assertContains(response, '<td class="text-right"><strong>0</strong></td>')
+
+    def test_publisher_advertiser_report_contents(self):
+        self.client.force_login(self.staff_user)
+        url = reverse("publisher_advertiser_report", args=[self.publisher1.slug])
+
+        # All reports
+        response = self.client.get(url)
+        self.assertContains(response, '<td class="text-right"><strong>4</strong></td>')
+        self.assertContains(response, self.advertiser1.name)
+        self.assertNotContains(response, self.advertiser2.name)
+
+        # Filter reports
+        response = self.client.get(url, {"report_advertiser": self.advertiser1.slug})
+        self.assertContains(response, '<td class="text-right"><strong>4</strong></td>')
+        # Date breakdown, not advertiser breakdown
+        self.assertNotContains(response, f"<td>{self.advertiser1.name}</td>")
+
+        response = self.client.get(url, {"report_advertiser": self.advertiser2.slug})
+        self.assertContains(response, '<td class="text-right"><strong>0</strong></td>')

--- a/adserver/urls.py
+++ b/adserver/urls.py
@@ -22,6 +22,7 @@ from .views import do_not_track_policy
 from .views import FlightDetailView
 from .views import FlightListView
 from .views import publisher_stripe_oauth_return
+from .views import PublisherAdvertiserReportView
 from .views import PublisherEmbedView
 from .views import PublisherGeoReportView
 from .views import PublisherMainView
@@ -140,6 +141,11 @@ urlpatterns = [
         r"publisher/<slug:publisher_slug>/report/geos/",
         PublisherGeoReportView.as_view(),
         name="publisher_geo_report",
+    ),
+    path(
+        r"publisher/<slug:publisher_slug>/report/advertisers/",
+        PublisherAdvertiserReportView.as_view(),
+        name="publisher_advertiser_report",
     ),
     path(
         r"publisher/<slug:publisher_slug>/embed/",


### PR DESCRIPTION
This allows publishers to understand who is running ads on their site,
and the relative performance between them.

This is currently in beta and the menu is only shown to staff.