### PR TITLE
Changes needed now that cryptography requires rust

### DIFF
--- a/docker-compose/local/django/Dockerfile
+++ b/docker-compose/local/django/Dockerfile
@@ -13,10 +13,14 @@ RUN apk update \
   # Translations dependencies
   && apk add gettext \
   # https://docs.djangoproject.com/en/dev/ref/django-admin/#dbshell
-  && apk add postgresql-client
+  && apk add postgresql-client \
+  # Needed to build Python Cryptography on Alpine Linux
+  # https://cryptography.io/en/latest/installation.html#alpine
+  && apk add openssl-dev cargo
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements
+RUN pip install --upgrade pip
 RUN pip install -r /requirements/development.txt
 RUN pip install -r /requirements/production.txt
 


### PR DESCRIPTION
This only really affects development. In production (Ubuntu), apparently new versions of `pip` will "just work"