### PR TITLE
Advertiser/publisher overview screens

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -666,7 +666,10 @@ class Flight(TimeStampedModel, IndestructibleModel):
         return value_clicks + value_views
 
     def percent_complete(self):
-        return self.total_value() / self.projected_total_value() * 100
+        projected_total = self.projected_total_value()
+        if projected_total > 0:
+            return self.total_value() / projected_total * 100
+        return 0
 
 
 class AdType(TimeStampedModel, models.Model):

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -659,6 +659,15 @@ class Flight(TimeStampedModel, IndestructibleModel):
         projected_value_views = float(self.sold_impressions * self.cpm) / 1000.0
         return projected_value_clicks + projected_value_views
 
+    def total_value(self):
+        """Total value ($) so far based on what's been delivered."""
+        value_clicks = float(self.total_clicks * self.cpc)
+        value_views = float(self.total_views * self.cpm) / 1000.0
+        return value_clicks + value_views
+
+    def percent_complete(self):
+        return self.total_value() / self.projected_total_value() * 100
+
 
 class AdType(TimeStampedModel, models.Model):
 

--- a/adserver/templates/adserver/advertiser/advertisement-create.html
+++ b/adserver/templates/adserver/advertiser/advertisement-create.html
@@ -11,7 +11,7 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item">{{ advertiser }}</li>
+  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'Flights' %}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_detail' advertiser.slug flight.slug %}">{{ flight.name }}</a></li>
   <li class="breadcrumb-item active">{% trans 'Create advertisement' %}</li>

--- a/adserver/templates/adserver/advertiser/advertisement-create.html
+++ b/adserver/templates/adserver/advertiser/advertisement-create.html
@@ -1,5 +1,4 @@
-{% extends "adserver/base.html" %}
-
+{% extends "adserver/advertiser/overview.html" %}
 {% load i18n %}
 {% load static %}
 {% load humanize %}
@@ -11,7 +10,6 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'Flights' %}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_detail' advertiser.slug flight.slug %}">{{ flight.name }}</a></li>
   <li class="breadcrumb-item active">{% trans 'Create advertisement' %}</li>

--- a/adserver/templates/adserver/advertiser/advertisement-detail.html
+++ b/adserver/templates/adserver/advertiser/advertisement-detail.html
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item">{{ advertiser }}</li>
+  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'Flights' %}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_detail' advertiser.slug advertisement.flight.slug %}">{{ advertisement.flight.name }}</a></li>
   <li class="breadcrumb-item active">{{ advertisement.name }}</li>

--- a/adserver/templates/adserver/advertiser/advertisement-detail.html
+++ b/adserver/templates/adserver/advertiser/advertisement-detail.html
@@ -1,5 +1,4 @@
-{% extends "adserver/base.html" %}
-
+{% extends "adserver/advertiser/overview.html" %}
 {% load i18n %}
 {% load static %}
 {% load humanize %}
@@ -10,7 +9,6 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'Flights' %}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_detail' advertiser.slug advertisement.flight.slug %}">{{ advertisement.flight.name }}</a></li>
   <li class="breadcrumb-item active">{{ advertisement.name }}</li>

--- a/adserver/templates/adserver/advertiser/advertisement-update.html
+++ b/adserver/templates/adserver/advertiser/advertisement-update.html
@@ -12,7 +12,7 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item">{{ advertiser }}</li>
+  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'Flights' %}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_detail' advertiser.slug advertisement.flight.slug %}">{{ advertisement.flight.name }}</a></li>
   <li class="breadcrumb-item active"><a href="{% url 'advertisement_detail' advertiser.slug advertisement.flight.slug advertisement.slug %}">{{ advertisement.name }}</a></li>

--- a/adserver/templates/adserver/advertiser/advertisement-update.html
+++ b/adserver/templates/adserver/advertiser/advertisement-update.html
@@ -1,5 +1,4 @@
-{% extends "adserver/base.html" %}
-
+{% extends "adserver/advertiser/overview.html" %}
 {% load i18n %}
 {% load static %}
 {% load humanize %}
@@ -12,7 +11,6 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'Flights' %}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_detail' advertiser.slug advertisement.flight.slug %}">{{ advertisement.flight.name }}</a></li>
   <li class="breadcrumb-item active"><a href="{% url 'advertisement_detail' advertiser.slug advertisement.flight.slug advertisement.slug %}">{{ advertisement.name }}</a></li>

--- a/adserver/templates/adserver/advertiser/flight-detail.html
+++ b/adserver/templates/adserver/advertiser/flight-detail.html
@@ -1,5 +1,4 @@
-{% extends "adserver/base.html" %}
-
+{% extends "adserver/advertiser/overview.html" %}
 {% load i18n %}
 {% load static %}
 {% load humanize %}
@@ -10,7 +9,6 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'Flights' %}</a></li>
   <li class="breadcrumb-item active">{{ flight.name }}</li>
 {% endblock breadcrumbs %}

--- a/adserver/templates/adserver/advertiser/flight-detail.html
+++ b/adserver/templates/adserver/advertiser/flight-detail.html
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item">{{ advertiser }}</li>
+  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'Flights' %}</a></li>
   <li class="breadcrumb-item active">{{ flight.name }}</li>
 {% endblock breadcrumbs %}

--- a/adserver/templates/adserver/advertiser/flight-list.html
+++ b/adserver/templates/adserver/advertiser/flight-list.html
@@ -1,5 +1,4 @@
-{% extends "adserver/base.html" %}
-
+{% extends "adserver/advertiser/overview.html" %}
 {% load i18n %}
 {% load static %}
 {% load humanize %}
@@ -10,7 +9,6 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item active">{% trans 'Flights' %}</li>
 {% endblock breadcrumbs %}
 

--- a/adserver/templates/adserver/advertiser/flight-list.html
+++ b/adserver/templates/adserver/advertiser/flight-list.html
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item">{{ advertiser }}</li>
+  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
   <li class="breadcrumb-item active">{% trans 'Flights' %}</li>
 {% endblock breadcrumbs %}
 

--- a/adserver/templates/adserver/advertiser/overview.html
+++ b/adserver/templates/adserver/advertiser/overview.html
@@ -9,13 +9,20 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item active">{{ advertiser }}</li>
+
+  {% url 'advertiser_main' advertiser.slug as advertiser_main_url %}
+
+  {% if request.path == advertiser_main_url %}
+    <li class="breadcrumb-item active">{{ advertiser }}</li>
+  {% else %}
+    <li class="breadcrumb-item"><a href="{{ advertiser_main_url }}">{{ advertiser }}</a></li>
+  {% endif %}
 {% endblock breadcrumbs %}
 
 
 {% block content_container %}
   <section>
-    <h1>{% blocktrans %}{{ advertiser }}{% endblocktrans %}</h1>
+    <h1>{% blocktrans with month=start_date|date:"F" %}{{ month }} {{ advertiser }} overview{% endblocktrans %}</h1>
     <p><small>Month to date overview for {{ advertiser }}.</small></p>
 
     <div class="row row-cols-1 row-cols-md-4">

--- a/adserver/templates/adserver/advertiser/overview.html
+++ b/adserver/templates/adserver/advertiser/overview.html
@@ -1,0 +1,101 @@
+{% extends "adserver/base.html" %}
+{% load crispy_forms_tags %}
+{% load humanize %}
+{% load i18n %}
+
+
+{% block title %}{% trans 'Advertiser Overview' %} - {{ advertiser }}{% endblock %}
+
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item active">{{ advertiser }}</li>
+{% endblock breadcrumbs %}
+
+
+{% block content_container %}
+  <section>
+    <h1>{% blocktrans %}{{ advertiser }}{% endblocktrans %}</h1>
+    <p><small>Month to date overview for {{ advertiser }}.</small></p>
+
+    <div class="row row-cols-1 row-cols-md-4">
+      <div class="col mb-3">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title text-center">{{ report.total.ctr|floatformat:3 }}%</h3>
+            <h6 class="text-muted text-center">{% trans 'CTR' %}</h6>
+          </div>
+        </div>
+      </div>
+      <div class="col mb-3">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title text-center">{{ report.total.views|intcomma }}</h3>
+            <h6 class="text-muted text-center">{% trans 'Views' %}</h6>
+          </div>
+        </div>
+      </div>
+      <div class="col mb-3">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title text-center">{{ report.total.clicks|intcomma }}</h3>
+            <h6 class="text-muted text-center">{% trans 'Clicks' %}</h6>
+          </div>
+        </div>
+      </div>
+      <div class="col mb-3">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title text-center">${{ report.total.cost|floatformat:2|intcomma }}</h3>
+            <h6 class="text-muted text-center">{% trans 'Spend' %}</h6>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="text-right mb-5"><a href="{% url 'advertiser_report' advertiser.slug %}?start_date={{ start_date|date:'Y-m-d' }}">{% trans 'detailed reporting' %} &raquo;</a></p>
+
+    <div class="row row-cols-1">
+      <div class="col">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">{% trans 'Active flights' %}</h5>
+
+            {% if flights %}
+              <div class="table-responsive">
+                <table class="table">
+                  <thead>
+                    <tr>
+                      <th><strong>{% trans 'Flight' %}</strong></th>
+                      <th><strong>{% trans 'End date' %}</strong></th>
+                      <th><strong>{% trans 'Progress' %}</strong></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for flight in flights %}
+                      <tr>
+                        <td>
+                          <a href="{% url 'flight_detail' advertiser.slug flight.slug %}">{{ flight.name }}</a>
+                        </td>
+                        <td>{{ flight.end_date }}</td>
+                        <td>
+                          <div class="progress" style="height: 1.5rem">
+                            <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: {{ flight.percent_complete|floatformat:0 }}%;" aria-valuenow="{{ flight.percent_complete|floatformat:0 }}" aria-valuemin="0" aria-valuemax="100">
+                              ${{ flight.value_remaining|floatformat:2 }} / ${{ flight.projected_total_value|floatformat:2 }} remaining</div>
+                          </div>
+                        </td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            {% else %}
+              <p>{% trans 'You have no active flights at this time' %}</p>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="text-right mb-5"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'All flights' %} &raquo;</a></p>
+
+  </section>
+{% endblock content_container %}

--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -66,6 +66,12 @@
 
             <ul class="nav flex-column mb-2">
               <li class="nav-item">
+                <a class="nav-link" href="{% url 'advertiser_main' advertiser.slug %}">
+                  <span class="fa fa-binoculars fa-fw mr-2 text-muted" aria-hidden="true"></span>
+                  <span>{% trans 'Overview' %}</span>
+                </a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link" href="{% url 'flight_list' advertiser.slug %}">
                   <span class="fa fa-calendar fa-fw mr-2 text-muted" aria-hidden="true"></span>
                   <span>{% trans 'Manage advertising' %}</span>

--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -102,6 +102,13 @@
             <ul class="nav flex-column mb-2">
 
               <li class="nav-item">
+                <a class="nav-link" href="{% url 'publisher_main' publisher.slug %}">
+                  <span class="fa fa-binoculars fa-fw mr-2 text-muted" aria-hidden="true"></span>
+                  <span>{% trans 'Overview' %}</span>
+                </a>
+              </li>
+
+              <li class="nav-item">
                 <a class="nav-link" href="{% url 'publisher_report' publisher.slug %}">
                   <span class="fa fa-bar-chart fa-fw mr-2 text-muted" aria-hidden="true"></span>
                   <span>{% trans 'Reports' %}</span>

--- a/adserver/templates/adserver/dashboard.html
+++ b/adserver/templates/adserver/dashboard.html
@@ -23,7 +23,7 @@
         <li>--</li>
       {% endif %}
       {% for publisher in publishers %}
-        <li><a href="{% url 'publisher_report' publisher.slug %}">{{ publisher.name }}</a></li>
+        <li><a href="{% url 'publisher_main' publisher.slug %}">{{ publisher.name }}</a></li>
       {% endfor %}
     </ul>
   {% endif %}

--- a/adserver/templates/adserver/dashboard.html
+++ b/adserver/templates/adserver/dashboard.html
@@ -35,7 +35,7 @@
         <li><a href="{% url 'all_advertisers_report' %}">{% trans 'All advertisers' %}</a></li>
       {% endif %}
       {% for advertiser in advertisers %}
-        <li><a href="{% url 'advertiser_report' advertiser.slug %}">{{ advertiser.name }}</a></li>
+        <li><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser.name }}</a></li>
       {% endfor %}
     </ul>
   {% endif %}

--- a/adserver/templates/adserver/publisher/embed.html
+++ b/adserver/templates/adserver/publisher/embed.html
@@ -1,4 +1,4 @@
-{% extends "adserver/base.html" %}
+{% extends "adserver/publisher/overview.html" %}
 {% load i18n %}
 
 
@@ -7,7 +7,6 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'publisher_main' publisher.slug %}">{{ publisher }}</a></li>
   <li class="breadcrumb-item active">{% trans 'Client Embed Code' %}</li>
 {% endblock breadcrumbs %}
 

--- a/adserver/templates/adserver/publisher/overview.html
+++ b/adserver/templates/adserver/publisher/overview.html
@@ -1,0 +1,78 @@
+{% extends "adserver/base.html" %}
+{% load crispy_forms_tags %}
+{% load humanize %}
+{% load i18n %}
+
+
+{% block title %}{% trans 'Publisher overview' %} - {{ publisher }}{% endblock %}
+
+
+{% block breadcrumbs %}
+  {{ block.super }}
+
+  {% url 'publisher_main' publisher.slug as publisher_main_url %}
+  {% if request.path == publisher_main_url %}
+    <li class="breadcrumb-item active">{{ publisher }}</li>
+  {% else %}
+    <li class="breadcrumb-item"><a href="{{ publisher_main_url }}">{{ publisher }}</a></li>
+  {% endif %}
+
+{% endblock breadcrumbs %}
+
+
+{% block content_container %}
+  <section>
+    <h1>{% blocktrans %}{{ publisher }}{% endblocktrans %}</h1>
+    <p><small>Month to date overview for {{ publisher }}.</small></p>
+
+    {% include "adserver/includes/publisher-paid-notice.html" with publisher=publisher only %}
+
+    <div class="row row-cols-1 row-cols-md-4">
+      <div class="col mb-3">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title text-center">${{ report.total.revenue_share|floatformat:2|intcomma }}</h3>
+            <h6 class="text-muted text-center">{% trans 'Revenue' %}</h6>
+            {% url 'publisher_payouts' publisher.slug as publisher_payout_url %}
+            <p class="text-muted small text-center mb-0">{% blocktrans %}See all your <a href="{{ publisher_payout_url }}">payouts</a>.{% endblocktrans %}</p>
+          </div>
+        </div>
+      </div>
+      <div class="col mb-3">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title text-center">{{ report.total.ctr|floatformat:3 }}%</h3>
+            <h6 class="text-muted text-center">{% trans 'CTR' %}</h6>
+            <p class="text-muted small text-center mb-0">
+              {% if report.total.ctr >= 0.1 %}
+                <span>{% trans 'Your CTR looks good.' %}</span>
+              {% elif report.total.ctr >= 0.05 %}
+                <span>{% trans 'Your CTR is OK but could use some improvement.' %}</span>
+              {% else %}
+                <span>{% trans 'Your CTR seems low. Perhaps the quality of the placement needs improvement.' %}</span>
+              {% endif %}
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col mb-3">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title text-center">{{ report.total.views|intcomma }}</h3>
+            <h6 class="text-muted text-center">{% trans 'Views' %}</h6>
+          </div>
+        </div>
+      </div>
+      <div class="col mb-3">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title text-center">{{ report.total.clicks|intcomma }}</h3>
+            <h6 class="text-muted text-center">{% trans 'Clicks' %}</h6>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="text-right mb-5"><a href="{% url 'publisher_report' publisher.slug %}?start_date={{ start_date|date:'Y-m-d' }}">{% trans 'detailed reporting' %} &raquo;</a></p>
+
+  </section>
+{% endblock content_container %}

--- a/adserver/templates/adserver/publisher/overview.html
+++ b/adserver/templates/adserver/publisher/overview.html
@@ -16,13 +16,12 @@
   {% else %}
     <li class="breadcrumb-item"><a href="{{ publisher_main_url }}">{{ publisher }}</a></li>
   {% endif %}
-
 {% endblock breadcrumbs %}
 
 
 {% block content_container %}
   <section>
-    <h1>{% blocktrans %}{{ publisher }}{% endblocktrans %}</h1>
+    <h1>{% blocktrans with month=start_date|date:"F" %}{{ month }} {{ publisher }} overview{% endblocktrans %}</h1>
     <p><small>Month to date overview for {{ publisher }}.</small></p>
 
     {% include "adserver/includes/publisher-paid-notice.html" with publisher=publisher only %}
@@ -44,12 +43,14 @@
             <h3 class="card-title text-center">{{ report.total.ctr|floatformat:3 }}%</h3>
             <h6 class="text-muted text-center">{% trans 'CTR' %}</h6>
             <p class="text-muted small text-center mb-0">
-              {% if report.total.ctr >= 0.1 %}
+              {% if report.total.views < 3000 %}
+                <!-- The sample is too small to draw conclusions -->
+              {% elif report.total.ctr >= 0.1 %}
                 <span>{% trans 'Your CTR looks good.' %}</span>
               {% elif report.total.ctr >= 0.05 %}
-                <span>{% trans 'Your CTR is OK but could use some improvement.' %}</span>
+                <span>{% blocktrans with link='https://www.ethicalads.io/publishers/faq/#how-do-i-ensure-the-ads-will-perform-well-on-my-site' %}Your CTR is OK but could use <a href="{{ link }}" target="_blank">some improvement</a>.{% endblocktrans %}</span>
               {% else %}
-                <span>{% trans 'Your CTR seems low. Perhaps the quality of the placement needs improvement.' %}</span>
+                <span>{% blocktrans with link='https://www.ethicalads.io/publishers/faq/#how-do-i-ensure-the-ads-will-perform-well-on-my-site' %}Your CTR seems low. Perhaps the quality of the placement <a href="{{ link }}" target="_blank">needs improvement</a>.{% endblocktrans %}</span>
               {% endif %}
             </p>
           </div>

--- a/adserver/templates/adserver/publisher/payout-list.html
+++ b/adserver/templates/adserver/publisher/payout-list.html
@@ -1,4 +1,4 @@
-{% extends "adserver/base.html" %}
+{% extends "adserver/publisher/overview.html" %}
 {% load humanize %}
 {% load i18n %}
 
@@ -8,7 +8,6 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'publisher_main' publisher.slug %}">{{ publisher }}</a></li>
   <li class="breadcrumb-item active">{% trans 'Payouts' %}</li>
 {% endblock breadcrumbs %}
 

--- a/adserver/templates/adserver/publisher/payout.html
+++ b/adserver/templates/adserver/publisher/payout.html
@@ -1,4 +1,4 @@
-{% extends "adserver/base.html" %}
+{% extends "adserver/publisher/overview.html" %}
 {% load humanize %}
 {% load i18n %}
 
@@ -8,7 +8,6 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'publisher_main' publisher.slug %}">{{ publisher }}</a></li>
   <li class="breadcrumb-item"><a href="{% url 'publisher_payouts' publisher.slug %}">{% trans 'Payouts' %}</a></li>
   <li class="breadcrumb-item active">{{ payout.date|date:"M j, Y" }}</li>
 {% endblock breadcrumbs %}

--- a/adserver/templates/adserver/publisher/settings.html
+++ b/adserver/templates/adserver/publisher/settings.html
@@ -1,4 +1,4 @@
-{% extends "adserver/base.html" %}
+{% extends "adserver/publisher/overview.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
 
@@ -12,7 +12,6 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'publisher_main' publisher.slug %}">{{ publisher }}</a></li>
   <li class="breadcrumb-item active">{% trans 'Settings' %}</li>
 {% endblock breadcrumbs %}
 

--- a/adserver/templates/adserver/reports/advertiser.html
+++ b/adserver/templates/adserver/reports/advertiser.html
@@ -11,7 +11,14 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item active">{{ advertiser }}</li>
+  <li class="breadcrumb-item"><a href="{% url 'advertiser_main' advertiser.slug %}">{{ advertiser }}</a></li>
+
+  {% url 'advertiser_report' advertiser.slug as advertiser_report_url %}
+  {% if request.path == advertiser_report_url %}
+    <li class="breadcrumb-item active">{% trans 'Reports' %}</li>
+  {% else %}
+    <li class="breadcrumb-item"><a href="{{ advertiser_report_url }}">{% trans 'Reports' %}</a></li>
+  {% endif %}
 {% endblock breadcrumbs %}
 
 

--- a/adserver/templates/adserver/reports/all-publishers-uplift.html
+++ b/adserver/templates/adserver/reports/all-publishers-uplift.html
@@ -1,4 +1,4 @@
-{% extends "adserver/reports/publisher.html" %}
+{% extends "adserver/reports/base.html" %}
 {% load humanize %}
 {% load i18n %}
 
@@ -48,4 +48,23 @@
 {% endblock explainer %}
 
 
-{% block summary-heading %}{% trans 'Total uplift results for all publishers' %}{% endblock summary-heading %}
+{% block summary %}
+  <section>
+    <div>
+      <div class="row">
+        <h2 class="col-md-8">{% trans 'Total uplift results for all publishers' %}</h2>
+
+        {% if export_url %}
+          <aside class="mb-3 col-md-4 text-right">
+            <a href="{{ export_url }}" class="btn btn-sm btn-outline-secondary" role="button" aria-pressed="true">
+              <span class="fa fa-download mr-1" aria-hidden="true"></span>
+              <span>CSV Export</span>
+            </a>
+          </aside>
+        {% endif %}
+      </div>
+
+      {% include "adserver/reports/includes/publisher-report-table.html" %}
+    </div>
+  </section>
+{% endblock summary %}

--- a/adserver/templates/adserver/reports/publisher.html
+++ b/adserver/templates/adserver/reports/publisher.html
@@ -10,7 +10,14 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item active">{{ publisher }}</li>
+  <li class="breadcrumb-item"><a href="{% url 'publisher_main' publisher.slug %}">{{ publisher }}</a></li>
+
+  {% url 'publisher_report' publisher.slug as publisher_report_url %}
+  {% if request.path == publisher_report_url %}
+    <li class="breadcrumb-item active">{% trans 'Reports' %}</li>
+  {% else %}
+    <li class="breadcrumb-item"><a href="{{ publisher_report_url }}">{% trans 'Reports' %}</a></li>
+  {% endif %}
 {% endblock breadcrumbs %}
 
 {% block additional_filters %}

--- a/adserver/tests/test_advertiser_dashboard.py
+++ b/adserver/tests/test_advertiser_dashboard.py
@@ -103,6 +103,32 @@ class TestAdvertiserDashboardViews(TestCase):
             get_user_model(), username="test-user", advertisers=[self.advertiser]
         )
 
+    def advertiser_overview(self):
+        url = reverse(
+            "advertiser_main", kwargs={"advertiser_slug": self.advertiser.slug}
+        )
+
+        # Anonymous - no access
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response["location"].startswith("/accounts/login/"))
+
+        self.flight.live = False
+        self.flight.save()
+
+        self.client.force_login(self.user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "no active flights")
+
+        self.flight.live = True
+        self.flight.save()
+
+        self.client.force_login(self.user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.flight.name)
+
     def test_flight_list_view(self):
         url = reverse("flight_list", kwargs={"advertiser_slug": self.advertiser.slug})
 

--- a/adserver/tests/test_publisher_dashboard.py
+++ b/adserver/tests/test_publisher_dashboard.py
@@ -90,7 +90,7 @@ class TestPublisherDashboardViews(TestCase):
 
         self.client.force_login(self.staff_user)
         resp = self.client.get(url)
-        self.assertContains(resp, "Your CTR seems low")
+        self.assertContains(resp, "too small to draw conclusions")
 
     def test_publisher_embed_code(self):
         url = reverse("publisher_embed", args=[self.publisher1.slug])

--- a/adserver/tests/test_publisher_dashboard.py
+++ b/adserver/tests/test_publisher_dashboard.py
@@ -80,6 +80,18 @@ class TestPublisherDashboardViews(TestCase):
             image=None,
         )
 
+    def test_publisher_overview(self):
+        url = reverse("publisher_main", args=[self.publisher1.slug])
+
+        # Anonymous
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(resp["location"].startswith("/accounts/login/"))
+
+        self.client.force_login(self.staff_user)
+        resp = self.client.get(url)
+        self.assertContains(resp, "Your CTR seems low")
+
     def test_publisher_embed_code(self):
         url = reverse("publisher_embed", args=[self.publisher1.slug])
 


### PR DESCRIPTION
Adds advertiser/publisher overview screens with month-to-date earnings/spending and key metrics. I want to add some graphs here but I'm wondering about the best way to add them. Regardless, this seems better than what we have now.

## Screenshots

![Screenshot from 2021-03-31 12-36-54](https://user-images.githubusercontent.com/185043/113248217-5631dc00-9271-11eb-8828-495ff8e28dc4.png)


Fixes #173 
Fixes #174 
(at least partially)