### PR TITLE
Remove refunded offers from aggregate reports

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -46,7 +46,7 @@ def _default_filters(impression_type, start_date, end_date):
     queryset = Offer.objects.filter(
         date__gte=start_date,
         date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
-        is_refunded=False,
+        # is_refunded=False,  # This causes the query to be a filtered index and is much slower
     )
 
     if impression_type == CLICKS:

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -390,14 +390,6 @@ class TestReportViews(TestReportsBase):
             Offer,
             advertisement=self.ad1,
             publisher=self.publisher1,
-            country="US",
-            viewed=True,
-            is_refunded=True,  # Won't count
-        )
-        get(
-            Offer,
-            advertisement=self.ad1,
-            publisher=self.publisher1,
             country="FR",
             viewed=True,
             clicked=True,
@@ -461,13 +453,6 @@ class TestReportViews(TestReportsBase):
             advertisement=self.ad1,
             publisher=self.publisher2,
             viewed=True,
-        )
-        get(
-            Offer,
-            advertisement=self.ad1,
-            publisher=self.publisher1,
-            viewed=True,
-            is_refunded=True,  # Won't count
         )
 
         # Update reporting
@@ -590,9 +575,6 @@ class TestReportViews(TestReportsBase):
         get(Offer, publisher=self.publisher1, div_id="p1", viewed=True)
         get(Offer, publisher=self.publisher1, div_id="p2", viewed=True)
         get(Offer, publisher=self.publisher1, div_id="p2", viewed=True)
-        get(
-            Offer, publisher=self.publisher1, div_id="p2", viewed=True, is_refunded=True
-        )
         get(Offer, publisher=self.publisher1, div_id="ad_23453464", viewed=True)
 
         # Update reporting
@@ -632,13 +614,6 @@ class TestReportViews(TestReportsBase):
         get(Offer, publisher=self.publisher1, country="US", viewed=True)
         get(Offer, publisher=self.publisher1, country="US", viewed=True)
         get(Offer, publisher=self.publisher1, country="US", viewed=True)
-        get(
-            Offer,
-            publisher=self.publisher1,
-            country="US",
-            viewed=True,
-            is_refunded=True,
-        )
         get(Offer, publisher=self.publisher1, country="FR", viewed=True, clicked=True)
 
         # Update reporting
@@ -722,14 +697,6 @@ class TestReportViews(TestReportsBase):
             publisher=self.publisher1,
             keywords=["test"],
             viewed=True,
-        )
-        get(
-            Offer,
-            advertisement=self.ad1,
-            publisher=self.publisher1,
-            keywords=["test"],
-            viewed=True,
-            is_refunded=True,
         )
         get(
             Offer,


### PR DESCRIPTION
Refunds are extremely rare but cause report generation to be *much* slower. We will tolerate slightly inaccurate reports (the actual $ spent reports will be correct) to have them be created faster.