### PR TITLE
Change the offers db_table to give us more space

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1790,7 +1790,8 @@ class Offer(AdBase):
     class Meta:
         # This is needed because we can't sort on pk to get the created ordering
         ordering = ("-date",)
-        db_table = "adserver_offer_2021_11"
+        if settings.ADSERVER_OFFER_DB_TABLE:
+            db_table = settings.ADSERVER_OFFER_DB_TABLE
 
 
 class PublisherPayout(TimeStampedModel):

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1790,6 +1790,7 @@ class Offer(AdBase):
     class Meta:
         # This is needed because we can't sort on pk to get the created ordering
         ordering = ("-date",)
+        db_table = "adserver_offer_2021_11"
 
 
 class PublisherPayout(TimeStampedModel):

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -124,6 +124,8 @@ DATABASES = {
 }
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
 
+ADSERVER_OFFER_DB_TABLE = env("ADSERVER_OFFER_DB_TABLE", default=None)
+
 # Add support for a read replica, mostly used in reporting.
 DATABASE_ROUTERS = env("DATABASE_ROUTER", default=[])
 if DATABASE_ROUTERS:


### PR DESCRIPTION
This is our initial plan to reduce the overhead of the Offers table.
The migration should be pretty simple:

* Run the following SQL to create the DB table
* Add the env `ADSERVER_OFFER_DB_TABLE=adserver_offer_2021_11`
* Restart your Django application with this db_table
* Offers should be blank, and start accumulating in the new table

This requires running the following SQL to create the table:

```
CREATE TABLE "adserver_offer_2021_11" ("created" timestamp with time zone NOT NULL, "modified" timestamp with time zone NOT NULL, "date" timestamp with time zone NOT NULL, "ip" inet NOT NULL, "user_agent" varchar(1000) NULL, "client_id" varchar(1000) NULL, "country" varchar(2) NULL, "url" varchar(10000) NULL, "browser_family" varchar(1000) NULL, "os_family" varchar(1000) NULL, "keywords" text NULL, "div_id" varchar(100) NULL, "ad_type_slug" varchar(100) NULL, "is_bot" boolean NOT NULL, "is_mobile" boolean NOT NULL, "is_refunded" boolean NOT NULL, "id" uuid NOT NULL PRIMARY KEY, "viewed" boolean NOT NULL, "clicked" boolean NOT NULL, "uplifted" boolean NULL, "view_time" integer NULL CHECK ("view_time" >= 0), "advertisement_id" integer NULL, "publisher_id" integer NULL);

ALTER TABLE "adserver_offer_2021_11" ADD CONSTRAINT "adserver_offer_2021__advertisement_id_154ae817_fk_adserver_" FOREIGN KEY ("advertisement_id") REFERENCES "adserver_advertisement" ("id") DEFERRABLE INITIALLY DEFERRED;
ALTER TABLE "adserver_offer_2021_11" ADD CONSTRAINT "adserver_offer_2021__publisher_id_d9abea3b_fk_adserver_" FOREIGN KEY ("publisher_id") REFERENCES "adserver_publisher" ("id") DEFERRABLE INITIALLY DEFERRED;
CREATE INDEX "adserver_offer_2021_11_date_cc145c38" ON "adserver_offer_2021_11" ("date");
CREATE INDEX "adserver_offer_2021_11_advertisement_id_154ae817" ON "adserver_offer_2021_11" ("advertisement_id");
CREATE INDEX "adserver_offer_2021_11_publisher_id_d9abea3b" ON "adserver_offer_2021_11" ("publisher_id");
```