### PR TITLE
Add `other` to the list of topics when none other apply.

### DIFF
--- a/adserver/regiontopics.py
+++ b/adserver/regiontopics.py
@@ -10,6 +10,7 @@ topic_list = [
     "game-dev",
     "blockchain",
     "techwriting",
+    "other",  # Special case, doesn't have any explicit tags
 ]
 
 data_science = [

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -360,6 +360,10 @@ def daily_update_regiontopic(day=None):  # pylint: disable=too-many-branches
 
                 topics.add(topic)
 
+            # If nothing gets set as a topic, assign it other
+            if not topics:
+                topics.add("other")
+
             if country in us_ca:
                 region = "us-ca"
             elif country in eu_aus_nz:


### PR DESCRIPTION
This will allow us to track how much traffic doens't fit in a topic.