### PR TITLE
Run previous days reports automatically

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -251,7 +251,7 @@ def daily_update_uplift(day=None):
 
 
 @app.task()
-def daily_update_all_reports(day=None):
+def update_previous_day_reports(day=None):
     """
     Complete all report data for the previous day.
 

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -248,3 +248,23 @@ def daily_update_uplift(day=None):
             UpliftImpression.objects.filter(pk=impression.pk).update(
                 **{impression_type: values["total"]}
             )
+
+
+@app.task()
+def daily_update_all_reports(day=None):
+    """
+    Complete all report data for the previous day.
+
+    :arg day: An optional datetime object representing a day.
+    """
+    start_date, _ = _get_day(day)
+
+    # Do the previous day now that the day is complete
+    start_date -= datetime.timedelta(days=1)
+
+    # Do all reports
+    daily_update_geos(start_date)
+    daily_update_placements(start_date)
+    daily_update_impressions(start_date)
+    daily_update_keywords(start_date)
+    daily_update_uplift(start_date)

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -23,12 +23,12 @@ from ..models import Publisher
 from ..reports import AdvertiserReport
 from ..reports import PublisherGeoReport
 from ..reports import PublisherReport
-from ..tasks import daily_update_all_reports
 from ..tasks import daily_update_geos
 from ..tasks import daily_update_impressions
 from ..tasks import daily_update_keywords
 from ..tasks import daily_update_placements
 from ..tasks import daily_update_uplift
+from ..tasks import update_previous_day_reports
 from ..utils import calculate_ecpm
 from ..utils import get_ad_day
 
@@ -921,7 +921,7 @@ class TestReportTasks(TestReportsBase):
         ) as patched_placements, patch(
             "adserver.tasks.daily_update_uplift"
         ) as patched_uplift:
-            daily_update_all_reports()
+            update_previous_day_reports()
 
             yesterday = get_ad_day() - datetime.timedelta(days=1)
             patched_geos.assert_called_with(yesterday)

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -22,12 +23,14 @@ from ..models import Publisher
 from ..reports import AdvertiserReport
 from ..reports import PublisherGeoReport
 from ..reports import PublisherReport
+from ..tasks import daily_update_all_reports
 from ..tasks import daily_update_geos
 from ..tasks import daily_update_impressions
 from ..tasks import daily_update_keywords
 from ..tasks import daily_update_placements
 from ..tasks import daily_update_uplift
 from ..utils import calculate_ecpm
+from ..utils import get_ad_day
 
 
 class TestReportsBase(TestCase):
@@ -907,3 +910,23 @@ class TestReportClasses(TestReportsBase):
         self.assertAlmostEqual(report.total["cost"], 2.0)
         self.assertAlmostEqual(report.total["ctr"], 100 * 1 / 4)
         self.assertAlmostEqual(report.total["ecpm"], calculate_ecpm(2.0, 4))
+
+
+class TestReportTasks(TestReportsBase):
+    def test_index_all_reports(self):
+        with patch("adserver.tasks.daily_update_geos") as patched_geos, patch(
+            "adserver.tasks.daily_update_keywords"
+        ) as patched_keywords, patch(
+            "adserver.tasks.daily_update_placements"
+        ) as patched_placements, patch(
+            "adserver.tasks.daily_update_uplift"
+        ) as patched_uplift:
+            daily_update_all_reports()
+
+            yesterday = get_ad_day() - datetime.timedelta(days=1)
+            patched_geos.assert_called_with(yesterday)
+
+            self.assertTrue(patched_geos.called)
+            self.assertTrue(patched_keywords.called)
+            self.assertTrue(patched_placements.called)
+            self.assertTrue(patched_uplift.called)

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -124,7 +124,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     # Run the previous days reports
     "every-day-generate-indexes-all-reports": {
-        "task": "adserver.tasks.daily_update_all_reports",
+        "task": "adserver.tasks.update_previous_day_reports",
         "schedule": crontab(hour="2", minute="0"),
     },
 }

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -122,10 +122,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "adserver.tasks.daily_update_placements",
         "schedule": crontab(minute="45"),
     },
-    # TODO: Make this run nightly on the previous days data
-    "every-hour-generate-keyword-index": {
-        "task": "adserver.tasks.daily_update_keywords",
-        "schedule": crontab(hour="23", minute="58"),
+    # Run the previous days reports
+    "every-day-generate-indexes-all-reports": {
+        "task": "adserver.tasks.daily_update_all_reports",
+        "schedule": crontab(hour="2", minute="0"),
     },
 }
 


### PR DESCRIPTION
Add a scheduled task to run all of the reports for the previous day.
This needs to be run after the day is complete or it might miss some data.