### PR TITLE
Use impression-caching on RegionTopic report to improve performance

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1603,16 +1603,16 @@ class RegionTopicImpression(BaseImpression):
 
     region = models.CharField(_("Region"), max_length=100)
     topic = models.CharField(_("Topic"), max_length=100)
-    advertisement = models.ForeignKey(
-        Advertisement,
-        related_name="regiontopic_impressions",
-        on_delete=models.PROTECT,
-        null=True,
+    cpc = models.DecimalField(
+        _("Cost Per Click"), max_digits=5, decimal_places=2, default=0
+    )
+    cpm = models.DecimalField(
+        _("Cost Per 1k Impressions"), max_digits=5, decimal_places=2, default=0
     )
 
     class Meta:
         ordering = ("-date",)
-        unique_together = ("date", "region", "topic", "advertisement")
+        unique_together = ("date", "region", "topic", "cpc", "cpm")
 
     def __str__(self):
         """Simple override."""


### PR DESCRIPTION
This is a proof of concept attempt at denormalizing the data for the report onto the impression.
This makes the DB query much lighter,
and doesn't have any joins.

It also is neat because it lets me index production ad data into a local DB, since there aren't any ForeignKey's in the Impression data.

I think we could migrate most of our staff reports to this format,
which would have a few benefits:

* Smaller tables since all flights with the same pricing are aggregated
* Faster queries because there are no joins

I think this could give us a lot of benefits for BI-style uses.

We'd still need publisher & advertiser FK's on the reports that we put on the dashboards,
but we could even split these up to make them faster..