### PR TITLE
Tone down the link error message.

### DIFF
--- a/adserver/mixins.py
+++ b/adserver/mixins.py
@@ -83,7 +83,9 @@ class AdvertisementValidateLinkMixin:
     VALIDATE_LINK_MESSAGES = {
         "error": _(
             "Your link returned an error with status %s. "
-            "Unless your landing page is not live yet, this is probably a mistake."
+            "Double check that your landing page is live. "
+            "Occasionally, landing pages block automated access "
+            "and that can result in a false positive."
         ),
         "redirect": _(
             "Your link redirected to a page (%s) that did successfully load. "


### PR DESCRIPTION
I've seen a couple false positives here and we got a report from an advertiser yesterday. The other option is to spoof the user agent to check. I don't love doing that but it isn't the worst plan.