### PR TITLE
Ship Geo & Advertiser reports to publishers

### DIFF
--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -99,23 +99,19 @@
               </li>
               {% endif %}
 
-              {% if request.user.is_staff %}
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'publisher_geo_report' publisher.slug %}">
                   <span class="fa fa-globe fa-fw ml-4 text-muted" aria-hidden="true"></span>
                   <span>{% trans 'Geos' %}</span>
                 </a>
               </li>
-              {% endif %}
 
-              {% if request.user.is_staff %}
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'publisher_advertiser_report' publisher.slug %}">
                   <span class="fa fa-building fa-fw ml-4 text-muted" aria-hidden="true"></span>
                   <span>{% trans 'Advertisers' %}</span>
                 </a>
               </li>
-              {% endif %}
 
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'publisher_payouts' publisher.slug %}">


### PR DESCRIPTION
This just adds them to the template,
removing the `is_staff` check.