### PR TITLE
Notify when publisher metrics change

### DIFF
--- a/adserver/templates/adserver/slack/publisher-metric.slack
+++ b/adserver/templates/adserver/slack/publisher-metric.slack
@@ -1,0 +1,6 @@
+{% extends django_slack %}
+
+
+{% block text %}
+Publisher {{ publisher }}: "{{ metric }}" was {{ last_week_value|floatformat:-2 }} last week and {{ previous_week_value|floatformat:-2 }} the previous week ({% if percent_diff > 0 %}+{% endif %}{{ percent_diff|floatformat:2 }}%): {{ report_url }}
+{% endblock %}

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -137,6 +137,11 @@ CELERY_BEAT_SCHEDULE = {
         "task": "adserver.tasks.notify_of_completed_flights",
         "schedule": crontab(hour="0", minute="0"),
     },
+    "every-week-notify-publisher-changes": {
+        "task": "adserver.tasks.notify_of_publisher_changes",
+        # Runs on Wednesday
+        "schedule": crontab(day_of_week=3, hour="5", minute="0"),
+    },
 }
 
 


### PR DESCRIPTION
- Sends a slack notification (if slack is configured)
- Notifies if a publisher's CTR or views change by 25% wk/wk