### PR TITLE
Add an optional URL to the decision API

### DIFF
--- a/adserver/api/serializers.py
+++ b/adserver/api/serializers.py
@@ -42,6 +42,9 @@ class AdDecisionSerializer(serializers.Serializer):
         child=serializers.CharField(), max_length=10, required=False
     )
 
+    # The URL where the ad will appear
+    url = serializers.URLField(required=False)
+
     # Used to pass the actual ad viewer's data for targeting purposes
     user_ip = serializers.IPAddressField(required=False)
     user_ua = serializers.CharField(required=False)

--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -80,6 +80,8 @@ class BaseAdDecisionBackend:
         ):
             self.campaign_types.append(HOUSE_CAMPAIGN)
 
+        self.url = kwargs.get("url") or ""
+
         # When set, only return a specific ad or ads from a campaign
         self.ad_slug = kwargs.get("ad_slug")
         self.campaign_slug = kwargs.get("campaign_slug")

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -902,7 +902,9 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
                 total_clicks=models.F("total_clicks") + 1
             )
 
-    def _record_base(self, request, model, publisher, keywords, div_id, ad_type_slug):
+    def _record_base(
+        self, request, model, publisher, keywords, url, div_id, ad_type_slug
+    ):
         """
         Save the actual AdBase model to the database.
 
@@ -914,7 +916,7 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
         client_id = get_client_id(request)
         parsed_ua = parse(user_agent)
         country = get_client_country(request, ip_address)
-        url = request.META.get("HTTP_REFERER")
+        url = url or request.META.get("HTTP_REFERER")
 
         if model != Click and settings.ADSERVER_DO_NOT_TRACK:
             # For compliance with DNT,
@@ -960,6 +962,7 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
             model=Click,
             publisher=publisher,
             keywords=offer.keywords,
+            url=offer.url,
             div_id=offer.div_id,
             ad_type_slug=offer.ad_type_slug,
         )
@@ -985,6 +988,7 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
                 model=View,
                 publisher=publisher,
                 keywords=offer.keywords,
+                url=offer.url,
                 div_id=offer.div_id,
                 ad_type_slug=offer.ad_type_slug,
             )
@@ -993,7 +997,7 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
         return None
 
     def offer_ad(
-        self, request, publisher, ad_type_slug, div_id, keywords, forced=False
+        self, request, publisher, ad_type_slug, div_id, keywords, url=None, forced=False
     ):
         """
         Offer to display this ad on a specific publisher and a specific display (ad type).
@@ -1008,6 +1012,7 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
             model=Offer,
             publisher=publisher,
             keywords=keywords,
+            url=url,
             div_id=div_id,
             ad_type_slug=ad_type_slug,
         )
@@ -1052,7 +1057,7 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
         }
 
     @classmethod
-    def record_null_offer(cls, request, publisher, ad_type_slug, div_id, keywords):
+    def record_null_offer(cls, request, publisher, ad_type_slug, div_id, keywords, url):
         """
         Store null offers, so that we can keep track of our fill rate.
 
@@ -1066,6 +1071,7 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
             model=Offer,
             publisher=publisher,
             keywords=keywords,
+            url=url,
             div_id=div_id,
             ad_type_slug=ad_type_slug,
         )

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -1234,35 +1234,35 @@ class AdvertisingIntegrationTests(BaseApiTest):
         )
 
     def test_offer_url(self):
-        url1 = "http://example.com/path.html"
-        url2 = "http://example.com/altpath.html"
+        referrer_url = "http://example.com/path.html"
+        post_url = "http://example.com/altpath.html"
 
         # Defaults to the referrer if no URL sent
         resp = self.client.post(
             self.url,
             json.dumps(self.data),
             content_type="application/json",
-            HTTP_REFERER=url1,
+            HTTP_REFERER=referrer_url,
         )
         self.assertEqual(resp.status_code, 200, resp.content)
 
         offer = Offer.objects.filter(id=resp.json()["nonce"]).first()
         self.assertIsNotNone(offer)
-        self.assertEqual(offer.url, url1)
+        self.assertEqual(offer.url, referrer_url)
 
         # Passed URL overrides the referrer
-        self.data["url"] = url2
+        self.data["url"] = post_url
         resp = self.client.post(
             self.url,
             json.dumps(self.data),
             content_type="application/json",
-            HTTP_REFERER=url1,
+            HTTP_REFERER=referrer_url,
         )
         self.assertEqual(resp.status_code, 200, resp.content)
 
         offer = Offer.objects.filter(id=resp.json()["nonce"]).first()
         self.assertIsNotNone(offer)
-        self.assertEqual(offer.url, url2)
+        self.assertEqual(offer.url, post_url)
 
 
 class TestProxyViews(BaseApiTest):

--- a/adserver/tests/test_models.py
+++ b/adserver/tests/test_models.py
@@ -368,6 +368,39 @@ class TestAdModels(BaseAdModelsTestCase):
 
         self.assertAlmostEqual(self.flight.projected_total_value(), 5.0)
 
+    def test_offer_ad(self):
+        request = self.factory.get("/")
+        request.ip_address = "1.1.1.1"
+        request.user_agent = (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/90.0.4430.72 Safari/537.36"
+        )
+
+        div_id = "foo"
+        url = "http://example.com/path.html"
+        keywords = ["python", "ruby"]
+
+        output = self.ad1.offer_ad(
+            request=request,
+            publisher=self.publisher,
+            ad_type_slug=self.text_ad_type,
+            div_id=div_id,
+            keywords=keywords,
+            url=url,
+        )
+        offer = Offer.objects.get(pk=output["nonce"])
+
+        self.assertEqual(offer.publisher, self.publisher)
+        self.assertEqual(offer.advertisement, self.ad1)
+        self.assertEqual(offer.div_id, div_id)
+        self.assertEqual(offer.url, url)
+        self.assertEqual(offer.ip, "1.1.0.0")  # anonymized
+        self.assertEqual(offer.os_family, "Linux")
+        self.assertEqual(offer.browser_family, "Chrome")
+        self.assertFalse(offer.viewed)
+        self.assertFalse(offer.clicked)
+        self.assertFalse(offer.uplifted)
+
     def test_refund(self):
         request = self.factory.get("/")
 

--- a/adserver/tests/test_models.py
+++ b/adserver/tests/test_models.py
@@ -400,6 +400,8 @@ class TestAdModels(BaseAdModelsTestCase):
         self.assertFalse(offer.viewed)
         self.assertFalse(offer.clicked)
         self.assertFalse(offer.uplifted)
+        self.assertTrue("python" in offer.keywords)
+        self.assertTrue("ruby" in offer.keywords)
 
     def test_refund(self):
         request = self.factory.get("/")

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -825,6 +825,7 @@ class TestReportClasses(TestReportsBase):
             ad_type_slug=self.ad_type1.slug,
             div_id="ad-id",
             keywords=[],
+            url=None,
         )
 
         report = PublisherReport(AdImpression.objects.filter(publisher=self.publisher1))


### PR DESCRIPTION
This will allow the ad client to send the URL where the ad will appear. While the client can't be trusted, this will give more granular data for well-behaved clients.

Fixes https://github.com/readthedocs/ethical-ad-server/issues/354 (from the server side - client still needs to do this)