### PR TITLE
Split Circle tests into two

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - image: 'cimg/python:3.6'
     steps:
       - checkout
-      - run: pip install --user requirements/testing.txt
+      - run: pip install --user -r requirements/testing.txt
       - run: tox -e py3
 
   checks:
@@ -20,7 +20,7 @@ jobs:
           NODE_VERSION: 10.17.0
     steps:
       - checkout
-      - run: pip install --user requirements/testing.txt
+      - run: pip install --user -r requirements/testing.txt
       - run: tox -e migrations
       - run: tox -e lint
       - run: tox -e docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - checkout
       - run: pip install --user -r requirements/testing.txt
       - run: tox -e py3
+      - run: tox -e coverage
 
   checks:
     docker:
@@ -22,7 +23,6 @@ jobs:
       - run: tox -e migrations
       - run: tox -e lint
       - run: tox -e docs
-      - run: tox -e coverage
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ jobs:
   checks:
     docker:
       - image: 'cimg/python:3.6'
-        environment:
-          NODE_VERSION: 10.17.0
     steps:
       - checkout
       - run: pip install --user -r requirements/testing.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
       - run: tox -e migrations
       - run: tox -e lint
       - run: tox -e docs
+      - run: tox -e coverage
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,26 +2,33 @@
 #
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
-version: 2
+version: 2.1
+
 jobs:
-  build:
+  tests:
     docker:
-      - image: circleci/python:3.6
-
-    working_directory: ~/repo
-
+      - image: 'cimg/python:3.6'
     steps:
       - checkout
+      - run: pip install --user requirements/testing.txt
+      - run: tox -e py3
 
-      - run:
-          name: Install test dependencies
-          command: |
-            python3 -m venv .venv
-            . .venv/bin/activate
-            pip install -r requirements/testing.txt
+  checks:
+    docker:
+      - image: 'cimg/python:3.6'
+        environment:
+          NODE_VERSION: 10.17.0
+    steps:
+      - checkout
+      - run: pip install --user requirements/testing.txt
+      - run: tox -e migrations
+      - run: tox -e lint
+      - run: tox -e docs
+      - run: tox -e eslint
 
-      - run:
-          name: Run tests
-          command: |
-            . .venv/bin/activate
-            tox
+workflows:
+  version: 2
+  test:
+    jobs:
+      - checks
+      - tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
       - run: tox -e migrations
       - run: tox -e lint
       - run: tox -e docs
-      - run: tox -e eslint
 
 workflows:
   version: 2


### PR DESCRIPTION
This makes it more obvious if tests or checks failed.
It also allows us to run them in parallel.