### PR TITLE
Make the Geo report a bit faster

### DIFF
--- a/adserver/mixins.py
+++ b/adserver/mixins.py
@@ -61,6 +61,9 @@ class GeoReportMixin:
         if "country" in kwargs and kwargs["country"]:
             queryset = queryset.filter(country=kwargs["country"])
 
+        if "countries" in kwargs and kwargs["countries"]:
+            queryset = queryset.filter(country__in=kwargs["countries"])
+
         return queryset
 
     def get_country_options(self, queryset):

--- a/adserver/mixins.py
+++ b/adserver/mixins.py
@@ -61,7 +61,8 @@ class GeoReportMixin:
         if "country" in kwargs and kwargs["country"]:
             queryset = queryset.filter(country=kwargs["country"])
 
-        if "countries" in kwargs and kwargs["countries"]:
+        # Only filter this if we didn't pass a specific country
+        elif "countries" in kwargs and kwargs["countries"]:
             queryset = queryset.filter(country__in=kwargs["countries"])
 
         return queryset

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -1038,12 +1038,23 @@ class PublisherGeoReportView(PublisherAccessMixin, GeoReportMixin, BaseReportVie
         publisher_slug = kwargs.get("publisher_slug", "")
         publisher = get_object_or_404(Publisher, slug=publisher_slug)
 
+        country_options = self.get_country_options(
+            self.get_queryset(
+                publisher=publisher,
+                campaign_type=context["campaign_type"],
+                start_date=context["start_date"],
+                end_date=context["end_date"],
+            )
+        )
+
         queryset = self.get_queryset(
             publisher=publisher,
             campaign_type=context["campaign_type"],
             start_date=context["start_date"],
             end_date=context["end_date"],
             country=country,
+            # Don't iterate over countries that aren't in the output
+            countries=set(indx[0] for indx in country_options),
         )
 
         report = PublisherGeoReport(
@@ -1054,15 +1065,6 @@ class PublisherGeoReportView(PublisherAccessMixin, GeoReportMixin, BaseReportVie
             max_results=None if country else self.LIMIT,
         )
         report.generate()
-
-        country_options = self.get_country_options(
-            self.get_queryset(
-                publisher=publisher,
-                campaign_type=context["campaign_type"],
-                start_date=context["start_date"],
-                end_date=context["end_date"],
-            )
-        )
 
         context.update(
             {


### PR DESCRIPTION
Currently we were iterating over every country in the report aggregation,
then tripping out the ones above self.LIMIT.
We're already querying that list for the UI,
so use it to filter the queryset as well.