### PR TITLE
Remove suggested_capabilities from the Stripe API

### DIFF
--- a/adserver/views.py
+++ b/adserver/views.py
@@ -1293,7 +1293,7 @@ class PublisherStripeOauthConnectView(
 
         params = {
             "client_id": settings.STRIPE_CONNECT_CLIENT_ID,
-            "suggested_capabilities[]": "transfers",
+            # "suggested_capabilities[]": "transfers",
             "stripe_user[email]": self.request.user.email,
             "state": stripe_state,
             "redirect_uri": self.request.build_absolute_uri(


### PR DESCRIPTION
I'm attempting to get it to properly set the `recipient` account type,
which will allow us to send money to folks overseas.
Currently all our accounts are set to `full`,
which disables this ability.

I've changed the settings in the dashboard,
but I believe they are not being respected becuase of this line in the docs:

> You can override the Configuration settings for an individual account by specifying its capabilities and service agreement type with the Accounts API.

https://stripe.com/docs/connect/service-agreement-types#choosing-type