### PR TITLE
Tweak to progress bar formatting

### DIFF
--- a/adserver/templates/adserver/advertiser/overview.html
+++ b/adserver/templates/adserver/advertiser/overview.html
@@ -102,8 +102,12 @@
                             <td>
                               <div class="progress" style="height: 1.5rem">
                                 <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: {{ flight.percent_complete|floatformat:0 }}%;" aria-valuenow="{{ flight.percent_complete|floatformat:0 }}" aria-valuemin="0" aria-valuemax="100">
-                                  ${{ flight.value_remaining|floatformat:2 }} / ${{ flight.projected_total_value|floatformat:2 }} remaining</div>
+                                {{ flight.percent_complete|floatformat:0 }}% complete
+                                </div>
                               </div>
+                              {% if flight.cpc or flight.cpm %}
+                                <p class="text-center text-muted small">${{ flight.value_remaining|floatformat:2 }} / ${{ flight.projected_total_value|floatformat:2 }} remaining</p>
+                              {% endif %}
                             </td>
                           </tr>
                         {% endfor %}


### PR DESCRIPTION
The progress bar will now show the percent complete (eg. `85%`) and then the details will appear under the progress bar.

![Screenshot from 2021-11-16 11-40-52](https://user-images.githubusercontent.com/185043/142056185-eae495e6-a015-4a1b-a1b8-7202fd60433c.png)

