### PR TITLE
Fixes a bug with old-style ads

### DIFF
--- a/adserver/forms.py
+++ b/adserver/forms.py
@@ -543,12 +543,14 @@ class AdvertisementForm(AdvertisementFormMixin, forms.ModelForm):
         if not self.instance.pk or self.instance.content:
             del self.fields["text"]
             self.fields["content"].widget.attrs["rows"] = 3
+            self.fields["content"].required = True
             ad_display_fields = ["headline", "content", "cta"]
         else:
             del self.fields["headline"]
             del self.fields["content"]
             del self.fields["cta"]
             self.fields["text"].widget.attrs["rows"] = 3
+            self.fields["text"].required = True
             ad_display_fields = ["text"]
 
         self.helper.layout = Layout(

--- a/adserver/tests/test_advertiser_dashboard.py
+++ b/adserver/tests/test_advertiser_dashboard.py
@@ -344,7 +344,8 @@ class TestAdvertiserDashboardViews(TestCase):
             "name": "New Name",
             "live": True,
             "link": "http://example.com",
-            "text": "Sample text",
+            "headline": "Some Company: ",
+            "content": "Sample text",
             "image": "",
             "ad_types": [self.ad_type1.pk],
         }
@@ -378,7 +379,8 @@ class TestAdvertiserDashboardViews(TestCase):
             "name": "New Name",
             "live": True,
             "link": "http://example.com",
-            "text": "Sample text",
+            "headline": "Some Company: ",
+            "content": "Sample text",
             "image": "",
             "ad_types": [self.ad_type1.pk],
         }

--- a/adserver/tests/test_forms.py
+++ b/adserver/tests/test_forms.py
@@ -328,6 +328,13 @@ class FormTests(TestCase):
         )
         self.assertTrue(form.is_valid(), form.errors)
 
+    def test_content_required(self):
+        # When this is a "new style" ad form, at least content of headline, content and CTA is required
+        self.ad_data["content"] = ""
+        form = AdvertisementForm(data=self.ad_data, flight=self.flight)
+        self.assertFalse(form.is_valid())
+        self.assertEquals(form.errors["content"], ["This field is required."])
+
     # Below are tests for old-style ads with a single text field instead of broken out
     # headline, content, and CTA
     def test_ad_form_add_link(self):


### PR DESCRIPTION
By submitting an ad with no content, it was possible to convert your ad to an old-style ad (a single HTML text field). This fixes that by making the content field required for new ads and the text field required for old ads.