### PR TITLE
Fix a few issues with refunding

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1367,40 +1367,6 @@ class AdBase(TimeStampedModel, IndestructibleModel):
     def get_absolute_url(self):
         return self.url
 
-    @transaction.atomic
-    def refund(self):
-        """Refund this view or click."""
-        if self.is_refunded:
-            # Prevent double refunding
-            return False
-
-        # Update the denormalized aggregate impression object
-        impression = self.advertisement.impressions.get(
-            publisher=self.publisher, date=self.date.date()
-        )
-        AdImpression.objects.filter(pk=impression.pk).update(
-            **{self.impression_type: models.F(self.impression_type) - 1}
-        )
-
-        # Update the denormalized impressions on the Flight
-        if self.impression_type == VIEWS or (
-            self.impression_type == OFFERS and self.viewed
-        ):
-            Flight.objects.filter(pk=self.advertisement.flight_id).update(
-                total_views=models.F("total_views") - 1
-            )
-        elif self.impression_type == CLICKS or (
-            self.impression_type == OFFERS and self.clicked
-        ):
-            Flight.objects.filter(pk=self.advertisement.flight_id).update(
-                total_clicks=models.F("total_clicks") - 1
-            )
-
-        self.is_refunded = True
-        self.save()
-
-        return True
-
 
 class Click(AdBase):
 
@@ -1448,6 +1414,48 @@ class Offer(AdBase):
     uplifted = models.BooleanField(
         _("Attribute Offer to uplift"), default=None, null=True
     )
+
+    @transaction.atomic
+    def refund(self):
+        """
+        Refund this offer and any clicks/views derived from it.
+
+        This does not modify any denormalized index records (eg. GeoImpression, PlacementImpression)
+        except for AdImpression itself.
+        """
+        if self.is_refunded:
+            # Prevent double refunding
+            return False
+
+        # Update the denormalized aggregate impression object
+        impression = self.advertisement.impressions.get(
+            publisher=self.publisher, date=self.date.date()
+        )
+        AdImpression.objects.filter(pk=impression.pk).update(
+            **{self.impression_type: models.F(self.impression_type) - 1}
+        )
+
+        # Update the denormalized impressions on the Flight
+        # And the denormalized aggregate AdImpressions
+        if self.viewed:
+            Flight.objects.filter(pk=self.advertisement.flight_id).update(
+                total_views=models.F("total_views") - 1
+            )
+            AdImpression.objects.filter(pk=impression.pk).update(
+                **{VIEWS: models.F(VIEWS) - 1}
+            )
+        if self.clicked:
+            Flight.objects.filter(pk=self.advertisement.flight_id).update(
+                total_clicks=models.F("total_clicks") - 1
+            )
+            AdImpression.objects.filter(pk=impression.pk).update(
+                **{CLICKS: models.F(CLICKS) - 1}
+            )
+
+        self.is_refunded = True
+        self.save()
+
+        return True
 
     class Meta:
         # This is needed because we can't sort on pk to get the created ordering

--- a/adserver/tests/test_models.py
+++ b/adserver/tests/test_models.py
@@ -333,81 +333,57 @@ class TestAdModels(BaseAdModelsTestCase):
 
         self.assertAlmostEqual(self.flight.projected_total_value(), 5.0)
 
-    def test_view_refund(self):
+    def test_refund(self):
         request = self.factory.get("/")
 
         request.ip_address = "127.0.0.1"
         request.user_agent = "test user agent"
 
-        self.flight.cpm = 50.0
-        self.flight.cpc = 0
-        self.flight.sold_clicks = 0
-        self.flight.sold_impressions = 100
-        self.flight.save()
-
-        offer = get(Offer, publisher=self.publisher)
-
-        # Each view is $0.05
-        view1 = self.ad1.track_view(request, self.publisher, offer=offer)
-        view2 = self.ad1.track_view(request, self.publisher, offer=offer)
-        view3 = self.ad1.track_view(request, self.publisher, offer=offer)
-
-        for view in (view1, view2, view3):
-            self.assertIsNotNone(view)
-
-        self.flight.refresh_from_db()
-
-        self.assertEqual(self.flight.total_views, 3)
-
-        impression = self.ad1.impressions.get(
-            publisher=self.publisher, date=view1.date.date()
+        output = self.ad1.offer_ad(
+            request=request,
+            publisher=self.publisher,
+            ad_type_slug=self.text_ad_type,
+            div_id="foo",
+            keywords=None,
         )
-        self.assertEqual(impression.views, 3)
-
-        report = AdvertiserReport(
-            AdImpression.objects.filter(advertisement__flight=self.flight)
+        offer1 = Offer.objects.get(pk=output["nonce"])
+        output = self.ad1.offer_ad(
+            request=request,
+            publisher=self.publisher,
+            ad_type_slug=self.text_ad_type,
+            div_id="foo",
+            keywords=None,
         )
-        report.generate()
-        self.assertAlmostEqual(report.total["views"], 3)
-        self.assertAlmostEqual(report.total["cost"], 0.15)
-
-        # Refund 2 of the 3 views
-        self.assertTrue(view1.refund())
-        self.assertTrue(view2.refund())
-
-        # Ensure you can't double refund
-        self.assertFalse(view1.refund())
-
-        self.assertTrue(view1.is_refunded)
-        self.assertTrue(view2.is_refunded)
-        self.assertFalse(view3.is_refunded)
-
-        # Reload data from the DB
-        self.flight.refresh_from_db()
-        impression.refresh_from_db()
-
-        self.assertEqual(self.flight.total_views, 1)
-        self.assertEqual(impression.views, 1)
-
-        report = AdvertiserReport(
-            AdImpression.objects.filter(advertisement__flight=self.flight)
+        offer2 = Offer.objects.get(pk=output["nonce"])
+        output = self.ad1.offer_ad(
+            request=request,
+            publisher=self.publisher,
+            ad_type_slug=self.text_ad_type,
+            div_id="foo",
+            keywords=None,
         )
-        report.generate()
-        self.assertAlmostEqual(report.total["views"], 1)
-        self.assertAlmostEqual(report.total["cost"], 0.05)
+        offer3 = Offer.objects.get(pk=output["nonce"])
 
-    def test_click_refund(self):
-        request = self.factory.get("/")
-
-        request.ip_address = "127.0.0.1"
-        request.user_agent = "test user agent"
-
-        offer = get(Offer, publisher=self.publisher)
+        view1 = self.ad1.track_view(request, self.publisher, offer=offer1)
+        view2 = self.ad1.track_view(request, self.publisher, offer=offer2)
+        view3 = self.ad1.track_view(request, self.publisher, offer=offer3)
+        self.ad1.invalidate_nonce(VIEWS, offer1.pk)
+        self.ad1.invalidate_nonce(VIEWS, offer2.pk)
+        self.ad1.invalidate_nonce(VIEWS, offer3.pk)
 
         # Each click is $2.00 (cpc)
-        click1 = self.ad1.track_click(request, self.publisher, offer=offer)
-        click2 = self.ad1.track_click(request, self.publisher, offer=offer)
-        click3 = self.ad1.track_click(request, self.publisher, offer=offer)
+        click1 = self.ad1.track_click(request, self.publisher, offer=offer1)
+        click2 = self.ad1.track_click(request, self.publisher, offer=offer2)
+        click3 = self.ad1.track_click(request, self.publisher, offer=offer3)
+        self.ad1.invalidate_nonce(CLICKS, offer1.pk)
+        self.ad1.invalidate_nonce(CLICKS, offer2.pk)
+        self.ad1.invalidate_nonce(CLICKS, offer3.pk)
+
+        for offer in (offer1, offer2, offer3):
+            offer.refresh_from_db()
+            self.assertTrue(offer.viewed)
+            self.assertTrue(offer.clicked)
+            self.assertFalse(offer.is_refunded)
 
         for click in (click1, click2, click3):
             self.assertIsNotNone(click)
@@ -428,16 +404,21 @@ class TestAdModels(BaseAdModelsTestCase):
         self.assertAlmostEqual(report.total["clicks"], 3)
         self.assertAlmostEqual(report.total["cost"], 6.0)
 
-        # Refund 2 of the 3 clicks
-        self.assertTrue(click1.refund())
-        self.assertTrue(click2.refund())
+        # Refund 2 of the 3 offers (including the clicks/views)
+        self.assertTrue(offer1.refund())
+        self.assertTrue(offer2.refund())
 
         # Ensure you can't double refund
-        self.assertFalse(click1.refund())
+        self.assertFalse(offer1.refund())
 
-        self.assertTrue(click1.is_refunded)
-        self.assertTrue(click2.is_refunded)
-        self.assertFalse(click3.is_refunded)
+        self.assertTrue(offer1.is_refunded)
+        self.assertTrue(offer2.is_refunded)
+        self.assertFalse(offer3.is_refunded)
+
+        # Ensure the refunded offers still count as clicked/viewed (although those are refunded as well)
+        for offer in (offer1, offer2):
+            self.assertTrue(offer.viewed)
+            self.assertTrue(offer.clicked)
 
         # Reload data from the DB
         self.flight.refresh_from_db()
@@ -445,10 +426,13 @@ class TestAdModels(BaseAdModelsTestCase):
 
         self.assertEqual(self.flight.total_clicks, 1)
         self.assertEqual(impression.clicks, 1)
+        self.assertEqual(self.flight.total_views, 1)
+        self.assertEqual(impression.views, 1)
 
         report = AdvertiserReport(
             AdImpression.objects.filter(advertisement__flight=self.flight)
         )
         report.generate()
+        self.assertAlmostEqual(report.total["views"], 1)
         self.assertAlmostEqual(report.total["clicks"], 1)
         self.assertAlmostEqual(report.total["cost"], 2.0)


### PR DESCRIPTION
- Refunding now *only* works on the Offer model
- Related clicks/views are also refunded

## Notes
- I'd consider moving `invalidate_nonce` to be called from `track_view` and `track_click`. I don't see any reason why those methods shouldn't call it. If agreed, I'll do that in a separate PR.
- Currently refunding doesn't update the relevant index tables (eg. GeoImpression). I noted that in the comments but perhaps another solution would be to make the admin action grab the unique dates and queue up re-indexing on those dates. Thoughts?
- Unfortunately, there isn't something tying an `Offer` object to a `View` or `Click` object. Those don't get "refunded" as part of this but I guess that's OK since we don't really use them for anything. We might want to clean that up at some point.