### PR TITLE
Don't reject invalid values in the URL field

### DIFF
--- a/adserver/api/serializers.py
+++ b/adserver/api/serializers.py
@@ -1,4 +1,6 @@
 """De-serializers for the ad server APIs."""
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
 from rest_framework import serializers
 
 from ..constants import ALL_CAMPAIGN_TYPES
@@ -43,7 +45,8 @@ class AdDecisionSerializer(serializers.Serializer):
     )
 
     # The URL where the ad will appear
-    url = serializers.URLField(required=False)
+    # This purposefully doesn't use a URLField so we can disregard invalid values rather than rejecting them
+    url = serializers.CharField(max_length=256, required=False)
 
     # Used to pass the actual ad viewer's data for targeting purposes
     user_ip = serializers.IPAddressField(required=False)
@@ -81,6 +84,14 @@ class AdDecisionSerializer(serializers.Serializer):
             keywords = [k.lower().strip() for k in keywords if k.strip()]
 
         return keywords
+
+    def validate_url(self, url):
+        validator = URLValidator()
+        try:
+            validator(url)  # Throws ValidationError on invalid
+            return url
+        except ValidationError:
+            return None
 
 
 class PublisherSerializer(serializers.HyperlinkedModelSerializer):

--- a/adserver/api/serializers.py
+++ b/adserver/api/serializers.py
@@ -1,4 +1,6 @@
 """De-serializers for the ad server APIs."""
+import logging
+
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from rest_framework import serializers
@@ -8,6 +10,9 @@ from ..models import Advertisement
 from ..models import Advertiser
 from ..models import Flight
 from ..models import Publisher
+
+
+log = logging.getLogger(__name__)  # noqa
 
 
 class AdPlacementSerializer(serializers.Serializer):
@@ -91,6 +96,7 @@ class AdDecisionSerializer(serializers.Serializer):
             validator(url)  # Throws ValidationError on invalid
             return url
         except ValidationError:
+            log.warning("Invalid ad decision referring URL: %s", url)
             return None
 
 

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -1264,6 +1264,34 @@ class AdvertisingIntegrationTests(BaseApiTest):
         self.assertIsNotNone(offer)
         self.assertEqual(offer.url, post_url)
 
+        # Invalid URL
+        self.data["url"] = "invalid-url"
+        resp = self.client.post(
+            self.url,
+            json.dumps(self.data),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        offer = Offer.objects.filter(id=resp.json()["nonce"]).first()
+
+        # Offer is accepted - URL is set to None
+        self.assertIsNotNone(offer)
+        self.assertIsNone(offer.url)
+
+        # Missing URL
+        del self.data["url"]
+        resp = self.client.post(
+            self.url,
+            json.dumps(self.data),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        offer = Offer.objects.filter(id=resp.json()["nonce"]).first()
+
+        # Offer is accepted - URL is set to None
+        self.assertIsNotNone(offer)
+        self.assertIsNone(offer.url)
+
 
 class TestProxyViews(BaseApiTest):
     def setUp(self):


### PR DESCRIPTION
Make the URL field not reject invalid values. Instead, it will validate it and disregard an invalid value. The ad will still get offered. It does still reject a blank value (`&url=`).

After doing this, I'm not 100% sure we even want this. For other fields (eg. publisher) we actually do reject invalid values.