### PR TITLE
Fix silly bug with Payouts

### DIFF
--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -107,14 +107,13 @@ class PublisherPayoutView(StaffUserMixin, TemplateView):
         payouts = {}
 
         for publisher in queryset:
-            data = generate_publisher_payout_data(
-                publisher, include_current_report=False
-            )
 
             # Cache payout data to make running payouts faster
             data = cache.get(f"payout-{publisher.pk}")
             if not data:
-                data = generate_publisher_payout_data(publisher)
+                data = generate_publisher_payout_data(
+                    publisher, include_current_report=False
+                )
                 cache.set(f"payout-{publisher.pk}", data, self.CACHE_SECONDS)
 
             report = data.get("due_report")


### PR DESCRIPTION
This was calling generate_publisher_payout_data _twice_,
which caused the page to be really slow.
Not sure how I missed this the first time :(