### PR TITLE
Use the right payout objects when finishing

### DIFF
--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -248,7 +248,9 @@ class PublisherFinishPayoutView(StaffUserMixin, DetailView):
         self.publisher = get_object_or_404(
             Publisher, slug=self.kwargs["publisher_slug"]
         )
-        self.payout = self.publisher.payouts.exclude(status=PAID).first()
+        # Get the last payout, which is the one we actually want to pay out,
+        # since there could be multiple with status=EMAILED from previous months.
+        self.payout = self.publisher.payouts.exclude(status=PAID).last()
         if not self.payout:
             raise Http404("No payout found")
         return self.payout

--- a/adserver/tests/test_staff_actions.py
+++ b/adserver/tests/test_staff_actions.py
@@ -239,13 +239,25 @@ class PublisherPayoutTests(TestCase):
         self.client.force_login(self.staff_user)
 
         self.payout = get(
-            PublisherPayout, status="emailed", publisher=self.publisher1, amount=55
+            PublisherPayout,
+            status="emailed",
+            publisher=self.publisher1,
+            amount=55,
+            date=timezone.now() - timedelta(days=3),
         )
         self.payout2 = get(
-            PublisherPayout, status="emailed", publisher=self.publisher1, amount=77
+            PublisherPayout,
+            status="emailed",
+            publisher=self.publisher1,
+            amount=77,
+            date=timezone.now() - timedelta(days=2),
         )
         self.payout3 = get(
-            PublisherPayout, status="emailed", publisher=self.publisher1, amount=99
+            PublisherPayout,
+            status="emailed",
+            publisher=self.publisher1,
+            amount=99,
+            date=timezone.now() - timedelta(days=1),
         )
 
         self.assertEqual(self.payout.status, "emailed")
@@ -255,12 +267,12 @@ class PublisherPayoutTests(TestCase):
             "staff-finish-publisher-payout",
             kwargs=dict(publisher_slug=self.publisher1.slug),
         )
-        start_response = self.client.get(finish_url)
-        self.assertEqual(start_response.status_code, 200)
-        self.assertContains(start_response, self.payout.get_status_display())
-        self.assertContains(start_response, "$99")
+        finish_response = self.client.get(finish_url)
+        self.assertEqual(finish_response.status_code, 200)
+        self.assertContains(finish_response, self.payout3.get_status_display())
+        self.assertContains(finish_response, "$99")
 
         post_response = self.client.post(finish_url)
         self.assertEqual(post_response.status_code, 302)
         # requery to get new object
-        self.assertEqual(PublisherPayout.objects.get(pk=self.payout.pk).status, "paid")
+        self.assertEqual(PublisherPayout.objects.get(pk=self.payout3.pk).status, "paid")

--- a/adserver/tests/test_staff_actions.py
+++ b/adserver/tests/test_staff_actions.py
@@ -241,6 +241,12 @@ class PublisherPayoutTests(TestCase):
         self.payout = get(
             PublisherPayout, status="emailed", publisher=self.publisher1, amount=55
         )
+        self.payout2 = get(
+            PublisherPayout, status="emailed", publisher=self.publisher1, amount=77
+        )
+        self.payout3 = get(
+            PublisherPayout, status="emailed", publisher=self.publisher1, amount=99
+        )
 
         self.assertEqual(self.payout.status, "emailed")
 
@@ -252,7 +258,7 @@ class PublisherPayoutTests(TestCase):
         start_response = self.client.get(finish_url)
         self.assertEqual(start_response.status_code, 200)
         self.assertContains(start_response, self.payout.get_status_display())
-        self.assertContains(start_response, "$55")
+        self.assertContains(start_response, "$99")
 
         post_response = self.client.post(finish_url)
         self.assertEqual(post_response.status_code, 302)


### PR DESCRIPTION
This previously caused a bug where we were getting the wrong payout amount for previously unfinalized payouts.