### PR TITLE
Add a more obvious callout for the publisher referral in payouts

### DIFF
--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -23,7 +23,6 @@ from ..models import Publisher
 from .forms import CreateAdvertiserForm
 from .forms import CreatePublisherForm
 from .forms import StartPublisherPayoutForm
-from adserver.utils import generate_absolute_url
 from adserver.utils import generate_publisher_payout_data
 
 

--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -138,16 +138,7 @@ class PublisherPayoutView(StaffUserMixin, TemplateView):
             ):
                 continue
 
-            payouts_url = generate_absolute_url(
-                reverse("publisher_payouts", kwargs={"publisher_slug": publisher.slug})
-            )
-            settings_url = generate_absolute_url(
-                reverse("publisher_settings", kwargs={"publisher_slug": publisher.slug})
-            )
             payout_context = dict(
-                payouts_url=payouts_url,
-                settings_url=settings_url,
-                publisher=publisher,
                 total=due_str,
                 ctr=ctr_str,
                 **data,

--- a/adserver/templates/adserver/email/publisher-payout.html
+++ b/adserver/templates/adserver/email/publisher-payout.html
@@ -1,7 +1,9 @@
 {% autoescape off %}
 
-{# TODO: Find a way to make this non-EA specific,
-but for now I think we can't avoid it because of linking to content on our marketing pages. #}
+{% comment %}
+TODO: Find a way to make this non-EA specific,
+but for now I think we can't avoid it because of linking to content on our marketing pages.
+{% endcomment %}
 
 <p>
   Hello,

--- a/adserver/templates/adserver/email/publisher-payout.html
+++ b/adserver/templates/adserver/email/publisher-payout.html
@@ -1,7 +1,18 @@
 {% autoescape off %}
 
+{# TODO: Find a way to make this non-EA specific,
+but for now I think we can't avoid it because of linking to content on our marketing pages. #}
+
 <p>
   Hello,
+</p>
+
+<p>
+  <strong>New:</strong>
+  We have launched a <a href="https://www.ethicalads.io/blog/2021/07/publisher-referral-offer/">referral program</a> for our existing publishers.
+  We're offering bonus cash for both you and the person you refer to EthicalAds on their first payout.
+  If you know anyone who would be a good fit for EthicalAds, now would be a great time to refer them.
+  You can use this link: <a href="https://ethicalads.io/publishers/?referral=Publisher:{{ publisher.slug }}">https://ethicalads.io/publishers/?referral=Publisher:{{ publisher.slug }}</a> to ensure you get credit for the referral.
 </p>
 
 <p>

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -423,6 +423,13 @@ def generate_publisher_payout_data(
             )
         )
 
+    payouts_url = generate_absolute_url(
+        reverse("publisher_payouts", kwargs={"publisher_slug": publisher.slug})
+    )
+    settings_url = generate_absolute_url(
+        reverse("publisher_settings", kwargs={"publisher_slug": publisher.slug})
+    )
+
     return dict(
         first=first,
         start_date=start_date,
@@ -442,6 +449,9 @@ def generate_publisher_payout_data(
         if current_report
         else None,
         current_report_url=current_report_url,
+        payouts_url=payouts_url,
+        settings_url=settings_url,
+        publisher=publisher,
     )
 
 


### PR DESCRIPTION
This is a bit more visible than our previous asks,
and specifically mentions our offer.