### PR TITLE
Tweaks to the archive management command

### DIFF
--- a/adserver/tests/test_management_commands.py
+++ b/adserver/tests/test_management_commands.py
@@ -296,9 +296,10 @@ class TestArchiveOffers(TestCase):
 
         output = self.out.getvalue()
         self.assertFalse("Skipping deleting archived offers" in output)
-        self.assertTrue("Copying offer dumps to backups" in output)
-        self.assertTrue("Deleting archived offers" in output)
+        self.assertTrue("Copying offers" in output)
         self.assertTrue("Successfully copied" in output)
+        self.assertTrue("Deleting archived offers" in output)
+        self.assertTrue("Updating database statistics" in output)
 
         management.call_command(
             "archive_offers",


### PR DESCRIPTION
The big change here is to copy a day's worth of offers to backups before moving on to the next day. Previously, it did all the archiving before doing any copying to backups. This makes the command easier to stop and start as needed