### PR TITLE
Total revenue report improvements

### DIFF
--- a/adserver/templates/adserver/reports/all-advertisers.html
+++ b/adserver/templates/adserver/reports/all-advertisers.html
@@ -35,7 +35,7 @@
       <h2>
         {% trans 'Total results for all advertisers' %}
       </h2>
-      <table class="table table-hover">
+      <table class="table table-hover report">
         <thead>
           <tr>
             <th><strong>{% trans 'Time Period' %}</strong></th>

--- a/adserver/templates/adserver/reports/all-publishers.html
+++ b/adserver/templates/adserver/reports/all-publishers.html
@@ -70,7 +70,7 @@
           </aside>
         {% endif %}
       </div>
-      <table class="table table-hover">
+      <table class="table table-hover report">
         <thead>
           <tr>
             <th><strong>{% trans 'Time Period' %}</strong></th>

--- a/adserver/templates/adserver/reports/includes/publisher-report-table.html
+++ b/adserver/templates/adserver/reports/includes/publisher-report-table.html
@@ -10,12 +10,11 @@
       <th class="text-right"><strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
       <th class="text-right"><strong>{% trans 'Revenue' %}</strong></th>
       {% if request.user.is_staff %}
-        <th class="text-right"><!-- Staff split --></th>
-        <th class="text-right"><strong>{% trans 'Our&nbsp;Rev' %}</strong></th>
-        <th class="text-right"><strong>{% trans 'Total&nbsp;Rev' %}</strong></th>
-        <th class="text-right"><strong>{% blocktrans %}<abbr title="Effective cost per thousand impressions">eCPM</abbr>{% endblocktrans %}</strong></th>
-        <th class="text-right"><strong>{% blocktrans %}<abbr title="% of traffic with a paid ad">Fill Rate</abbr>{% endblocktrans %}</strong></th>
-        <th class="text-right"><strong>{% blocktrans %}<abbr title="% of traffic that views ads we offered">View Rate</abbr>{% endblocktrans %}</strong></th>
+        <th class="text-right staff-only"><strong>{% trans 'Our&nbsp;Rev' %}</strong></th>
+        <th class="text-right staff-only"><strong>{% trans 'Total&nbsp;Rev' %}</strong></th>
+        <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="Effective cost per thousand impressions">eCPM</abbr>{% endblocktrans %}</strong></th>
+        <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="% of traffic with a paid ad">Fill Rate</abbr>{% endblocktrans %}</strong></th>
+        <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="% of traffic that views ads we offered">View Rate</abbr>{% endblocktrans %}</strong></th>
       {% endif %}
     </tr>
   </thead>
@@ -29,7 +28,6 @@
         <td class="text-right">{{ result.ctr|floatformat:3 }}%</td>
         <td class="text-right">${{ result.revenue_share|floatformat:2|intcomma }}</td>
         {% if request.user.is_staff %}
-          <td class="text-right">|</td>
           <td class="text-right">${{ result.our_revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.ecpm|floatformat:2 }}</td>
@@ -46,7 +44,6 @@
       <td class="text-right"><strong>{{ report.total.ctr|floatformat:3 }}%</strong></td>
       <td class="text-right"><strong>${{ report.total.revenue_share|floatformat:2|intcomma }}</strong></td>
       {% if request.user.is_staff %}
-        <td class="text-right">|</td>
         <td class="text-right"><strong>${{ report.total.our_revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.ecpm|floatformat:2 }}</strong></td>

--- a/assets/src/scss/_theme.scss
+++ b/assets/src/scss/_theme.scss
@@ -17,9 +17,15 @@ body {
     border: 1px solid $border-color;
   }
 
-  td {
-    font-family: $font-family-monospace;
+  .report {
+    td, th {
+      font-family: $font-family-monospace;
+    }
+    .staff-only {
+      color: $info;
+    }
   }
+
 
   /* Preview an advertisement - most of this custom CSS comes from Read the Docs' existing ad settings */
   .advertisement-preview {


### PR DESCRIPTION
These are some suggestions for #323.

- Use CSS class report for reports
- Use monospace font only for reports
- Display header for staff-only columns in a different color