### PR TITLE
Add a null offer constraint

### DIFF
--- a/adserver/migrations/0048_null_offer_unique_constraint.py
+++ b/adserver/migrations/0048_null_offer_unique_constraint.py
@@ -1,0 +1,34 @@
+"""
+Fixes a possible race condition where two entries for the same date/publisher with advertisement=null can occur.
+
+This migration will fail if there are records that won't satisfy the constraint in the DB.
+Here's a query to find all such records:
+
+    SELECT ai1.id, ai2.id, ai1.date, ai1.publisher_id, ai1.advertisement_id
+    FROM adserver_adimpression ai1
+    INNER JOIN adserver_adimpression ai2
+    ON (
+        ai1.publisher_id = ai2.publisher_id
+        AND ai1.date = ai2.date
+        AND ai1.id < ai2.id
+        AND ai1.advertisement_id IS NULL
+        AND ai2.advertisement_id IS NULL
+    )
+    ORDER BY ai2.id;
+"""
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('adserver', '0047_breakout_ad_parts'),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name='adimpression',
+            constraint=models.UniqueConstraint(condition=models.Q(advertisement=None), fields=('publisher', 'date'), name='null_offer_unique'),
+        ),
+    ]

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -13,6 +13,7 @@ from django.core.validators import MinValueValidator
 from django.db import IntegrityError
 from django.db import models
 from django.db import transaction
+from django.db.models.constraints import UniqueConstraint
 from django.template import engines
 from django.template.loader import get_template
 from django.urls import reverse
@@ -1227,6 +1228,14 @@ class AdImpression(BaseImpression):
     )
 
     class Meta:
+        # We must also constrain when the `advertisement` is null
+        constraints = (
+            UniqueConstraint(
+                fields=("publisher", "date"),
+                condition=models.Q(advertisement=None),
+                name="null_offer_unique",
+            ),
+        )
         ordering = ("-date",)
         unique_together = ("publisher", "advertisement", "date")
         verbose_name_plural = _("Ad impressions")


### PR DESCRIPTION
This fixes an occasional race condition we see where two null offers for the same date/publisher. This can occur when two requests come in within a few milliseconds of each other immediately after midnight UTC. There are 23 offending records in our DB. This migration will probably lock the table although the migration shouldn't be too bad since this table only has ~300k rows in production.