### PR TITLE
Publisher report cleanup

### DIFF
--- a/adserver/reports.py
+++ b/adserver/reports.py
@@ -281,9 +281,7 @@ class PublisherReport(BaseReport):
         )
 
     def get_index_display(self, index):
-        """
-        Handle making sure dates use the same 3 letter syntax as Django
-        """
+        """Handle making sure dates use the same 3 letter syntax as Django."""
         if isinstance(index, datetime.date):
             return index.strftime("%b %d, %Y")
 

--- a/adserver/reports.py
+++ b/adserver/reports.py
@@ -1,5 +1,6 @@
 """Advertising performance reports displayed to advertisers, publishers, and staff."""
 import collections
+import datetime
 import logging
 import operator
 
@@ -278,6 +279,15 @@ class PublisherReport(BaseReport):
         self.total["view_rate"] = calculate_ctr(
             self.total["views"], self.total["offers"]
         )
+
+    def get_index_display(self, index):
+        """
+        Handle making sure dates use the same 3 letter syntax as Django
+        """
+        if isinstance(index, datetime.date):
+            return index.strftime("%b %d, %Y")
+
+        return str(index)
 
 
 class PublisherGeoReport(PublisherReport):

--- a/adserver/templates/adserver/reports/all-advertisers.html
+++ b/adserver/templates/adserver/reports/all-advertisers.html
@@ -35,7 +35,7 @@
       <h2>
         {% trans 'Total results for all advertisers' %}
       </h2>
-      <table class="table table-hover">
+      <table class="table table-hover report">
         <thead>
           <tr>
             <th><strong>{% trans 'Time Period' %}</strong></th>

--- a/adserver/templates/adserver/reports/all-publishers.html
+++ b/adserver/templates/adserver/reports/all-publishers.html
@@ -70,7 +70,7 @@
           </aside>
         {% endif %}
       </div>
-      <table class="table table-hover">
+      <table class="table table-hover report">
         <thead>
           <tr>
             <th><strong>{% trans 'Time Period' %}</strong></th>

--- a/adserver/templates/adserver/reports/includes/publisher-report-table.html
+++ b/adserver/templates/adserver/reports/includes/publisher-report-table.html
@@ -4,10 +4,10 @@
 <table class="table table-hover report">
   <thead>
     <tr>
-      <th><strong>{% trans 'Report Index' %}</strong></th>
-      <th class="text-right"><strong>{% trans 'Total&nbsp;Views' %}</strong></th>
-      <th class="text-right"><strong>{% trans 'Total&nbsp;Clicks' %}</strong></th>
-      <th class="text-right"><strong>{% blocktrans %}Total&nbsp;<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
+      <th><strong>{% trans 'Index' %}</strong></th>
+      <th class="text-right"><strong>{% trans 'Views' %}</strong></th>
+      <th class="text-right"><strong>{% trans 'Clicks' %}</strong></th>
+      <th class="text-right"><strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
       <th class="text-right"><strong>{% trans 'Revenue' %}</strong></th>
       {% if request.user.is_staff %}
         <th class="text-right"><!-- Staff split --></th>

--- a/adserver/templates/adserver/reports/includes/publisher-report-table.html
+++ b/adserver/templates/adserver/reports/includes/publisher-report-table.html
@@ -14,8 +14,8 @@
         <th class="text-right"><strong>{% trans 'Our&nbsp;Rev' %}</strong></th>
         <th class="text-right"><strong>{% trans 'Total&nbsp;Rev' %}</strong></th>
         <th class="text-right"><strong>{% blocktrans %}<abbr title="Effective cost per thousand impressions">eCPM</abbr>{% endblocktrans %}</strong></th>
-        <th class="text-right"><strong>{% trans 'Fill Rate' %}</strong></th>
-        <th class="text-right"><strong>{% trans 'View Rate' %}</strong></th>
+        <th class="text-right"><strong>{% blocktrans %}<abbr title="% of traffic with a paid ad">Fill Rate</abbr>{% endblocktrans %}</strong></th>
+        <th class="text-right"><strong>{% blocktrans %}<abbr title="% of traffic that views ads we offered">View Rate</abbr>{% endblocktrans %}</strong></th>
       {% endif %}
     </tr>
   </thead>

--- a/adserver/templates/adserver/reports/includes/publisher-report-table.html
+++ b/adserver/templates/adserver/reports/includes/publisher-report-table.html
@@ -8,15 +8,14 @@
       <th class="text-right"><strong>{% trans 'Total&nbsp;Views' %}</strong></th>
       <th class="text-right"><strong>{% trans 'Total&nbsp;Clicks' %}</strong></th>
       <th class="text-right"><strong>{% blocktrans %}Total&nbsp;<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
+      <th class="text-right"><strong>{% trans 'Revenue' %}</strong></th>
       {% if request.user.is_staff %}
+        <th class="text-right"><!-- Staff split --></th>
+        <th class="text-right"><strong>{% trans 'Our&nbsp;Rev' %}</strong></th>
+        <th class="text-right"><strong>{% trans 'Total&nbsp;Rev' %}</strong></th>
         <th class="text-right"><strong>{% blocktrans %}<abbr title="Effective cost per thousand impressions">eCPM</abbr>{% endblocktrans %}</strong></th>
         <th class="text-right"><strong>{% trans 'Fill Rate' %}</strong></th>
         <th class="text-right"><strong>{% trans 'View Rate' %}</strong></th>
-      {% endif %}
-      <th class="text-right"><strong>{% trans 'Total&nbsp;Revenue' %}</strong></th>
-      <th class="text-right"><strong>{% trans 'Your&nbsp;Revenue&nbsp;Share' %}</strong></th>
-      {% if request.user.is_staff %}
-        <th class="text-right"><strong>{% trans 'Our&nbsp;Revenue&nbsp;Share' %}</strong></th>
       {% endif %}
     </tr>
   </thead>
@@ -28,15 +27,14 @@
         <td class="text-right">{{ result.views|intcomma }}</td>
         <td class="text-right">{{ result.clicks|intcomma }}</td>
         <td class="text-right">{{ result.ctr|floatformat:3 }}%</td>
+        <td class="text-right">${{ result.revenue_share|floatformat:2|intcomma }}</td>
         {% if request.user.is_staff %}
+          <td class="text-right">|</td>
+          <td class="text-right">${{ result.our_revenue|floatformat:2|intcomma }}</td>
+          <td class="text-right">${{ result.revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.ecpm|floatformat:2 }}</td>
           <td class="text-right">{{ result.fill_rate|floatformat:1 }}%</td>
           <td class="text-right">{{ result.view_rate|floatformat:1 }}%</td>
-        {% endif %}
-        <td class="text-right">${{ result.revenue|floatformat:2|intcomma }}</td>
-        <td class="text-right">${{ result.revenue_share|floatformat:2|intcomma }}</td>
-        {% if request.user.is_staff %}
-          <td class="text-right">${{ result.our_revenue|floatformat:2|intcomma }}</td>
         {% endif %}
       </tr>
       {% endif %}
@@ -46,15 +44,14 @@
       <td class="text-right"><strong>{{ report.total.views|intcomma }}</strong></td>
       <td class="text-right"><strong>{{ report.total.clicks|intcomma }}</strong></td>
       <td class="text-right"><strong>{{ report.total.ctr|floatformat:3 }}%</strong></td>
+      <td class="text-right"><strong>${{ report.total.revenue_share|floatformat:2|intcomma }}</strong></td>
       {% if request.user.is_staff %}
+        <td class="text-right">|</td>
+        <td class="text-right"><strong>${{ report.total.our_revenue|floatformat:2|intcomma }}</strong></td>
+        <td class="text-right"><strong>${{ report.total.revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.ecpm|floatformat:2 }}</strong></td>
         <td class="text-right"><strong>{{ report.total.fill_rate|floatformat:1 }}%</strong></td>
         <td class="text-right"><strong>{{ report.total.view_rate|floatformat:1 }}%</strong></td>
-      {% endif %}
-      <td class="text-right"><strong>${{ report.total.revenue|floatformat:2|intcomma }}</strong></td>
-      <td class="text-right"><strong>${{ report.total.revenue_share|floatformat:2|intcomma }}</strong></td>
-      {% if request.user.is_staff %}
-        <td class="text-right"><strong>${{ report.total.our_revenue|floatformat:2|intcomma }}</strong></td>
       {% endif %}
     </tr>
   </tbody>

--- a/adserver/templates/adserver/reports/includes/publisher-report-table.html
+++ b/adserver/templates/adserver/reports/includes/publisher-report-table.html
@@ -10,12 +10,11 @@
       <th class="text-right"><strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
       <th class="text-right"><strong>{% trans 'Revenue' %}</strong></th>
       {% if request.user.is_staff %}
-        <th class="text-right"><!-- Staff split --></th>
-        <th class="text-right"><strong>{% trans 'Our&nbsp;Rev' %}</strong></th>
-        <th class="text-right"><strong>{% trans 'Total&nbsp;Rev' %}</strong></th>
-        <th class="text-right"><strong>{% blocktrans %}<abbr title="Effective cost per thousand impressions">eCPM</abbr>{% endblocktrans %}</strong></th>
-        <th class="text-right"><strong>{% blocktrans %}<abbr title="% of traffic with a paid ad">Fill Rate</abbr>{% endblocktrans %}</strong></th>
-        <th class="text-right"><strong>{% blocktrans %}<abbr title="% of traffic that views ads we offered">View Rate</abbr>{% endblocktrans %}</strong></th>
+        <th class="text-right staff-only"><strong>{% trans 'Our&nbsp;Rev' %}</strong></th>
+        <th class="text-right staff-only"><strong>{% trans 'Total&nbsp;Rev' %}</strong></th>
+        <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="Effective cost per thousand impressions">eCPM</abbr>{% endblocktrans %}</strong></th>
+        <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="% of traffic with a paid ad">Fill Rate</abbr>{% endblocktrans %}</strong></th>
+        <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="% of traffic that views ads we offered">View Rate</abbr>{% endblocktrans %}</strong></th>
       {% endif %}
     </tr>
   </thead>
@@ -29,7 +28,6 @@
         <td class="text-right">{{ result.ctr|floatformat:3 }}%</td>
         <td class="text-right">${{ result.revenue_share|floatformat:2|intcomma }}</td>
         {% if request.user.is_staff %}
-          <td class="text-right">|</td>
           <td class="text-right">${{ result.our_revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.ecpm|floatformat:2 }}</td>
@@ -46,7 +44,6 @@
       <td class="text-right"><strong>{{ report.total.ctr|floatformat:3 }}%</strong></td>
       <td class="text-right"><strong>${{ report.total.revenue_share|floatformat:2|intcomma }}</strong></td>
       {% if request.user.is_staff %}
-        <td class="text-right">|</td>
         <td class="text-right"><strong>${{ report.total.our_revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.ecpm|floatformat:2 }}</strong></td>

--- a/assets/src/scss/_theme.scss
+++ b/assets/src/scss/_theme.scss
@@ -17,9 +17,15 @@ body {
     border: 1px solid $border-color;
   }
 
-  td {
-    font-family: $font-family-monospace;
+  .report {
+    td, th {
+      font-family: $font-family-monospace;
+    }
+    .staff-only {
+      color: $info;
+    }
   }
+
 
   /* Preview an advertisement - most of this custom CSS comes from Read the Docs' existing ad settings */
   .advertisement-preview {

--- a/assets/src/scss/_theme.scss
+++ b/assets/src/scss/_theme.scss
@@ -17,6 +17,10 @@ body {
     border: 1px solid $border-color;
   }
 
+  td {
+    font-family: monospace;
+  }
+
   /* Preview an advertisement - most of this custom CSS comes from Read the Docs' existing ad settings */
   .advertisement-preview {
     .ethical-callout {

--- a/assets/src/scss/_theme.scss
+++ b/assets/src/scss/_theme.scss
@@ -18,7 +18,7 @@ body {
   }
 
   td {
-    font-family: monospace;
+    font-family: $font-family-monospace;
   }
 
   /* Preview an advertisement - most of this custom CSS comes from Read the Docs' existing ad settings */


### PR DESCRIPTION
### Changes

* stops showing publishers our revenue
* moves all the "staff" reports to the right and puts a visual separator.
* Tweaks the month display in the reports to always use 3 letter months
* Use a monospace font

### Questions

* Not 100% sure on the best font to use. Could use some feedback there :)
* Should we show the eCPM to publishers?
* Should we show fill rate to publishers? We had a request for this
  - Fill rate is currently not very useful if they have house ads turned on, so probably need to fix that first

### Preview

<img width="937" alt="Screen Shot 2021-03-04 at 5 57 24 PM" src="https://user-images.githubusercontent.com/25510/110056137-1b409500-7d13-11eb-8b38-0c0c848f2e64.png">
