### PR TITLE
Add a read replica DB router & settings

### DIFF
--- a/adserver/management/commands/archive_offers.py
+++ b/adserver/management/commands/archive_offers.py
@@ -84,11 +84,6 @@ class Command(BaseCommand):
         zipped_output_file = Path(str(output_file) + ".bz2")
         end_day = day + datetime.timedelta(days=1)
 
-        # Find the proper DB to query
-        copy_connection = "default"
-        if "replica" in connection:
-            copy_connection = "replica"
-
         self.stdout.write(_("Archiving %s to %s...") % (day, output_file))
 
         # Using the date params as an f-string is suboptimal but these are validated
@@ -98,7 +93,7 @@ class Command(BaseCommand):
                 WHERE date >= '{day:%Y-%m-%d}' AND date < '{end_day:%Y-%m-%d}'
                 ORDER BY date
             ) TO STDOUT WITH CSV HEADER"""
-        with connection[copy_connection].cursor() as cursor:
+        with connection[settings.REPLICA_SLUG].cursor() as cursor:
             with open(output_file, "w") as fd:
                 # https://www.psycopg.org/docs/cursor.html#cursor.copy_expert
                 cursor.copy_expert(query, fd)

--- a/adserver/management/commands/archive_offers.py
+++ b/adserver/management/commands/archive_offers.py
@@ -84,6 +84,11 @@ class Command(BaseCommand):
         zipped_output_file = Path(str(output_file) + ".bz2")
         end_day = day + datetime.timedelta(days=1)
 
+        # Find the proper DB to query
+        copy_connection = "default"
+        if "replica" in connection:
+            copy_connection = "replica"
+
         self.stdout.write(_("Archiving %s to %s...") % (day, output_file))
 
         # Using the date params as an f-string is suboptimal but these are validated
@@ -93,7 +98,7 @@ class Command(BaseCommand):
                 WHERE date >= '{day:%Y-%m-%d}' AND date < '{end_day:%Y-%m-%d}'
                 ORDER BY date
             ) TO STDOUT WITH CSV HEADER"""
-        with connection.cursor() as cursor:
+        with connection[copy_connection].cursor() as cursor:
             with open(output_file, "w") as fd:
                 # https://www.psycopg.org/docs/cursor.html#cursor.copy_expert
                 cursor.copy_expert(query, fd)
@@ -180,7 +185,8 @@ class Command(BaseCommand):
         self.stdout.write(_("- Executing SQL:"))
         self.stdout.write(query % (day, end_day))
 
-        with connection.cursor() as cursor:
+        # Always delete from the default.
+        with connection["default"].cursor() as cursor:
             # Offers are normally immutable so the delete has to be run as raw sql
             cursor.execute(
                 query,

--- a/adserver/router.py
+++ b/adserver/router.py
@@ -33,7 +33,7 @@ class ReplicaRouter:  # pylint: disable=unused-argument
         """Only write to the default database."""
         return "default"
 
-    def allow_relation(self, obj1, obj2, **hints):
+    def allow_relation(self, obj1, obj2, **hints):  # pylint: disable=protected-access
         """Don't allow creating relations across databases."""
         db_list = ("default", "replica")
         if obj1._state.db in db_list and obj2._state.db in db_list:

--- a/adserver/router.py
+++ b/adserver/router.py
@@ -1,3 +1,4 @@
+"""Router for replica replica."""
 from .models import AdImpression
 from .models import GeoImpression
 from .models import KeywordImpression
@@ -7,16 +8,16 @@ from .models import RegionTopicImpression
 from .models import UpliftImpression
 
 
-class ReplicaRouter:
-    """
-    A database router that allows for reading from a replica, mostly used for reporting for now.
-    """
+class ReplicaRouter:  # pylint: disable=unused-argument
+
+    """A database router that allows for reading from a replica, mostly used for reporting for now."""
 
     # All reporting models
     index_models = {
         AdImpression,
         PlacementImpression,
         GeoImpression,
+        KeywordImpression,
         RegionImpression,
         RegionTopicImpression,
         UpliftImpression,

--- a/adserver/router.py
+++ b/adserver/router.py
@@ -35,10 +35,9 @@ class ReplicaRouter:  # pylint: disable=unused-argument
 
     def allow_relation(self, obj1, obj2, **hints):
         """Don't allow creating relations across databases."""
+        # pylint: disable=protected-access
         db_list = ("default", "replica")
-        if (
-            obj1._state.db in db_list and obj2._state.db in db_list
-        ):  # pylint: disable=protected-access
+        if obj1._state.db in db_list and obj2._state.db in db_list:
             return True
         return None
 

--- a/adserver/router.py
+++ b/adserver/router.py
@@ -1,0 +1,46 @@
+from .models import AdImpression
+from .models import GeoImpression
+from .models import KeywordImpression
+from .models import PlacementImpression
+from .models import RegionImpression
+from .models import RegionTopicImpression
+from .models import UpliftImpression
+
+
+class ReplicaRouter:
+    """
+    A database router that allows for reading from a replica, mostly used for reporting for now.
+    """
+
+    # All reporting models
+    index_models = {
+        AdImpression,
+        PlacementImpression,
+        GeoImpression,
+        RegionImpression,
+        RegionTopicImpression,
+        UpliftImpression,
+    }
+
+    def db_for_read(self, model, **hints):
+        """Read all indexes from the replica server (this is only used for reporting)."""
+        if model in self.index_models:
+            return "replica"
+        return None
+
+    def db_for_write(self, model, **hints):
+        """Only write to the default database."""
+        return "default"
+
+    def allow_relation(self, obj1, obj2, **hints):
+        """Don't allow creating relations across databases."""
+        db_list = ("default", "replica")
+        if obj1._state.db in db_list and obj2._state.db in db_list:
+            return True
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """Don't allow migrating the replica, since we shouldn't write to it."""
+        if db == "replica":
+            return False
+        return True

--- a/adserver/router.py
+++ b/adserver/router.py
@@ -33,10 +33,12 @@ class ReplicaRouter:  # pylint: disable=unused-argument
         """Only write to the default database."""
         return "default"
 
-    def allow_relation(self, obj1, obj2, **hints):  # pylint: disable=protected-access
+    def allow_relation(self, obj1, obj2, **hints):
         """Don't allow creating relations across databases."""
         db_list = ("default", "replica")
-        if obj1._state.db in db_list and obj2._state.db in db_list:
+        if (
+            obj1._state.db in db_list and obj2._state.db in db_list
+        ):  # pylint: disable=protected-access
             return True
         return None
 

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -67,7 +67,7 @@ def _get_day(day):
 
 def _default_filters(impression_type, start_date, end_date):
     """Filter the queryset by date and impression type."""
-    queryset = Offer.objects.filter(
+    queryset = Offer.objects.using("replica").filter(
         date__gte=start_date,
         date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
         # is_refunded=False,  # This causes the query to be a filtered index and is much slower

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -69,7 +69,7 @@ def _default_filters(impression_type, start_date, end_date):
     """Filter the queryset by date and impression type."""
     # Use the replica for this query, since it's how we do all our reporting queries,
     # and it currently hammers the prod DB.
-    queryset = Offer.objects.using("replica").filter(
+    queryset = Offer.objects.using(settings.REPLICA_SLUG).filter(
         date__gte=start_date,
         date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
         # is_refunded=False,  # This causes the query to be a filtered index and is much slower

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -67,6 +67,8 @@ def _get_day(day):
 
 def _default_filters(impression_type, start_date, end_date):
     """Filter the queryset by date and impression type."""
+    # Use the replica for this query, since it's how we do all our reporting queries,
+    # and it currently hammers the prod DB.
     queryset = Offer.objects.using("replica").filter(
         date__gte=start_date,
         date__lt=end_date,  # Things at UTC midnight should count towards tomorrow

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -124,6 +124,16 @@ DATABASES = {
 }
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
 
+# Add support for a read replica, mostly used in reporting.
+DATABASE_ROUTERS = env("DATABASE_ROUTER", default=[])
+if DATABASE_ROUTERS:
+    REPLICA = env.db("REPLICA_DATABASE_URL", default=None)
+    if not REPLICA:
+        raise ImproperlyConfigured(
+            "You have defined a DATABASE_ROUTER, but not a REPLICA_DATABASE_URL. Please use both."
+        )
+    DATABASES["replica"] = REPLICA
+
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -133,6 +133,10 @@ if DATABASE_ROUTERS:
             "You have defined a DATABASE_ROUTER, but not a REPLICA_DATABASE_URL. Please use both."
         )
     DATABASES["replica"] = REPLICA
+    REPLICA_SLUG = "replica"
+else:
+    # Allow us to use `Offer.objects.using(settings.REPLICA_SLUG) when we do & don't have a replica
+    REPLICA_SLUG = "default"
 
 
 # Password validation


### PR DESCRIPTION
This will allow us to use a read replica in production.
Currently this is only used for reports,
and in the task that cleans Offers from the DB.
In the future though,
we will extend the usage to most tasks and non-write operations.

The biggest issue here is making sure we don't have replica lag.
Things like `get_or_create` are thus using the default DB explicitly,
when acting on Impression models.