### PR TITLE
Send Slack notifications on completed flights

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1097,11 +1097,11 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
             nonce = offer.pk
 
         view_url = generate_absolute_url(
-            "view-proxy", kwargs={"advertisement_id": self.pk, "nonce": nonce}
+            reverse("view-proxy", kwargs={"advertisement_id": self.pk, "nonce": nonce})
         )
 
         click_url = generate_absolute_url(
-            "click-proxy", kwargs={"advertisement_id": self.pk, "nonce": nonce}
+            reverse("click-proxy", kwargs={"advertisement_id": self.pk, "nonce": nonce})
         )
 
         text = self.render_links(click_url)

--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -102,10 +102,10 @@ class PublisherPayoutView(StaffUserMixin, TemplateView):
                 continue
 
             payouts_url = generate_absolute_url(
-                "publisher_payouts", kwargs={"publisher_slug": publisher.slug}
+                reverse("publisher_payouts", kwargs={"publisher_slug": publisher.slug})
             )
             settings_url = generate_absolute_url(
-                "publisher_settings", kwargs={"publisher_slug": publisher.slug}
+                reverse("publisher_settings", kwargs={"publisher_slug": publisher.slug})
             )
             payout_context = dict(
                 payouts_url=payouts_url,

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -5,6 +5,7 @@ import logging
 from collections import defaultdict
 
 from celery.utils.iso8601 import parse_iso8601
+from django.conf import settings
 from django.db.models import Count
 from django.db.models import F
 from django.utils.timezone import is_naive
@@ -438,10 +439,11 @@ def notify_of_completed_flights():
             log.info("Flight %s finished in the last day.", flight)
 
             # Send notification about this flight
-            slack_message(
-                "adserver/slack/flight-complete.slack",
-                {
-                    "flight": flight,
-                    "flight_url": generate_absolute_url(flight.get_absolute_url()),
-                },
-            )
+            if settings.SLACK_TOKEN:
+                slack_message(
+                    "adserver/slack/flight-complete.slack",
+                    {
+                        "flight": flight,
+                        "flight_url": generate_absolute_url(flight.get_absolute_url()),
+                    },
+                )

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -9,6 +9,7 @@ from django.db.models import Count
 from django.db.models import F
 from django.utils.timezone import is_naive
 from django.utils.timezone import utc
+from django_slack import slack_message
 
 from .constants import CLICKS
 from .constants import IMPRESSION_TYPES
@@ -16,6 +17,7 @@ from .constants import OFFERS
 from .constants import PAID_CAMPAIGN
 from .constants import VIEWS
 from .models import AdImpression
+from .models import Flight
 from .models import GeoImpression
 from .models import KeywordImpression
 from .models import Offer
@@ -37,6 +39,7 @@ from .regiontopics import security_privacy
 from .regiontopics import us_ca
 from .regiontopics import wider_apac
 from .reports import PublisherReport
+from .utils import generate_absolute_url
 from .utils import get_ad_day
 from config.celery_app import app
 
@@ -417,3 +420,28 @@ def calculate_publisher_ctrs(days=7):
 
         publisher.sampled_ctr = report.total["ctr"]
         publisher.save()
+
+
+@app.task()
+def notify_of_completed_flights():
+    """Send a notification about flights which completed in the last day."""
+    cutoff = get_ad_day() - datetime.timedelta(days=1)
+    for flight in Flight.objects.filter(live=True).filter():
+        if (
+            flight.clicks_remaining() == 0
+            and flight.views_remaining() == 0
+            and AdImpression.objects.filter(
+                date__gte=cutoff,
+                advertisement__flight=flight,
+            ).exists()
+        ):
+            log.info("Flight %s finished in the last day.", flight)
+
+            # Send notification about this flight
+            slack_message(
+                "adserver/slack/flight-complete.slack",
+                {
+                    "flight": flight,
+                    "flight_url": generate_absolute_url(flight.get_absolute_url()),
+                },
+            )

--- a/adserver/templates/adserver/slack/flight-complete.slack
+++ b/adserver/templates/adserver/slack/flight-complete.slack
@@ -1,0 +1,6 @@
+{% extends django_slack %}
+
+
+{% block text %}
+Flight {{ flight }} for {{ flight.campaign.advertiser }} wrapped up today: {{ flight_url }}
+{% endblock %}

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -331,9 +331,9 @@ def generate_client_id(ip_address, user_agent):
     return hash_id.hexdigest()
 
 
-def generate_absolute_url(view, kwargs):
+def generate_absolute_url(url):
     """
-    Generate a fully qualified URL for a view on our site.
+    Generate a fully qualified URL for a path on our site.
 
     This will look like ``https://server.ethicalads.io/foo/``.
     """
@@ -343,9 +343,7 @@ def generate_absolute_url(view, kwargs):
     if settings.ADSERVER_HTTPS:
         scheme = "https"
 
-    url = "{scheme}://{domain}{url}".format(
-        scheme=scheme, domain=domain, url=reverse(view, kwargs=kwargs)
-    )
+    url = "{scheme}://{domain}{url}".format(scheme=scheme, domain=domain, url=url)
     return url
 
 
@@ -372,7 +370,7 @@ def generate_publisher_payout_data(publisher):
         start_date = publisher.created
 
     report_url = generate_absolute_url(
-        "publisher_report", kwargs={"publisher_slug": publisher.slug}
+        reverse("publisher_report", kwargs={"publisher_slug": publisher.slug})
     )
 
     current_queryset = publisher.adimpression_set.filter(

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
     "adserver",
     "adserver.auth",
     "simple_history",
+    "django_slack",
 ]
 
 MIDDLEWARE = [
@@ -334,6 +335,16 @@ STRIPE_CONNECT_CLIENT_ID = env("STRIPE_CONNECT_CLIENT_ID", default=None)
 stripe.api_key = STRIPE_SECRET_KEY
 stripe.api_version = "2020-03-02"
 
+
+# Slack
+# Sending slack notifications
+# By default, Slack notifications are only sent when DEBUG=False
+# and when SLACK_TOKEN is set
+# https://django-slack.readthedocs.io/
+# --------------------------------------------------------------------------
+SLACK_TOKEN = env("SLACK_TOKEN", default=None)
+SLACK_CHANNEL = env("SLACK_CHANNEL", default="#ads-notifications")
+SLACK_USERNAME = env("SLACK_USERNAME", default="Ethical Ad Server")
 
 # Ad server specific settings
 # https://ethical-ad-server.readthedocs.io/en/latest/install/configuration.html

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -133,6 +133,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "adserver.tasks.calculate_publisher_ctrs",
         "schedule": crontab(hour="3", minute="30"),
     },
+    "every-day-notify-completed-flights": {
+        "task": "adserver.tasks.notify_of_completed_flights",
+        "schedule": crontab(hour="0", minute="0"),
+    },
 }
 
 

--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -20,3 +20,9 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 # This will ensure that the test suite matches what's run in CI
 # There will be no IP geolocation done in testing
 GEOIP_PATH = os.path.join(BASE_DIR, "geoip-noexists")
+
+# By setting a testing backend, this allows verifying these messages
+# from unit tests
+# https://django-slack.readthedocs.io/#testing
+SLACK_BACKEND = "django_slack.backends.TestBackend"
+SLACK_TOKEN = "this-is-a-test-token"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,5 +52,8 @@ bleach==3.3.0
 # Security features
 django-enforce-host==1.0.1
 
+# For Slack notifications and possibly for logging errors to Slack
+django-slack==5.16.2
+
 # Stripe for payments
 stripe>=2.48.0,<3.0


### PR DESCRIPTION
- This PR refactored the `generate_absolute_url` function to accept a path instead of a view and kwargs.
- We will need to generate and set a SLACK_TOKEN for this to work in production. It can be set as an environment variable.
- Relies on [django-slack](https://django-slack.readthedocs.io/)