### PR TITLE
Allow advertisers to control their authorized users

### DIFF
--- a/adserver/templates/adserver/advertiser/users-invite.html
+++ b/adserver/templates/adserver/advertiser/users-invite.html
@@ -1,0 +1,30 @@
+{% extends "adserver/advertiser/overview.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+
+{% block title %}{% trans 'Authorized Users Invite' %} - {{ advertiser }}{% endblock %}
+
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item">
+    <a href="{% url 'advertiser_users' advertiser.slug %}">{% trans 'Authorized users' %}</a>
+  </li>
+  <li class="breadcrumb-item active">{% trans 'Invite' %}</li>
+{% endblock breadcrumbs %}
+
+
+{% block content_container %}
+  <section>
+    <h1>{% blocktrans %}Invite user to {{ advertiser }}{% endblocktrans %}</h1>
+
+    <div class="row">
+
+      <div class="col-md-6">
+        {% crispy form form.helper %}
+      </div>
+
+    </div>
+  </section>
+{% endblock content_container %}

--- a/adserver/templates/adserver/advertiser/users-remove.html
+++ b/adserver/templates/adserver/advertiser/users-remove.html
@@ -1,0 +1,31 @@
+{% extends "adserver/advertiser/overview.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+
+{% block title %}{% trans 'Authorized Users Remove Access' %} - {{ advertiser }}{% endblock %}
+
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item">
+    <a href="{% url 'advertiser_users' advertiser.slug %}">{% trans 'Authorized users' %}</a>
+  </li>
+  <li class="breadcrumb-item active">{% trans 'Remove' %}</li>
+{% endblock breadcrumbs %}
+
+
+{% block content_container %}
+  <section>
+    <h1>{% trans 'Remove user access' %}</h1>
+    <p class="mb-5">{% blocktrans with name=user.name email=user.email %}Remove {{ name }} ({{ email }}) from {{ advertiser }}{% endblocktrans %}</p>
+
+    <div>
+      <form method="post">
+        {% csrf_token %}
+        <input type="submit" class="btn btn-danger" value="{% trans 'Remove user access' %}">
+        <p class="text-muted form-text">{% trans 'The user may still login but will no longer have access to this advertiser.' %}</p>
+      </form>
+    </div>
+  </section>
+{% endblock content_container %}

--- a/adserver/templates/adserver/advertiser/users.html
+++ b/adserver/templates/adserver/advertiser/users.html
@@ -1,0 +1,54 @@
+{% extends "adserver/advertiser/overview.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+
+{% block title %}{% trans 'Authorized Users' %} - {{ advertiser }}{% endblock %}
+
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item active">{% trans 'Authorized users' %}</li>
+{% endblock breadcrumbs %}
+
+
+{% block content_container %}
+  <section>
+    <h1>{% blocktrans %}Authorized users for {{ advertiser }}{% endblocktrans %}</h1>
+    <p class="mb-5">{% trans 'These are users who have access to manage ads and view reports.' %}</p>
+
+    <aside class="mb-3 text-right">
+      <a href="{% url 'advertiser_users_invite' advertiser.slug %}" class="btn btn-sm btn-outline-primary" role="button" aria-pressed="true">
+        <span class="fa fa-plus mr-1" aria-hidden="true"></span>
+        <span>{% trans 'Invite user' %}</span>
+      </a>
+    </aside>
+
+    {% if users %}
+      <div class="table-responsive">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th><strong>{% trans 'Name' %}</strong></th>
+              <th><strong>{% trans 'Email' %}</strong></th>
+              <th><strong>{% trans 'Options' %}</strong></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for user in users %}
+              <tr>
+                <td>{{ user.name }}</td>
+                <td>{{ user.email }}</td>
+                <td>
+                  <a href="{% url 'advertiser_users_remove' advertiser.slug user.id %}" title="{% trans 'You will have a chance to confirm' %}">{% trans 'remove' %}</a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <p class="text-center">{% trans 'There are no authorized users for this advertiser.' %}</p>
+    {% endif %}
+  </section>
+{% endblock content_container %}

--- a/adserver/templates/adserver/advertiser/users.html
+++ b/adserver/templates/adserver/advertiser/users.html
@@ -40,7 +40,9 @@
                 <td>{{ user.name }}</td>
                 <td>{{ user.email }}</td>
                 <td>
-                  <a href="{% url 'advertiser_users_remove' advertiser.slug user.id %}" title="{% trans 'You will have a chance to confirm' %}">{% trans 'remove' %}</a>
+                  {% if request.user.id != user.id %}
+                    <a href="{% url 'advertiser_users_remove' advertiser.slug user.id %}" title="{% trans 'You will have a chance to confirm' %}">{% trans 'remove' %}</a>
+                  {% endif %}
                 </td>
               </tr>
             {% endfor %}

--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -95,6 +95,13 @@
                   <span>{% trans 'Publishers' %}</span>
                 </a>
               </li>
+
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'advertiser_users' advertiser.slug %}">
+                  <span class="fa fa-users fa-fw mr-2 text-muted" aria-hidden="true"></span>
+                  <span>{% trans 'Authorized users' %}</span>
+                </a>
+              </li>
             </ul>
           {% elif publisher %}
             <h6 class="text-muted">{{ publisher }}</h6>

--- a/adserver/urls.py
+++ b/adserver/urls.py
@@ -7,6 +7,9 @@ from .views import AdClickProxyView
 from .views import AdvertisementCreateView
 from .views import AdvertisementDetailView
 from .views import AdvertisementUpdateView
+from .views import AdvertiserAuthorizedUsersInviteView
+from .views import AdvertiserAuthorizedUsersRemoveView
+from .views import AdvertiserAuthorizedUsersView
 from .views import AdvertiserFlightReportView
 from .views import AdvertiserGeoReportView
 from .views import AdvertiserMainView
@@ -139,6 +142,21 @@ urlpatterns = [
         r"advertiser/<slug:advertiser_slug>/flights/<slug:flight_slug>/advertisements/<slug:advertisement_slug>/update/",
         AdvertisementUpdateView.as_view(),
         name="advertisement_update",
+    ),
+    path(
+        r"advertiser/<slug:advertiser_slug>/users/",
+        AdvertiserAuthorizedUsersView.as_view(),
+        name="advertiser_users",
+    ),
+    path(
+        r"advertiser/<slug:advertiser_slug>/users/invite/",
+        AdvertiserAuthorizedUsersInviteView.as_view(),
+        name="advertiser_users_invite",
+    ),
+    path(
+        r"advertiser/<slug:advertiser_slug>/users/<int:user_id>/remove/",
+        AdvertiserAuthorizedUsersRemoveView.as_view(),
+        name="advertiser_users_remove",
     ),
     # Publisher management and reporting
     path(

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -964,12 +964,13 @@ class AdvertiserAuthorizedUsersView(
 
     """Authorized users for an advertiser."""
 
+    context_object_name = "users"
     model = get_user_model()
     template_name = "adserver/advertiser/users.html"
 
     def get_context_data(self, **kwargs):  # pylint: disable=arguments-differ
         context = super().get_context_data(**kwargs)
-        context.update({"advertiser": self.advertiser, "users": self.object_list})
+        context.update({"advertiser": self.advertiser})
         return context
 
     def get_queryset(self):


### PR DESCRIPTION
This gives advertisers the ability to control the authorized users who can access their reports and control ads. A few advertisers have multiple authorized users and have requested the ability to add more.


## Screenshot
![Screenshot from 2021-04-29 09-41-30](https://user-images.githubusercontent.com/185043/116587272-2eb14c00-a8cf-11eb-8e8e-11624107ec04.png)
