### PR TITLE
Add basic stats to the dashboard view

### DIFF
--- a/adserver/templates/adserver/dashboard.html
+++ b/adserver/templates/adserver/dashboard.html
@@ -16,6 +16,29 @@
 
   {% if publishers %}
     <h2>{% trans 'Publishers' %}</h2>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-3">
+            <span class="fa fa-eye">
+              {{ total.views }}
+              Views
+            </span>
+          </div>
+          <div class="col-md-3">
+            <span class="fa fa-mouse-pointer">
+            {{ total.clicks }}
+            Clicks
+            </span>
+          </div>
+          <div class="col-md-3">
+            <span class="fa fa-dollar">
+            {{ total.revenue_share }}
+            Revenue
+            </span>
+        </div>
+      </div>
+    </div>
+    <br>
     <ul>
       {% if request.user.is_staff %}
         <li><a href="{% url 'all_publishers_report' %}">{% trans 'All publishers' %}</a></li>

--- a/adserver/urls.py
+++ b/adserver/urls.py
@@ -18,7 +18,7 @@ from .views import AllPublisherReportView
 from .views import ApiTokenCreateView
 from .views import ApiTokenDeleteView
 from .views import ApiTokenListView
-from .views import dashboard
+from .views import DashboardView
 from .views import do_not_track
 from .views import do_not_track_policy
 from .views import FlightDetailView
@@ -39,7 +39,7 @@ from .views import UpliftReportView
 
 
 urlpatterns = [
-    path("", dashboard, name="dashboard-home"),
+    path("", DashboardView.as_view(), name="dashboard-home"),
     # Robots.txt
     path(
         r"robots.txt",


### PR DESCRIPTION
This adds the total publisher data to the view.
I made a basic UI for it,
but probably needs to be cleaned up.

This currently breaks tests, but I wanted to know if we wanted to put these stats at the homepage, or always redirect users to their publisher account in they only have 1, and put them there? Seems best to me to have them always on the homepage, to simplify logic. 