### PR TITLE
Clean up a number of payout workflow issues

### DIFF
--- a/adserver/reports.py
+++ b/adserver/reports.py
@@ -286,7 +286,8 @@ class PublisherReport(BaseReport):
     def get_index_display(self, index):
         """Handle making sure dates use the same 3 letter syntax as Django."""
         if isinstance(index, datetime.date):
-            return index.strftime("%b %d, %Y")
+            # %a is the day of week, so you know which are weekends
+            return index.strftime("%b %d, %Y (%a)")
 
         return super().get_index_display(index)
 

--- a/adserver/staff/forms.py
+++ b/adserver/staff/forms.py
@@ -187,8 +187,10 @@ class StartPublisherPayoutForm(forms.Form):
     subject = forms.CharField(label=_("Subject"), max_length=200)
     body = forms.CharField(label=_("body"), widget=forms.Textarea)
     amount = forms.CharField(label=_("Amount"), disabled=True)
-    archive = forms.BooleanField(label=_("Archive after sending?"), initial=True)
-    # TODO: Allow people to create drafts, instead of immediately sending.
+    archive = forms.BooleanField(
+        label=_("Archive after sending?"), initial=True, required=False
+    )
+    draft = forms.BooleanField(label=_("Create draft, don't send."), required=False)
 
     def __init__(self, *args, **kwargs):
         """Add the form helper and customize the look of the form."""
@@ -203,7 +205,6 @@ class StartPublisherPayoutForm(forms.Form):
     def _send_email(self):
         token = getattr(settings, "FRONT_TOKEN")
         channel = getattr(settings, "FRONT_CHANNEL")
-        author = getattr(settings, "FRONT_AUTHOR")
 
         headers = {
             "Authorization": f"Bearer {token}",
@@ -211,18 +212,28 @@ class StartPublisherPayoutForm(forms.Form):
         }
 
         payload = {
-            # "to": ['eric@ericholscher.com'], # For testing
             "to": [user.email for user in self.publisher.user_set.all()],
             "sender_name": self.cleaned_data["sender"],
             "subject": self.cleaned_data["subject"],
             "options": {"archive": self.cleaned_data["archive"]},
             "body": self.cleaned_data["body"],
         }
-        if author:
-            payload["author_id"] = author
+
         url = f"https://api2.frontapp.com/channels/{channel}/messages"
-        log.info("Sending email")
-        requests.request("POST", url, json=payload, headers=headers)
+        if self.cleaned_data["draft"]:
+            url = f"https://api2.frontapp.com/channels/{channel}/drafts"
+            # Allow the team to see the draft
+            payload["mode"] = "shared"
+            # Author is required on drafts..
+            payload["author_id"] = getattr(settings, "FRONT_AUTHOR")
+
+        log.info(
+            "Sending email draft=%s archive=%s",
+            self.cleaned_data["draft"],
+            self.cleaned_data["archive"],
+        )
+        response = requests.request("POST", url, json=payload, headers=headers)
+        log.info("Response: %s", response.status_code)
 
     def save(self):
         """Do the work to save the payout."""

--- a/adserver/templates/adserver/dashboard.html
+++ b/adserver/templates/adserver/dashboard.html
@@ -22,7 +22,7 @@
     <ul>
         <li><a href="{% url 'staff_advertisers_report' %}">{% trans 'Staff Advertiser Report' %}</a></li>
         <li><a href="{% url 'staff_publishers_report' %}">{% trans 'Staff Publisher Report' %}</a></li>
-        <li><a href="{% url 'staff_keyword_report' %}">{% trans 'Staff Region & Topic Report' %}</a></li>
+        <li><a href="{% url 'staff_regiontopic_report' %}">{% trans 'Staff Region & Topic Report' %}</a></li>
         <li><a href="{% url 'staff_keyword_report' %}">{% trans 'Staff Keyword Report' %}</a></li>
         <li><a href="{% url 'staff_geo_report' %}">{% trans 'Staff Geo Report' %}</a></li>
         <li><a href="{% url 'publisher_uplift_report' %}">{% trans 'Staff Uplift Report' %}</a></li>

--- a/adserver/templates/adserver/email/publisher-payout.html
+++ b/adserver/templates/adserver/email/publisher-payout.html
@@ -1,4 +1,9 @@
 {% autoescape off %}
+
+<p>
+  Hello,
+</p>
+
 <p>
   Thanks for being one of our publishers on the EthicalAds network.
   We do payouts by the 15th of the month,

--- a/adserver/templates/adserver/publisher/payout.html
+++ b/adserver/templates/adserver/publisher/payout.html
@@ -24,6 +24,15 @@
   <dt>{% trans 'Date' %}</dt>
   <dd>{{ payout.date|date:"M j, Y" }}</dd>
 
+  {% if payout.start_date %}
+  <dt>{% trans 'Payout Time' %}</dt>
+  <dd>
+  <a href="{% url 'publisher_report' payout.publisher.slug %}?start_date={{ payout.start_date|date:'Y-m-d' }}&end_date={{ payout.end_date|date:'Y-m-d' }}&campaign_type=paid">
+  {{ payout.start_date|date:"M j, Y" }} - {{ payout.end_date|date:"M j, Y" }}
+  </a>
+</dd>
+  {% endif %}
+
   <dt>{% trans 'Amount' %}</dt>
   <dd>${{ payout.amount|floatformat:2|intcomma }}</dd>
 

--- a/adserver/templates/adserver/staff/publisher-payout-finish.html
+++ b/adserver/templates/adserver/staff/publisher-payout-finish.html
@@ -20,7 +20,12 @@
   <dd>{{ payout.publisher }}</dd>
 
   <dt>{% trans 'Method' %}</dt>
-  <dd>{{ payout.publisher.payout_method }}</dd>
+  <dd>
+  {{ payout.publisher.get_payout_method_display }}
+  {% if payout.publisher.paypal_email %}
+  ({{ payout.publisher.paypal_email }})
+  {% endif %}
+  </dd>
 
   <dt>{% trans 'Status' %}</dt>
   <dd>{{ payout.get_status_display }}</dd>

--- a/adserver/templates/adserver/staff/publisher-payout-list.html
+++ b/adserver/templates/adserver/staff/publisher-payout-list.html
@@ -21,6 +21,7 @@
           <th><strong>{% trans 'Since' %}</strong></th>
           <th><strong>{% trans 'First' %}</strong></th>
           <th><strong>{% trans 'Amount' %}</strong></th>
+          <th><strong>{% trans '% Change' %}</strong></th>
           <th><strong>{% trans 'CTR' %}</strong></th>
           <th><strong>{% trans 'Status' %}</strong></th>
           <th><strong>{% trans 'Action' %}</strong></th>
@@ -33,6 +34,7 @@
             <td>{{ payout_data.start_date|date }}</td>
             <td>{{ payout_data.first }}</td>
             <td>${{ payout_data.total }}</td>
+            <td>{{ payout_data.change|floatformat:2 }}%</td>
             <td>{{ payout_data.ctr }}%</td>
             <td>
             {% if payout_data.payout %}

--- a/adserver/templates/adserver/staff/publisher-payout-start.html
+++ b/adserver/templates/adserver/staff/publisher-payout-start.html
@@ -12,7 +12,7 @@
 
 
 {% block content_container %}
-<h1>{% block heading %}{% trans 'Send Email' %}{% endblock heading %}</h1>
+<h1>{% block heading %}{% trans 'Start Payout' %}{% endblock heading %}</h1>
 <div class="row">
   <div class="col-md">
     {% crispy form form.helper %}


### PR DESCRIPTION
We hit a bunch of things during payout that slowed us down.
This resolves a few of them:

* Easier to compare payout to last month
* Redirect Start form submission -> Finish form submission.
* Day of week in the date on reports
* Note publisher & email on Payout start & finish page