### PR TITLE
Distinct away duplicate ad types

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -396,7 +396,7 @@ class Campaign(TimeStampedModel, IndestructibleModel):
         )
         if exclude_deprecated:
             queryset = queryset.exclude(deprecated=True)
-        return queryset
+        return queryset.distinct()
 
     def total_value(self):
         """Calculate total cost/revenue for all ads/flights in this campaign."""


### PR DESCRIPTION
This can return duplicate ad types if an ad type applies to multiple publisher groups.

## Screenshot
![Screenshot from 2022-01-19 14-35-43](https://user-images.githubusercontent.com/185043/150229506-454acdc9-d429-422d-852f-473c5122c693.png)

