### PR TITLE
Make azure logging quiet

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -270,6 +270,12 @@ LOGGING = {
             "handlers": ["mail_admins"],
             "propagate": True,
         },
+        # Disable azure's super spammy INFO logging
+        "azure": {
+            "level": "WARNING",
+            "handlers": ["console-adserver"],
+            "propagate": False,
+        },
     },
 }
 


### PR DESCRIPTION
It's currently spamming the console with INFO logs like:

```
 Outgoing request: Method=PUT, Path=/backups/offers/2021-02-01-offers.csv.bz2, ...
```