### PR TITLE
Expose View Rate to publishers.

### DIFF
--- a/adserver/templates/adserver/reports/includes/publisher-report-table.html
+++ b/adserver/templates/adserver/reports/includes/publisher-report-table.html
@@ -27,12 +27,12 @@
         <td class="text-right">{{ result.clicks|intcomma }}</td>
         <td class="text-right">{{ result.ctr|floatformat:3 }}%</td>
         <td class="text-right">${{ result.revenue_share|floatformat:2|intcomma }}</td>
+        <td class="text-right">{{ result.view_rate|floatformat:1 }}%</td>
         {% if "adserver.staff_publisher_fields" in perms %}
           <td class="text-right">${{ result.our_revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.ecpm|floatformat:2 }}</td>
           <td class="text-right">{{ result.fill_rate|floatformat:1 }}%</td>
-          <td class="text-right">{{ result.view_rate|floatformat:1 }}%</td>
         {% endif %}
       </tr>
       {% endif %}
@@ -43,12 +43,12 @@
       <td class="text-right"><strong>{{ report.total.clicks|intcomma }}</strong></td>
       <td class="text-right"><strong>{{ report.total.ctr|floatformat:3 }}%</strong></td>
       <td class="text-right"><strong>${{ report.total.revenue_share|floatformat:2|intcomma }}</strong></td>
+      <td class="text-right"><strong>{{ report.total.view_rate|floatformat:1 }}%</strong></td>
       {% if "adserver.staff_publisher_fields" in perms %}
         <td class="text-right"><strong>${{ report.total.our_revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.ecpm|floatformat:2 }}</strong></td>
         <td class="text-right"><strong>{{ report.total.fill_rate|floatformat:1 }}%</strong></td>
-        <td class="text-right"><strong>{{ report.total.view_rate|floatformat:1 }}%</strong></td>
       {% endif %}
     </tr>
   </tbody>

--- a/adserver/templates/adserver/reports/includes/publisher-report-table.html
+++ b/adserver/templates/adserver/reports/includes/publisher-report-table.html
@@ -9,12 +9,12 @@
       <th class="text-right"><strong>{% trans 'Clicks' %}</strong></th>
       <th class="text-right"><strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
       <th class="text-right"><strong>{% trans 'Revenue' %}</strong></th>
+      <th class="text-right"><strong>{% blocktrans %}<abbr title="% of traffic that viewed the ad">View Rate</abbr>{% endblocktrans %}</strong></th>
       {% if "adserver.staff_publisher_fields" in perms %}
         <th class="text-right staff-only"><strong>{% trans 'Our&nbsp;Rev' %}</strong></th>
         <th class="text-right staff-only"><strong>{% trans 'Total&nbsp;Rev' %}</strong></th>
         <th class="text-right staff-only"><strong>{% blocktrans %}Total <abbr title="Effective cost per thousand impressions">eCPM</abbr>{% endblocktrans %}</strong></th>
         <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="% of traffic with a paid ad">Fill Rate</abbr>{% endblocktrans %}</strong></th>
-        <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="% of traffic that views ads we offered">View Rate</abbr>{% endblocktrans %}</strong></th>
       {% endif %}
     </tr>
   </thead>


### PR DESCRIPTION
I wonder if we need additional context here,
since this will almost never be 100% for various reasons (eg. a user loads a page then closes the browser).

I do think exposing this data will motivate publishers to improve their placements though,
if we can communicate it effectively.