### PR TITLE
Show upcoming flights on the overview screen

### DIFF
--- a/adserver/constants.py
+++ b/adserver/constants.py
@@ -25,6 +25,9 @@ CAMPAIGN_TYPES = (
     (COMMUNITY_CAMPAIGN, _("Community")),
     (HOUSE_CAMPAIGN, _("House")),
 )
+FLIGHT_STATE_CURRENT = _("Current")
+FLIGHT_STATE_UPCOMING = _("Upcoming")
+FLIGHT_STATE_PAST = _("Past")
 
 PAYOUT_STRIPE = "stripe"
 PAYOUT_PAYPAL = "paypal"

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -30,6 +30,9 @@ from user_agents import parse
 from .constants import CAMPAIGN_TYPES
 from .constants import CLICKS
 from .constants import DECISIONS
+from .constants import FLIGHT_STATE_CURRENT
+from .constants import FLIGHT_STATE_PAST
+from .constants import FLIGHT_STATE_UPCOMING
 from .constants import IMPRESSION_TYPES
 from .constants import OFFERS
 from .constants import PAID_CAMPAIGN
@@ -479,10 +482,10 @@ class Flight(TimeStampedModel, IndestructibleModel):
     def state(self):
         today = get_ad_day().date()
         if self.live and self.start_date <= today:
-            return _("Current")
+            return FLIGHT_STATE_CURRENT
         if self.end_date > today:
-            return _("Upcoming")
-        return _("Past")
+            return FLIGHT_STATE_UPCOMING
+        return FLIGHT_STATE_PAST
 
     def get_absolute_url(self):
         return reverse(

--- a/adserver/templates/adserver/advertiser/overview.html
+++ b/adserver/templates/adserver/advertiser/overview.html
@@ -59,49 +59,54 @@
         </div>
       </div>
     </div>
-    <p class="text-right mb-5"><a href="{% url 'advertiser_report' advertiser.slug %}?start_date={{ start_date|date:'Y-m-d' }}">{% trans 'detailed reporting' %} &raquo;</a></p>
+    <p class="text-right mb-5"><a href="{% url 'advertiser_report' advertiser.slug %}?start_date={{ start_date|date:'Y-m-d' }}&end_date={{ end_date|date:'Y-m-d' }}">{% trans 'detailed reporting' %} &raquo;</a></p>
 
     <div class="row row-cols-1">
       <div class="col">
         <div class="card">
           <div class="card-body">
-            <h5 class="card-title">{% trans 'Active flights' %}</h5>
-
             {% if flights %}
-              <div class="table-responsive">
-                <table class="table">
-                  <thead>
-                    <tr>
-                      <th><strong>{% trans 'Flight' %}</strong></th>
-                      <th><strong>{% trans 'End date' %}</strong></th>
-                      <th>
-                        <strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong>
-                        <span class="fa fa-info-circle fa-fw" aria-hidden="true" data-toggle="tooltip" title="{% trans 'This CTR is all-time, not month to date' %}" data-original-title="{% trans 'This CTR is all-time, not month to date' %}"></span>
-                      </th>
-                      <th><strong>{% trans 'Progress' %}</strong></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for flight in flights %}
-                      <tr>
-                        <td>
-                          <a href="{% url 'flight_detail' advertiser.slug flight.slug %}">{{ flight.name }}</a>
-                        </td>
-                        <td>{{ flight.end_date }}</td>
-                        <td>{{ flight.ctr|floatformat:3 }}%</td>
-                        <td>
-                          <div class="progress" style="height: 1.5rem">
-                            <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: {{ flight.percent_complete|floatformat:0 }}%;" aria-valuenow="{{ flight.percent_complete|floatformat:0 }}" aria-valuemin="0" aria-valuemax="100">
-                              ${{ flight.value_remaining|floatformat:2 }} / ${{ flight.projected_total_value|floatformat:2 }} remaining</div>
-                          </div>
-                        </td>
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
-              </div>
+              {% regroup flights by state as flight_groups %}
+              {% for state, flight_list in flight_groups %}
+                {% if flight_list %}
+                  <h5 class="card-title">{% blocktrans %}{{ state }} flights{% endblocktrans %}</h5>
+
+                  <div class="table-responsive">
+                    <table class="table table-hover">
+                      <thead>
+                        <tr>
+                          <th><strong>{% trans 'Flight' %}</strong></th>
+                          <th><strong>{% trans 'End date' %}</strong></th>
+                          <th>
+                            <strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong>
+                            <span class="fa fa-info-circle fa-fw" aria-hidden="true" data-toggle="tooltip" title="{% trans 'This CTR is all-time, not month to date' %}" data-original-title="{% trans 'This CTR is all-time, not month to date' %}"></span>
+                          </th>
+                          <th><strong>{% trans 'Progress' %}</strong></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {% for flight in flight_list %}
+                          <tr>
+                            <td>
+                              <a href="{% url 'flight_detail' advertiser.slug flight.slug %}">{{ flight.name }}</a>
+                            </td>
+                            <td>{{ flight.end_date }}</td>
+                            <td>{{ flight.ctr|floatformat:3 }}%</td>
+                            <td>
+                              <div class="progress" style="height: 1.5rem">
+                                <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: {{ flight.percent_complete|floatformat:0 }}%;" aria-valuenow="{{ flight.percent_complete|floatformat:0 }}" aria-valuemin="0" aria-valuemax="100">
+                                  ${{ flight.value_remaining|floatformat:2 }} / ${{ flight.projected_total_value|floatformat:2 }} remaining</div>
+                              </div>
+                            </td>
+                          </tr>
+                        {% endfor %}
+                      </tbody>
+                    </table>
+                  </div>
+                {% endif %}
+              {% endfor %}
             {% else %}
-              <p>{% trans 'You have no active flights at this time' %}</p>
+              <p>{% trans 'You have no active or upcoming flights. See All Flights for past ones.' %}</p>
             {% endif %}
           </div>
         </div>

--- a/adserver/tests/test_models.py
+++ b/adserver/tests/test_models.py
@@ -5,6 +5,9 @@ from django.utils import timezone
 from django_dynamic_fixture import get
 
 from ..constants import CLICKS
+from ..constants import FLIGHT_STATE_CURRENT
+from ..constants import FLIGHT_STATE_PAST
+from ..constants import FLIGHT_STATE_UPCOMING
 from ..constants import VIEWS
 from ..models import AdImpression
 from ..models import AdType
@@ -318,6 +321,22 @@ class TestAdModels(BaseAdModelsTestCase):
         ad2.incr(VIEWS, self.publisher)
 
         self.assertAlmostEqual(self.campaign.total_value(), 4.3)
+
+    def test_flight_state(self):
+        self.assertEqual(self.flight.state, FLIGHT_STATE_CURRENT)
+
+        self.flight.live = False
+        self.assertEqual(self.flight.state, FLIGHT_STATE_UPCOMING)
+
+        self.flight.live = True
+        self.flight.start_date = timezone.now().date() - datetime.timedelta(days=50)
+        self.flight.end_date = timezone.now().date() - datetime.timedelta(days=20)
+
+        # Still current because it's still live
+        self.assertEqual(self.flight.state, FLIGHT_STATE_CURRENT)
+
+        self.flight.live = False
+        self.assertEqual(self.flight.state, FLIGHT_STATE_PAST)
 
     def test_flight_value_remaining(self):
         self.assertAlmostEqual(self.flight.value_remaining(), 1000 * 2)


### PR DESCRIPTION
I noticed a few issues with the overview screen and this attempts to correct them. Firstly, it shows a client's upcoming ad flights. This is important especially for a new client. Otherwise they get a screen that doesn't show much and doesn't show anything upcoming.

Secondly, and this is really minor, it sets the `end_date` when clicking through from the overview screen to the last day of the month. If the user has a cookied `end_date` and clicks through, they can get into a slightly odd state where it doesn't show the whole month to date.