### PR TITLE
Initial DJStripe integration

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -1,6 +1,5 @@
 """Celery tasks for the ad server."""
 import datetime
-import json
 import logging
 from collections import defaultdict
 
@@ -285,12 +284,9 @@ def daily_update_keywords(day=None):
             ):
                 continue
 
-            keywords = json.loads(values["keywords"])
-            publisher_keywords = set(keywords)
+            publisher_keywords = set(values["keywords"])
 
-            flight_targeting = json.loads(
-                values["advertisement__flight__targeting_parameters"]
-            )
+            flight_targeting = values["advertisement__flight__targeting_parameters"]
             flight_keywords = set(flight_targeting.get("include_keywords", {}))
 
             matched_keywords = publisher_keywords & flight_keywords
@@ -342,7 +338,7 @@ def daily_update_regiontopic(day=None):  # pylint: disable=too-many-branches
             if not (values["keywords"] and values["country"]):
                 continue
 
-            keywords = json.loads(values["keywords"])
+            keywords = values["keywords"]
             country = values["country"]
             ad = values["advertisement"]
             publisher_keywords = set(keywords)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -354,7 +354,22 @@ REST_FRAMEWORK = {
 STRIPE_SECRET_KEY = env("STRIPE_SECRET_KEY", default=None)
 STRIPE_CONNECT_CLIENT_ID = env("STRIPE_CONNECT_CLIENT_ID", default=None)
 stripe.api_key = STRIPE_SECRET_KEY
-stripe.api_version = "2020-03-02"
+stripe.api_version = "2020-08-27"
+
+# Needed for dj-stripe
+# https://dj-stripe.readthedocs.io/
+STRIPE_LIVE_SECRET_KEY = STRIPE_SECRET_KEY
+STRIPE_TEST_SECRET_KEY = STRIPE_SECRET_KEY
+STRIPE_LIVE_MODE = False  # Set to True in production
+DJSTRIPE_WEBHOOK_SECRET = env("STRIPE_WEBHOOK_SECRET", default=None)
+DJSTRIPE_FOREIGN_KEY_TO_FIELD = "id"
+if not DJSTRIPE_WEBHOOK_SECRET:
+    # This is less optimal than setting the webhook secret
+    # However, the app won't start without the secret
+    # with this setting set to the default
+    DJSTRIPE_WEBHOOK_VALIDATION = "retrieve_event"
+if STRIPE_LIVE_SECRET_KEY:
+    INSTALLED_APPS += ["djstripe"]
 
 
 # Slack

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -180,3 +180,6 @@ ADSERVER_STICKY_DECISION_DURATION = env.int(
 GEOIP_PATH = env("GEOIP_GEOLITE2_PATH", default=GEOIP_PATH)
 GEOIP_CITY = env("GEOIP_GEOLITE2_CITY_FILENAME", default="GeoLite2-City.mmdb")
 GEOIP_COUNTRY = env("GEOIP_GEOLITE2_COUNTRY_FILENAME", default="GeoLite2-Country.mmdb")
+
+# Stripe settings for dj-stripe
+STRIPE_LIVE_MODE = True

--- a/config/urls.py
+++ b/config/urls.py
@@ -46,6 +46,11 @@ if settings.ADSERVER_ADMIN_URL:
     # If no ADSERVER_ADMIN_URL is specified, the Django admin is disabled
     urlpatterns += [path(r"{}/".format(settings.ADSERVER_ADMIN_URL), admin.site.urls)]
 
+if "djstripe" in settings.INSTALLED_APPS:
+    urlpatterns += [
+        path(r"stripe/", include("djstripe.urls", namespace="djstripe")),
+    ]
+
 urlpatterns += [
     path(r"accounts/", include("allauth.urls")),
     path(r"", include("adserver.urls")),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,7 +43,7 @@ IP2Proxy==3.0.0
 # Countries helper used in ad targeting
 django-countries==5.4
 
-jsonfield==2.0.2
+jsonfield==3.1.0
 bleach==3.3.0
 
 # Security features
@@ -54,6 +54,7 @@ django-slack==5.16.2
 
 # Stripe for payments
 stripe>=2.48.0,<3.0
+dj-stripe==2.5.1
 
 # JWT used by Metabase embedding
 PyJWT==2.1.0


### PR DESCRIPTION
This initial PR only adds the stripe models to our database. 


## How does this work
[DJStripe](https://dj-stripe.readthedocs.io/) is a Stripe sponsored but independent project since Aug 2020. It works by having local database models that mirror the data in Stripe. When Stripe receives changes (say a customer pays an invoice via ACH), Stripe will send a webhook to our djstripe so our local copy stays up to date. In this way, it will be possible for our application to check whether invoices have been paid or are overdue as easily as querying the database.

## Testing locally

* Set the Stripe test key from https://dashboard.stripe.com/test/apikeys into `.envs/local/django` in the `STRIPE_SECRET_KEY` setting.
* Run the following:
    ```
    make dockerbuild      # rebuild your docker image with djstripe and deps
    make dockershell      # get a shell to the docker image
    ./manage.py migrate   # create the stripe tables in the DB
    ./manage.py djstripe_sync_models      # sync data from stripe to the DB
    ```
* Browse the Stripe data in the Django admin: http://ethicaladserver.lan:5000/admin/djstripe/

## Deploying to prod

* We already set the stripe secret key in prod so we don't need to do anything there.
* Create a Stripe webhook in https://dashboard.stripe.com/webhooks that points to `https://server.ethicalads.io/stripe/webhook/`
* Set the webhook secret into `DJSTRIPE_WEBHOOK_SECRET`

## Next steps
The next steps are:

* Create FKs from our models to these Stripe models:
    * Advertiser -> stripe.Customer
    * Flight m2m-> stripe.Invoice
    * Flight -> stripe.Coupon?
    * Publisher -> stripe.Account?
* Migrate our existing data from using stripe IDs to use the FKs