### PR TITLE
Null out old client IDs

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1462,10 +1462,11 @@ class AdBase(TimeStampedModel, IndestructibleModel):
     )
 
     # User Data
-    ip = models.GenericIPAddressField(_("Ip Address"))  # should be anonymized
+    ip = models.GenericIPAddressField(_("Ip Address"))  # anonymized
     user_agent = models.CharField(
         _("User Agent"), max_length=1000, blank=True, null=True
     )
+    # Client IDs are used primarily for fraud and short term (sub-day) frequency capping
     client_id = models.CharField(_("Client ID"), max_length=1000, blank=True, null=True)
     country = CountryField(null=True)
     url = models.CharField(_("Page URL"), max_length=10000, blank=True, null=True)

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -268,3 +268,10 @@ def update_previous_day_reports(day=None):
     daily_update_impressions(start_date)
     daily_update_keywords(start_date)
     daily_update_uplift(start_date)
+
+
+@app.task()
+def remove_old_client_ids(days=90):
+    """Remove old Client IDs which are used for short periods for fraud prevention."""
+    old_cutoff = get_ad_day() - datetime.timedelta(days=days)
+    Offer.objects.filter(date__lt=old_cutoff).update(client_id=None)

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -274,4 +274,10 @@ def update_previous_day_reports(day=None):
 def remove_old_client_ids(days=90):
     """Remove old Client IDs which are used for short periods for fraud prevention."""
     old_cutoff = get_ad_day() - datetime.timedelta(days=days)
-    Offer.objects.filter(date__lt=old_cutoff).update(client_id=None)
+    while True:
+        offer_ids = Offer.objects.filter(
+            date__lt=old_cutoff, client_id__isnull=False
+        ).values("pk")[:1000]
+        offers_changed = Offer.objects.filter(pk__in=offer_ids).update(client_id=None)
+        if not offers_changed:
+            break

--- a/adserver/tests/common.py
+++ b/adserver/tests/common.py
@@ -82,6 +82,10 @@ class BaseAdModelsTestCase(TestCase):
             template=None,
         )
 
+        self.ad1.ad_types.add(self.text_ad_type)
+        self.ad2.ad_types.add(self.text_ad_type)
+        self.ad2.ad_types.add(self.image_ad_type)
+
         self.staff_user = get(
             get_user_model(),
             is_staff=True,

--- a/adserver/tests/test_tasks.py
+++ b/adserver/tests/test_tasks.py
@@ -1,0 +1,39 @@
+import datetime
+
+from django.contrib.auth.models import AnonymousUser
+
+from ..models import Offer
+from ..tasks import remove_old_client_ids
+from .common import BaseAdModelsTestCase
+
+
+class TasksTest(BaseAdModelsTestCase):
+    def test_remove_client_ids(self):
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+
+        offer_dict = self.ad1.offer_ad(
+            request=request,
+            publisher=self.publisher,
+            ad_type_slug=self.text_ad_type.slug,
+            div_id="foo",
+            keywords=None,
+        )
+        offer = Offer.objects.filter(pk=offer_dict["nonce"]).first()
+        self.assertIsNotNone(offer)
+        self.assertIsNotNone(offer.client_id)
+
+        remove_old_client_ids()
+
+        # Shouldn't remove the offer's client_id since it is "recent"
+        offer.refresh_from_db()
+        self.assertIsNotNone(offer.client_id)
+
+        # Set the time back on the offer and the client_id should be blanked out
+        offer.date = offer.date - datetime.timedelta(days=100)
+        offer.save()
+        remove_old_client_ids()
+
+        # Offer's client_id is nulled out
+        offer.refresh_from_db()
+        self.assertIsNone(offer.client_id)

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -317,7 +317,7 @@ def generate_client_id(ip_address, user_agent):
     hash_id.update(force_bytes(settings.SECRET_KEY))
     hash_id.update(salt)
     if ip_address:
-        hash_id.update(force_bytes(ip_address))
+        hash_id.update(force_bytes(anonymize_ip_address(ip_address)))
     if user_agent:
         hash_id.update(force_bytes(user_agent))
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -129,6 +129,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "adserver.tasks.update_previous_day_reports",
         "schedule": crontab(hour="2", minute="0"),
     },
+    "every-day-clear-old-clientids": {
+        "task": "adserver.tasks.remove_old_client_ids",
+        "schedule": crontab(hour="3", minute="0"),
+    },
 }
 
 


### PR DESCRIPTION
ClientIDs are used for fraud prevention and for the ad pinning that shows the same ad to the same person for five seconds. These IDs are a 1-way hash made up of the user agent, the IP address, a salt, and our secret key. They aren't exposed to end users. They change over time as user agent strings or IPs change but they are steady over very short time periods and let us analyze things from a fraud perspective.

This change changes a few things:

- The IP will be anonymized before it is hashed. This will mean that folks with the same UA and similar IPs (last 2 bytes are dropped) will get the same ClientID. For most real fraud, this should be sufficient.
- After 90 days, Client IDs will be nulled out in the database.


**Performance note:** If this is approved, the performance on the live database will probably need to be assessed as nulling out parts of this table could be very expensive. It may need to be done in chunks to be performant.