### PR TITLE
Disable metabase restart

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -88,7 +88,6 @@ services:
 
   metabase:
     image: metabase/metabase
-    restart: always
     ports:
       - ${ETHICALADS_METABASE_PORT:-3000}:3000
     volumes:


### PR DESCRIPTION
This caused metabase to start whenever I started docker,
which was causing a lot of CPU overhead.

I'm curious if we even want metabase locally by default?
I've never used it, and it seems like a heavy thing to run on all dev instances.