### PR TITLE
Make report queries faster

### DIFF
--- a/adserver/reports.py
+++ b/adserver/reports.py
@@ -193,7 +193,15 @@ class PublisherReport(BaseReport):
 
         results = {}
 
-        for impression in queryset:
+        for impression in queryset.only(
+            "advertisement__flight",
+            "publisher__revenue_share_percentage",
+            "decisions",
+            "offers",
+            "views",
+            "clicks",
+            self.index,
+        ):
             index = getter(impression)
 
             if index not in results:


### PR DESCRIPTION
This only gets the data we need from the DB,
which makes this query much faster locally.
Not sure how much faster it will be in prod,
but should help some.