### PR TITLE
Fix off by 1 (actually 2) error in ad text size

### DIFF
--- a/adserver/forms.py
+++ b/adserver/forms.py
@@ -99,9 +99,9 @@ class AdvertisementFormMixin:
         text = cleaned_data.get("text")
 
         # New ads
-        headline = cleaned_data.get("headline", "")
+        headline = cleaned_data.get("headline") or ""
         content = cleaned_data.get("content")
-        cta = cleaned_data.get("cta", "")
+        cta = cleaned_data.get("cta") or ""
 
         if not ad_types:
             self.add_error(
@@ -166,7 +166,7 @@ class AdvertisementFormMixin:
                 if text:
                     stripped_text = bleach.clean(text, tags=[], strip=True)
                 else:
-                    stripped_text = f"{headline} {content} {cta}"
+                    stripped_text = f"{headline}{content}{cta}"
 
                 if len(stripped_text) > ad_type.max_text_length:
                     self.add_error(

--- a/adserver/tests/test_forms.py
+++ b/adserver/tests/test_forms.py
@@ -119,20 +119,30 @@ class FormTests(TestCase):
         )
         self.assertTrue(form.is_valid(), form.errors)
 
-        # Shorten the maximum allowed text to test text too long
-        self.ad_type.max_text_length = 10
-        self.ad_type.save()
+        data = self.ad_data.copy()
+        data["headline"] = ""
+        data["content"] = (
+            "This is precisely 100 characters if you count the number exactly. "
+            "I know it's true because I counted"
+        )
+        data["cta"] = ""
+
+        form = AdvertisementForm(
+            data=data, files={}, instance=self.ad, flight=self.flight
+        )
+        self.assertTrue(form.is_valid(), form.errors)
 
         # Invalid - text too long
+        data["headline"] = "1"
         form = AdvertisementForm(
-            data=self.ad_data, instance=self.ad, flight=self.flight
+            data=data, files={}, instance=self.ad, flight=self.flight
         )
         self.assertFalse(form.is_valid(), form.errors)
 
-        expected_text = "{} {} {}".format(
-            self.ad_data["headline"],
-            self.ad_data["content"],
-            self.ad_data["cta"],
+        expected_text = "{}{}{}".format(
+            data["headline"],
+            data["content"],
+            data["cta"],
         )
         self.assertEquals(
             form.errors["content"],
@@ -182,7 +192,7 @@ class FormTests(TestCase):
             ],
         )
 
-        expected_text = "{} {} {}".format(
+        expected_text = "{}{}{}".format(
             self.ad_data["headline"],
             self.ad_data["content"],
             self.ad_data["cta"],


### PR DESCRIPTION
I got a report of this from an advertiser. Basically if they leave the headline or CTA blank it can cause the total text length to be off slightly.