### PR TITLE
Add some payout optimizations to make it faster

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -175,7 +175,7 @@ class Publisher(TimeStampedModel, IndestructibleModel):
     record_placements = models.BooleanField(
         default=False, help_text=_("Record placement impressions for this publisher")
     )
-    # TODO: Move this to default=False, so new publishers have to request custom integrations
+    # This defaults to False, so publishers have to ask for it.
     render_pixel = models.BooleanField(
         default=False,
         help_text=_(

--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -4,6 +4,7 @@ import logging
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.core.cache import cache
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
@@ -91,11 +92,13 @@ class PublisherPayoutView(StaffUserMixin, TemplateView):
     """
 
     template_name = "adserver/staff/publisher-payout-list.html"
+    # Two hours should be enough to run most payouts
+    CACHE_SECONDS = 7200
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        limit = int(self.request.GET.get("limit", 50))
+        limit = int(self.request.GET.get("limit", 0))
         all_publishers = self.request.GET.get("all")
         publisher_slug = self.request.GET.get("publisher")
 
@@ -103,16 +106,25 @@ class PublisherPayoutView(StaffUserMixin, TemplateView):
         if publisher_slug:
             queryset = queryset.filter(slug__startswith=publisher_slug)
 
+        if limit:
+            queryset = queryset[:limit]
+
         payouts = {}
 
-        for publisher in queryset[:limit]:
-            data = generate_publisher_payout_data(publisher)
+        for publisher in queryset:
+            data = generate_publisher_payout_data(
+                publisher, include_current_report=False
+            )
+
+            # Cache payout data to make running payouts faster
+            data = cache.get(f"payout-{publisher.pk}")
+            if not data:
+                data = generate_publisher_payout_data(publisher)
+                cache.set(f"payout-{publisher.pk}", data, self.CACHE_SECONDS)
+
             report = data.get("due_report")
             if not report:
-                if not all_publishers:
-                    # Skip publishers without due money
-                    continue
-                report = data.get("current_report")
+                continue
 
             due_balance = report["total"]["revenue_share"]
             due_str = "{:.2f}".format(due_balance)

--- a/adserver/templates/adserver/staff/publisher-payout-list.html
+++ b/adserver/templates/adserver/staff/publisher-payout-list.html
@@ -34,7 +34,13 @@
             <td>{{ payout_data.start_date|date }}</td>
             <td>{{ payout_data.first }}</td>
             <td>${{ payout_data.total }}</td>
-            <td>{{ payout_data.change|floatformat:2 }}%</td>
+            <td>
+            {% if payout_data.change %}
+            {{ payout_data.change|floatformat:2 }}%
+            {% else %}
+            {% trans "N/A" %}
+            {% endif %}
+            </td>
             <td>{{ payout_data.ctr }}%</td>
             <td>
             {% if payout_data.payout %}


### PR DESCRIPTION
We had some pageload slowness last time we did payouts.
This adds a bit of caching to the payout data,
and does a bit less work that we don't need on this page.