### PR TITLE
Fix a bug where existing AdType was excluded

### DIFF
--- a/adserver/forms.py
+++ b/adserver/forms.py
@@ -530,9 +530,11 @@ class AdvertisementForm(AdvertisementFormMixin, forms.ModelForm):
 
         # Remove deprecated ad types unless the passed ad has those ad types
         if self.instance.pk:
-            adtype_queryset = adtype_queryset.filter(
-                Q(deprecated=False) | Q(pk__in=self.instance.ad_types.values("pk"))
+            # Extend the queryset to include the current type, so it's never unselected..
+            adtype_queryset |= AdType.objects.filter(
+                pk__in=self.instance.ad_types.values("pk")
             )
+            adtype_queryset = adtype_queryset.filter(deprecated=False)
         else:
             adtype_queryset = adtype_queryset.exclude(deprecated=True)
         self.fields["ad_types"].queryset = adtype_queryset


### PR DESCRIPTION
This happened on the WTD ads I was testing with.
The AdType for the ad (RTD Sidebar) was attached to the RTD Publisher group,
but the WTD Publisher wasn't in it (so I could targets ads only to it).
This fixes it so that the Ad Type shows in this case,
but there's probably a better fix..