### PR TITLE
Update GeoIP Links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 GEOIP_DIR = geoip
 GEOIP_CITY_FILE = dbip-city-lite.mmdb.gz
 GEOIP_COUNTRY_FILE = dbip-country-lite.mmdb.gz
-GEOIP_CITY_DB_URL = https://download.db-ip.com/free/dbip-city-lite-2020-07.mmdb.gz
-GEOIP_COUNTRY_DB_URL = https://download.db-ip.com/free/dbip-country-lite-2020-07.mmdb.gz
+GEOIP_CITY_DB_URL = https://download.db-ip.com/free/dbip-city-lite-2021-08.mmdb.gz
+GEOIP_COUNTRY_DB_URL = https://download.db-ip.com/free/dbip-country-lite-2021-08.mmdb.gz
 
 TOR_EXIT_LIST_FILE = torbulkexitlist.txt
 TOR_EXIT_LIST_URL = https://check.torproject.org/torbulkexitlist


### PR DESCRIPTION
Running `make geoip` generates an error related to gzip file encoding because the files from last year are no longer live. 

Updating to this month as a quick fix, but there might be a better way to automatically populate the most recent YYYY-MM. 