### PR TITLE
Don't overwrite Offer on uplift

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1255,8 +1255,8 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
         self.incr(impression_type=VIEWS, publisher=publisher)
 
         if request.GET.get("uplift"):
-            offer.uplifted = True
-            offer.save()
+            # Don't overwrite Offer object here, since it might have changed prior to our writing
+            Offer.objects.filter(pk=offer.pk).update(uplifted=True)
 
         if settings.ADSERVER_RECORD_VIEWS or publisher.record_views:
             return self._record_base(

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -1099,6 +1099,14 @@ class AdvertisingIntegrationTests(BaseApiTest):
                 viewed=True,
             ).exists()
         )
+        self.assertFalse(
+            Offer.objects.filter(
+                advertisement=self.ad,
+                publisher=self.publisher1,
+                uplifted=True,
+                viewed=False,
+            ).exists()
+        )
 
     def test_nullable_offers(self):
         self.ad.live = False

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -1089,10 +1089,14 @@ class AdvertisingIntegrationTests(BaseApiTest):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp["X-Adserver-Reason"], "Billed view")
 
-        # Confirm uplift is stored in the DB
+        # Confirm uplift is stored in the DB,
+        # and that it doesn't overwrite the ``viewed`` attribute.
         self.assertTrue(
             Offer.objects.filter(
-                advertisement=self.ad, publisher=self.publisher1, uplifted=True
+                advertisement=self.ad,
+                publisher=self.publisher1,
+                uplifted=True,
+                viewed=True,
             ).exists()
         )
 

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -1099,6 +1099,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
                 viewed=True,
             ).exists()
         )
+        # Test for regressions on https://github.com/readthedocs/ethical-ad-server/pull/290
         self.assertFalse(
             Offer.objects.filter(
                 advertisement=self.ad,


### PR DESCRIPTION
This was causing offer.viewed to be overwritten,
because we're using a specific Offer object instead of re-querying it.