### PR TITLE
Reporting UX improvements

### DIFF
--- a/adserver/templates/adserver/reports/advertiser-geo.html
+++ b/adserver/templates/adserver/reports/advertiser-geo.html
@@ -22,7 +22,7 @@
 {% block additional_filters %}
 {{ block.super }}
 
-<div class="col-lg-2 col-md-4 mb-3">
+<div class="col-xl-3 col-md-6 col-12 mb-3">
   <label class="col-form-label" for="id_country">{% trans 'Country' %}</label>
   <select class="form-control" name="country" id="id_country">
     <option value="">All Countries</option>

--- a/adserver/templates/adserver/reports/advertiser-publisher.html
+++ b/adserver/templates/adserver/reports/advertiser-publisher.html
@@ -22,7 +22,7 @@
 {% block additional_filters %}
 {{ block.super }}
 
-<div class="col-lg-2 col-md-4 mb-3">
+<div class="col-xl-3 col-md-6 col-12 mb-3">
   <label class="col-form-label" for="id_publisher">{% trans 'Top Publishers' %}</label>
   <select class="form-control" name="publisher" id="id_publisher">
     <option value="">All publishers</option>

--- a/adserver/templates/adserver/reports/all-publishers-uplift.html
+++ b/adserver/templates/adserver/reports/all-publishers-uplift.html
@@ -16,7 +16,7 @@
 
 
 {% block additional_filters %}
-  <div class="col-lg-2 col-md-4 mb-3">
+  <div class="col-xl-3 col-md-6 col-12 mb-3">
     <label class="col-form-label" for="id_revenue_share_percentage">{% trans 'Revenue Share' %}</label>
     <select class="form-control" name="revenue_share_percentage" id="id_revenue_share_percentage">
       <option>All shares</option>
@@ -26,7 +26,7 @@
     </select>
   </div>
 
-  <div class="col-lg-2 col-md-4 mb-3">
+  <div class="col-xl-3 col-md-6 col-12 mb-3">
     <label class="col-form-label" for="id_sort">{% trans 'Sort' %}</label>
     <select class="form-control" name="sort" id="id_sort">
       {% for option in sort_options %}

--- a/adserver/templates/adserver/reports/all-publishers.html
+++ b/adserver/templates/adserver/reports/all-publishers.html
@@ -17,7 +17,7 @@
 
 {% block additional_filters %}
 
-<div class="col-lg-2 col-md-4 mb-3">
+<div class="col-xl-3 col-md-6 col-12 mb-3">
   <label class="col-form-label" for="id_revenue_share_percentage">{% trans 'Revenue Share' %}</label>
   <select class="form-control" name="revenue_share_percentage" id="id_revenue_share_percentage">
     <option>All shares</option>
@@ -27,7 +27,7 @@
   </select>
 </div>
 
-<div class="col-lg-2 col-md-4 mb-3">
+<div class="col-xl-3 col-md-6 col-12 mb-3">
   <label class="col-form-label" for="id_sort">{% trans 'Sort' %}</label>
   <select class="form-control" name="sort" id="id_sort">
     <option value="name">Name</option>

--- a/adserver/templates/adserver/reports/base.html
+++ b/adserver/templates/adserver/reports/base.html
@@ -18,19 +18,19 @@
     <div>
       <form method="get">
         <div class="form-row">
-          <div class="col-lg-2 col-md-4 mb-3">
+          <div class="col-xl-3 col-md-6 col-12 mb-3">
             <label class="col-form-label" for="id_start_date">{% trans 'Start Date' %}</label>
             <input class="form-control" name="start_date" id="id_start_date" type="date" value="{{ start_date|date:"Y-m-d" }}" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
           </div>
 
-          <div class="col-lg-2 col-md-4 mb-3">
+          <div class="col-xl-3 col-md-6 col-12 mb-3">
             <label class="col-form-label" for="id_end_date">{% trans 'End Date' %}</label>
             <input class="form-control" name="end_date" id="id_end_date" type="date" value="{% if end_date %}{{ end_date|date:"Y-m-d" }}{% endif %}" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}">
           </div>
 
           {# Add filters when we have the data to show them #}
           {% if campaign_types %}
-          <div class="col-lg-2 col-md-4 mb-3">
+          <div class="col-xl-3 col-md-6 col-12 mb-3">
             <label class="col-form-label" for="id_campaign_type">{% trans 'Campaign type' %}</label>
             <select class="form-control" name="campaign_type" id="id_campaign_type">
               <option value="">All types</option>

--- a/adserver/templates/adserver/reports/publisher-advertiser.html
+++ b/adserver/templates/adserver/reports/publisher-advertiser.html
@@ -21,7 +21,7 @@
 {% block additional_filters %}
 {{ block.super }}
 
-<div class="col-lg-2 col-md-4 mb-3">
+<div class="col-xl-3 col-md-6 col-12 mb-3">
   <label class="col-form-label" for="id_advertiser">{% trans 'Top Advertisers' %}</label>
   <select class="form-control" name="advertiser" id="id_advertiser">
     <option value="">All advertisers</option>

--- a/adserver/templates/adserver/reports/publisher-geo.html
+++ b/adserver/templates/adserver/reports/publisher-geo.html
@@ -22,7 +22,7 @@
 {% block additional_filters %}
 {{ block.super }}
 
-<div class="col-lg-2 col-md-4 mb-3">
+<div class="col-xl-3 col-md-6 col-12 mb-3">
   <label class="col-form-label" for="id_country">{% trans 'Country' %}</label>
   <select class="form-control" name="country" id="id_country">
     <option value="">All Countries</option>

--- a/adserver/templates/adserver/reports/publisher-keyword.html
+++ b/adserver/templates/adserver/reports/publisher-keyword.html
@@ -21,7 +21,7 @@
 {% block additional_filters %}
 {{ block.super }}
 
-<div class="col-lg-2 col-md-4 mb-3">
+<div class="col-xl-3 col-md-6 col-12 mb-3">
   <label class="col-form-label" for="id_keyword">{% trans 'Top Keywords' %}</label>
   <select class="form-control" name="keyword" id="id_keyword">
     <option value="">All keywords</option>

--- a/adserver/templates/adserver/reports/publisher-placement.html
+++ b/adserver/templates/adserver/reports/publisher-placement.html
@@ -22,7 +22,7 @@
 {% block additional_filters %}
 {{ block.super }}
 
-<div class="col-lg-2 col-md-4 mb-3">
+<div class="col-xl-3 col-md-6 col-12 mb-3">
   <label class="col-form-label" for="id_div_id">{% trans 'Divs' %}</label>
   <select class="form-control" name="div_id" id="id_div_id">
     <option value="">All Divs</option>

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -550,6 +550,8 @@ class BaseReportView(UserPassesTestMixin, TemplateView):
 
     DEFAULT_REPORT_DAYS = 30
     LIMIT = 20
+    SESSION_KEY_START_DATE = "report_start_date"
+    SESSION_KEY_END_DATE = "report_end_date"
     export = False
     export_filename = "readthedocs-report.csv"
     export_view = None
@@ -643,20 +645,40 @@ class BaseReportView(UserPassesTestMixin, TemplateView):
         return None
 
     def get_start_date(self):
+        start_date = None
         if "start_date" in self.request.GET:
             start_date = self._parse_date_string(self.request.GET["start_date"])
-            if start_date:
-                return start_date
+        if not start_date and self.SESSION_KEY_START_DATE in self.request.session:
+            start_date = self._parse_date_string(
+                self.request.session[self.SESSION_KEY_START_DATE]
+            )
 
-        return get_ad_day() - timedelta(days=self.DEFAULT_REPORT_DAYS)
+        if not start_date:
+            start_date = get_ad_day() - timedelta(days=self.DEFAULT_REPORT_DAYS)
+
+        # Store date in the session
+        self.request.session[self.SESSION_KEY_START_DATE] = start_date.strftime(
+            "%Y-%m-%d"
+        )
+
+        return start_date
 
     def get_end_date(self):
+        end_date = None
         if "end_date" in self.request.GET:
             end_date = self._parse_date_string(self.request.GET["end_date"])
-            if end_date:
-                return end_date
+        if not end_date and self.SESSION_KEY_END_DATE in self.request.session:
+            end_date = self._parse_date_string(
+                self.request.session[self.SESSION_KEY_END_DATE]
+            )
 
-        return None
+        if end_date:
+            # Store date in the session
+            self.request.session[self.SESSION_KEY_END_DATE] = end_date.strftime(
+                "%Y-%m-%d"
+            )
+
+        return end_date
 
 
 class AdvertiserReportView(AdvertiserAccessMixin, BaseReportView):


### PR DESCRIPTION
- Make each filter a bit wider and more responsive on smaller screens
- Store start and end date for reporting in the session (GET vars reset the session value). This means that when somebody clicks a link to the geo report or another report, it remembers the start and end date from the previous report.