### PR TITLE
Use Cloudflare GeoIP and IP canonicalization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     exclude: migrations
     language_version: python3
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.3.5
+  rev: v2.7.1
   hooks:
   - id: reorder-python-imports
     language_version: python3

--- a/adserver/api/mixins.py
+++ b/adserver/api/mixins.py
@@ -2,7 +2,6 @@
 from django.conf import settings
 
 from ..utils import generate_client_id
-from ..utils import GeolocationTuple
 from ..utils import get_client_ip
 from ..utils import get_client_user_agent
 from ..utils import get_geolocation
@@ -11,7 +10,10 @@ from ..utils import get_geolocation
 class GeoIpMixin:
 
     """
-    A mixin that attaches IP, User Agent, and Geolocation data to the request.
+    A mixin that attaches updated IP, User Agent, and Geolocation data to the request.
+
+    These need to be updated because the person seeing the ad may not be
+    the person requesting the ad.
 
     In debug mode and for staff users, this data is also set as HTTP
     headers in the response. This is useful for debugging geolocation issues.
@@ -37,13 +39,9 @@ class GeoIpMixin:
             request.ip_address, request.user_agent
         )
 
-        # Geolocate the actual IP address
-        geo_data = get_geolocation(request, request.ip_address)
-        country_code = geo_data["country_code"]
-        region_code = geo_data["region"]
-        metro_code = geo_data["dma_code"]
-
-        request.geo = GeolocationTuple(country_code, region_code, metro_code)
+        # Geolocate the actual IP address (not the requestor's IP)
+        # This is needed for the case of a server requesting ads on a user's behalf
+        request.geo = get_geolocation(request)
 
     def finalize_response(self, request, response, *args, **kwargs):
         """Log data set on the request to HTTP headers in DEBUG or for staff."""
@@ -56,10 +54,8 @@ class GeoIpMixin:
             response["X-Adserver-ClientID"] = str(
                 getattr(request, "advertising_client_id", "")
             )
-            geo = getattr(request, "geo", None)
-            if geo:
-                response["X-Adserver-Country"] = str(geo.country_code)
-                response["X-Adserver-Region"] = str(geo.region_code)
-                response["X-Adserver-Metro"] = str(geo.metro_code)
+            response["X-Adserver-Country"] = str(request.geo.country)
+            response["X-Adserver-Region"] = str(request.geo.region)
+            response["X-Adserver-Metro"] = str(request.geo.metro)
 
         return response

--- a/adserver/api/mixins.py
+++ b/adserver/api/mixins.py
@@ -38,12 +38,10 @@ class GeoIpMixin:
         )
 
         # Geolocate the actual IP address
-        country_code = region_code = metro_code = None
-        geo_data = get_geolocation(request.ip_address)
-        if geo_data:
-            country_code = geo_data["country_code"]
-            region_code = geo_data["region"]
-            metro_code = geo_data["dma_code"]
+        geo_data = get_geolocation(request, request.ip_address)
+        country_code = geo_data["country_code"]
+        region_code = geo_data["region"]
+        metro_code = geo_data["dma_code"]
 
         request.geo = GeolocationTuple(country_code, region_code, metro_code)
 

--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -36,9 +36,7 @@ class BaseAdDecisionBackend:
 
         self.ad_types = [p["ad_type"] for p in self.placements]
 
-        self.country_code = request.geo.country_code
-        self.region_code = request.geo.region_code
-        self.metro_code = request.geo.metro_code
+        self.geolocation = request.geo
 
         # Optional parameters
         self.keywords = kwargs.get("keywords", []) or []
@@ -219,7 +217,7 @@ class AdvertisingEnabledBackend(BaseAdDecisionBackend):
             return True
 
         # Skip if we aren't meant to show to this country/state/dma
-        if not flight.show_to_geo(self.country_code, self.region_code, self.metro_code):
+        if not flight.show_to_geo(self.geolocation):
             return False
 
         # Skip if we aren't meant to show to these keywords

--- a/adserver/middleware.py
+++ b/adserver/middleware.py
@@ -33,6 +33,7 @@ class CloudflareMiddleware:
     Sets request.ip_address and request.country from Cloudflare headers.
 
     See: https://developers.cloudflare.com/fundamentals/get-started/http-request-headers
+    See: https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-Cloudflare-IP-Geolocation
 
     SECURITY NOTE: This middleware *SHOULD BE DISABLED* if not running on Cloudflare.
         Otherwise these headers are spoofable and could result in invalid traffic.
@@ -82,6 +83,7 @@ class CloudflareMiddleware:
         country_code = request.headers.get(self.COUNTRY_HEADER, None)
         if country_code == "XX":
             # CF always adds the header and sets "XX" if it can't geolocate
+            # CF uses "T1" for Tor traffic
             country_code = None
 
         return country_code

--- a/adserver/middleware.py
+++ b/adserver/middleware.py
@@ -5,6 +5,9 @@ import socket
 
 from django.conf import settings
 
+from .utils import GeolocationData
+from .utils import get_geoipdb_geolocation
+
 
 log = logging.getLogger(__name__)  # noqa
 
@@ -28,69 +31,35 @@ class ServerInfoMiddleware:
         return response
 
 
-class CloudflareMiddleware:
+class IpAddressMiddleware:
 
     """
-    Sets request.ip_address and request.country from Cloudflare headers.
+    Sets the IP address of the user onto the request object.
 
-    See: https://developers.cloudflare.com/fundamentals/get-started/http-request-headers
-    See: https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-Cloudflare-IP-Geolocation
-
-    SECURITY NOTE: This middleware *SHOULD BE DISABLED* if not running on Cloudflare.
-        Otherwise these headers are spoofable and could result in invalid traffic.
-        Also, Cloudflare IP Geolocation must be enabled.
+    In production, you probably want to use the CloudflareIpAddressMiddleware
+    or the XForwardedForMiddleware depending on your setup.
     """
 
-    COUNTRY_HEADER = "CF-IPCountry"
-    IP_HEADER = "CF-Connecting-IP"
+    PROVIDER_NAME = "REMOTE_ADDR header"
 
     def __init__(self, get_response):
         """One-time configuration and initialization."""
         self.get_response = get_response
 
     def __call__(self, request):
-        """Sets request.ip_address and request.country based on Cloudflare headers."""
-        request.ip_address = self._get_ip_address(request)
-        request.user_country = self._get_country(request)
+        """Sets the IP address of the user onto the request object."""
+        request.ip_address = self.get_ip_address(request)
         response = self.get_response(request)
 
-        if request.user_country and (settings.DEBUG or request.user.is_staff):
-            response["X-Adserver-GeoIPProvider"] = "Cloudflare"
-
+        if settings.DEBUG or request.user.is_staff:
+            response["X-Adserver-IpAddress-Provider"] = self.PROVIDER_NAME
         return response
 
-    def _get_ip_address(self, request):
-        ip = request.headers.get(self.IP_HEADER, None)
-
-        if ip:
-            try:
-                ipaddress.ip_address(ip)
-            except ValueError:
-                # This should be OK to log since this is a spoofed address
-                log.warning(
-                    "Invalid IP in Cloudflare headers. "
-                    "This header is probably untrustworthy so the CloudflareMiddleware should be disabled. "
-                    "%s=%s",
-                    self.IP_HEADER,
-                    ip,
-                )
-                ip = None
-        if not ip:
-            ip = request.META.get("REMOTE_ADDR", "")
-
-        return ip
-
-    def _get_country(self, request):
-        country_code = request.headers.get(self.COUNTRY_HEADER, None)
-        if country_code == "XX":
-            # CF always adds the header and sets "XX" if it can't geolocate
-            # CF uses "T1" for Tor traffic
-            country_code = None
-
-        return country_code
+    def get_ip_address(self, request):
+        return request.META.get("REMOTE_ADDR", None)
 
 
-class XForwardedForMiddleware:
+class XForwardedForMiddleware(IpAddressMiddleware):
 
     """
     Sets request.ip_address with the client's IP from x-forwarded-for.
@@ -102,20 +71,11 @@ class XForwardedForMiddleware:
         header is not guaranteed from the load balancer as a user could fake it.
     """
 
+    PROVIDER_NAME = "X-Forwarded-For"
     HEADER_NAME = "X-Forwarded-For"
 
-    def __init__(self, get_response):
-        """One-time configuration and initialization."""
-        self.get_response = get_response
-
-    def __call__(self, request):
-        """Sets request.ip_address based on x-forwarded-for."""
-        request.ip_address = self._get_ip_address(request)
-        response = self.get_response(request)
-        return response
-
-    def _get_ip_address(self, request):
-        client_ip = None
+    def get_ip_address(self, request):
+        ip = super().get_ip_address(request)
         x_forwarded_for = request.headers.get(self.HEADER_NAME, None)
         if x_forwarded_for:
             # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
@@ -130,6 +90,7 @@ class XForwardedForMiddleware:
 
             try:
                 ipaddress.ip_address(client_ip)
+                ip = client_ip
             except ValueError:
                 # This should be OK to log since this is a spoofed address
                 log.warning(
@@ -138,8 +99,110 @@ class XForwardedForMiddleware:
                     "x-forwarded-for=%s",
                     x_forwarded_for,
                 )
-                client_ip = None
-        if not client_ip:
-            client_ip = request.META.get("REMOTE_ADDR", "")
 
-        return client_ip
+        return ip
+
+
+class CloudflareIpAddressMiddleware(IpAddressMiddleware):
+
+    """
+    Sets request.ip_address from Cloudflare headers.
+
+    See: https://developers.cloudflare.com/fundamentals/get-started/http-request-headers
+
+    SECURITY NOTE: This middleware *SHOULD BE DISABLED* if not running on Cloudflare.
+        Otherwise these headers are spoofable and could result in invalid traffic.
+    """
+
+    PROVIDER_NAME = "Cloudflare"
+    IP_HEADER = "CF-Connecting-IP"
+
+    def get_ip_address(self, request):
+        ip = super().get_ip_address(request)
+        cf_ip = request.headers.get(self.IP_HEADER, None)
+
+        if cf_ip:
+            try:
+                ipaddress.ip_address(cf_ip)
+                ip = cf_ip
+            except ValueError:
+                # This should be OK to log since this is a spoofed address
+                log.warning(
+                    "Invalid IP in Cloudflare headers. "
+                    "This header is probably untrustworthy so the CloudflareIpAddressMiddleware should be disabled. "
+                    "%s=%s",
+                    self.IP_HEADER,
+                    cf_ip,
+                )
+
+        return ip
+
+
+class GeoIpMiddleware:
+
+    """
+    Sets a request.geo dictionary onto the request object.
+
+    This middleware doesn't have any provider and just sets null
+    for all the geolocation data. It isn't useful except in development/testing.
+
+    In production, you probably want to use the CloudflareGeoIpMiddleware
+    or the GeoIpDbMiddleware depending on your setup.
+    """
+
+    PROVIDER_NAME = "None"
+
+    def __init__(self, get_response):
+        """One-time configuration and initialization."""
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """Sets the geolocation data of the user onto the request object."""
+        request.geo = self.get_geoip(request)
+        response = self.get_response(request)
+
+        if settings.DEBUG or request.user.is_staff:
+            response["X-Adserver-GeoIp-Provider"] = self.PROVIDER_NAME
+        return response
+
+    def get_geoip(self, request):
+        return GeolocationData()
+
+
+class CloudflareGeoIpMiddleware(GeoIpMiddleware):
+
+    """
+    Sets request.geo from Cloudflare headers.
+
+    See: https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-Cloudflare-IP-Geolocation
+
+    SECURITY NOTE: This middleware *SHOULD BE DISABLED* if not running on Cloudflare.
+        Otherwise these headers are spoofable and could result in invalid traffic.
+        Also, Cloudflare IP Geolocation must be enabled.
+    """
+
+    COUNTRY_HEADER = "CF-IPCountry"
+    PROVIDER_NAME = "Cloudflare"
+
+    def get_geoip(self, request):
+        geo = super().get_geoip(request)
+
+        country_code = request.headers.get(self.COUNTRY_HEADER, None)
+        if country_code == "XX":
+            # CF always adds the header and sets "XX" if it can't geolocate
+            # CF uses "T1" for Tor traffic which should be handled by our system
+            country_code = None
+
+        geo.country = country_code
+
+        return geo
+
+
+class GeoIpDatabaseMiddleware(GeoIpMiddleware):
+
+    """Sets request.geo using a GeoIP database."""
+
+    PROVIDER_NAME = "GeoIP DB"
+
+    def get_geoip(self, request):
+        return get_geoipdb_geolocation(request)

--- a/adserver/middleware.py
+++ b/adserver/middleware.py
@@ -1,5 +1,90 @@
 """Ad server middleware."""
+import ipaddress
+import logging
 import socket
+
+from django.conf import settings
+
+
+log = logging.getLogger(__name__)  # noqa
+
+
+class ServerInfoMiddleware:
+
+    """Sets informational headers for staff users or in DEBUG mode."""
+
+    def __init__(self, get_response):
+        """One-time configuration and initialization."""
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """Sets headers for staff users or in debug mode."""
+        response = self.get_response(request)
+
+        if settings.DEBUG or request.user.is_staff:
+            response["X-Server"] = socket.gethostname()
+            response["X-Adserver-Version"] = settings.ADSERVER_VERSION
+        return response
+
+
+class CloudflareMiddleware:
+
+    """
+    Sets request.ip_address and request.country from Cloudflare headers.
+
+    See: https://developers.cloudflare.com/fundamentals/get-started/http-request-headers
+
+    SECURITY NOTE: This middleware *SHOULD BE DISABLED* if not running on Cloudflare.
+        Otherwise these headers are spoofable and could result in invalid traffic.
+        Also, Cloudflare IP Geolocation must be enabled.
+    """
+
+    COUNTRY_HEADER = "CF-IPCountry"
+    IP_HEADER = "CF-Connecting-IP"
+
+    def __init__(self, get_response):
+        """One-time configuration and initialization."""
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """Sets request.ip_address and request.country based on Cloudflare headers."""
+        request.ip_address = self._get_ip_address(request)
+        request.user_country = self._get_country(request)
+        response = self.get_response(request)
+
+        if request.user_country and (settings.DEBUG or request.user.is_staff):
+            response["X-Adserver-GeoIPProvider"] = "Cloudflare"
+
+        return response
+
+    def _get_ip_address(self, request):
+        ip = request.headers.get(self.IP_HEADER, None)
+
+        if ip:
+            try:
+                ipaddress.ip_address(ip)
+            except ValueError:
+                # This should be OK to log since this is a spoofed address
+                log.warning(
+                    "Invalid IP in Cloudflare headers. "
+                    "This header is probably untrustworthy so the CloudflareMiddleware should be disabled. "
+                    "%s=%s",
+                    self.IP_HEADER,
+                    ip,
+                )
+                ip = None
+        if not ip:
+            ip = request.META.get("REMOTE_ADDR", "")
+
+        return ip
+
+    def _get_country(self, request):
+        country_code = request.headers.get(self.COUNTRY_HEADER, None)
+        if country_code == "XX":
+            # CF always adds the header and sets "XX" if it can't geolocate
+            country_code = None
+
+        return country_code
 
 
 class XForwardedForMiddleware:
@@ -14,6 +99,8 @@ class XForwardedForMiddleware:
         header is not guaranteed from the load balancer as a user could fake it.
     """
 
+    HEADER_NAME = "X-Forwarded-For"
+
     def __init__(self, get_response):
         """One-time configuration and initialization."""
         self.get_response = get_response
@@ -22,11 +109,11 @@ class XForwardedForMiddleware:
         """Sets request.ip_address based on x-forwarded-for."""
         request.ip_address = self._get_ip_address(request)
         response = self.get_response(request)
-        response["X-Server"] = socket.gethostname()
         return response
 
     def _get_ip_address(self, request):
-        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", None)
+        client_ip = None
+        x_forwarded_for = request.headers.get(self.HEADER_NAME, None)
         if x_forwarded_for:
             # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
             # The client's IP will be the first one.
@@ -37,7 +124,19 @@ class XForwardedForMiddleware:
             # But be careful about IPv6 addresses
             if client_ip.count(":") == 1:
                 client_ip = client_ip.rsplit(":", maxsplit=1)[0]
-        else:
+
+            try:
+                ipaddress.ip_address(client_ip)
+            except ValueError:
+                # This should be OK to log since this is a spoofed address
+                log.warning(
+                    "Invalid IP from X-Forwarded-For. "
+                    "This header is probably untrustworthy so the XForwardedForMiddleware should be disabled. "
+                    "x-forwarded-for=%s",
+                    x_forwarded_for,
+                )
+                client_ip = None
+        if not client_ip:
             client_ip = request.META.get("REMOTE_ADDR", "")
 
         return client_ip

--- a/adserver/middleware.py
+++ b/adserver/middleware.py
@@ -21,8 +21,9 @@ class ServerInfoMiddleware:
         """Sets headers for staff users or in debug mode."""
         response = self.get_response(request)
 
+        response["X-Server"] = socket.gethostname()
+
         if settings.DEBUG or request.user.is_staff:
-            response["X-Server"] = socket.gethostname()
             response["X-Adserver-Version"] = settings.ADSERVER_VERSION
         return response
 

--- a/adserver/mixins.py
+++ b/adserver/mixins.py
@@ -11,12 +11,13 @@ from django.db import models
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
-from django_countries import countries
 
 from .constants import ALL_CAMPAIGN_TYPES
 from .constants import CAMPAIGN_TYPES
 from .models import Advertiser
 from .models import Publisher
+from .utils import COUNTRY_DICT
+
 
 log = logging.getLogger(__name__)  # noqa
 
@@ -187,8 +188,6 @@ class GeoReportMixin:
         return queryset
 
     def get_country_options(self, queryset):
-        countries_dict = dict(countries)
-
         # The order_by here is to enable distinct to work
         # https://docs.djangoproject.com/en/dev/ref/models/querysets/#distinct
         country_list = (
@@ -198,11 +197,10 @@ class GeoReportMixin:
             .distinct()[: self.LIMIT]
         )
 
-        return ((cc, countries_dict.get(cc, "Unknown")) for cc in country_list)
+        return ((cc, COUNTRY_DICT.get(cc, "Unknown")) for cc in country_list)
 
     def get_country_name(self, country):
-        countries_dict = dict(countries)
-        return countries_dict.get(country)
+        return COUNTRY_DICT.get(country)
 
 
 class KeywordReportMixin:

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -36,6 +36,7 @@ from ..models import Offer
 from ..models import Publisher
 from ..models import PublisherGroup
 from ..models import View
+from ..utils import GeolocationData
 
 
 class ApiPermissionTest(TestCase):
@@ -1622,10 +1623,15 @@ class TestProxyViews(BaseApiTest):
 
         Offer.objects.filter(id=self.offer["nonce"]).update(viewed=True)
 
-        resp = self.client.get(self.click_url, HTTP_CF_IPCountry="CA")
+        with self.modify_settings(
+            MIDDLEWARE={
+                "append": "adserver.middleware.CloudflareGeoIpMiddleware",
+            }
+        ):
+            resp = self.client.get(self.click_url, HTTP_CF_IPCountry="CA")
 
-        self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp["X-Adserver-Reason"], "Billed click")
+            self.assertEqual(resp.status_code, 302)
+            self.assertEqual(resp["X-Adserver-Reason"], "Billed click")
 
     def test_click_tracking_invalid_targeting(self):
         self.ad.flight.targeting_parameters = {"include_countries": ["CA"]}
@@ -1648,33 +1654,21 @@ class TestProxyViews(BaseApiTest):
         get(View, offer=self.offer)
 
         with mock.patch("adserver.views.get_geolocation") as get_geo:
-            get_geo.return_value = {
-                "country_code": "US",
-                "region": "ID",
-                "dma_code": 757,  # Boise
-            }
+            get_geo.return_value = GeolocationData("US", "ID", 757)  # Boise, ID
             resp = self.client.get(self.click_url)
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp["X-Adserver-Reason"], "Invalid targeting impression")
 
         with mock.patch("adserver.views.get_geolocation") as get_geo:
-            get_geo.return_value = {
-                "country_code": "US",
-                "region": "CA",
-                "dma_code": 807,  # Bay Area
-            }
+            get_geo.return_value = GeolocationData("US", "CA", 807)  # Bay Area
             resp = self.client.get(self.click_url)
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp["X-Adserver-Reason"], "Invalid targeting impression")
 
         with mock.patch("adserver.views.get_geolocation") as get_geo:
-            get_geo.return_value = {
-                "country_code": "US",
-                "region": "CA",
-                "dma_code": 825,  # San Diego
-            }
+            get_geo.return_value = GeolocationData("US", "CA", 825)  # San Diego, CA
             resp = self.client.get(self.click_url)
 
         self.assertEqual(resp.status_code, 302)

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -1616,19 +1616,24 @@ class TestProxyViews(BaseApiTest):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp["X-Adserver-Reason"], "Ratelimited click impression")
 
+    def test_click_tracking_valid_country_targeting(self):
+        self.ad.flight.targeting_parameters = {"include_countries": ["CA"]}
+        self.ad.flight.save()
+
+        Offer.objects.filter(id=self.offer["nonce"]).update(viewed=True)
+
+        resp = self.client.get(self.click_url, HTTP_CF_IPCountry="CA")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["X-Adserver-Reason"], "Billed click")
+
     def test_click_tracking_invalid_targeting(self):
         self.ad.flight.targeting_parameters = {"include_countries": ["CA"]}
         self.ad.flight.save()
 
         Offer.objects.filter(id=self.offer["nonce"]).update(viewed=True)
 
-        with mock.patch("adserver.views.get_geolocation") as get_geo:
-            get_geo.return_value = {
-                "country_code": "FR",
-                "region": None,
-                "dma_code": None,
-            }
-            resp = self.client.get(self.click_url)
+        resp = self.client.get(self.click_url, HTTP_CF_IPCountry="FR")
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp["X-Adserver-Reason"], "Invalid targeting impression")

--- a/adserver/tests/test_decision_engine.py
+++ b/adserver/tests/test_decision_engine.py
@@ -22,7 +22,7 @@ from ..models import Advertisement
 from ..models import Campaign
 from ..models import Flight
 from ..models import Publisher
-from ..utils import GeolocationTuple
+from ..utils import GeolocationData
 from ..utils import get_ad_day
 
 
@@ -113,7 +113,7 @@ class DecisionEngineTests(TestCase):
 
         self.factory = RequestFactory()
         self.request = self.factory.get("/")
-        self.request.geo = GeolocationTuple("US", "CA", None)
+        self.request.geo = GeolocationData("US", "CA", None)
 
         self.backend = AdvertisingEnabledBackend(
             request=self.request, placements=self.placements, publisher=self.publisher
@@ -230,23 +230,23 @@ class DecisionEngineTests(TestCase):
         ad, _ = self.backend.get_ad_and_placement()
         self.assertTrue(ad in (self.advertisement1, self.advertisement2))
 
-        self.backend.country_code = "US"
+        self.backend.geolocation = GeolocationData("US")
         ad, _ = self.backend.get_ad_and_placement()
         self.assertEqual(ad, self.advertisement1)
 
-        self.backend.country_code = "MX"
+        self.backend.geolocation = GeolocationData("MX")
         ad, _ = self.backend.get_ad_and_placement()
         self.assertTrue(ad in (self.advertisement1, self.advertisement2))
 
-        self.backend.country_code = "FO"
+        self.backend.geolocation = GeolocationData("FO")
         ad, _ = self.backend.get_ad_and_placement()
         self.assertEqual(ad, self.advertisement2)
 
-        self.backend.country_code = "AZ"
+        self.backend.geolocation = GeolocationData("AZ")
         ad, _ = self.backend.get_ad_and_placement()
         self.assertIsNone(ad)
 
-        self.backend.country_code = "RANDOM"
+        self.backend.geolocation = GeolocationData("T1")
         ad, _ = self.backend.get_ad_and_placement()
         self.assertEqual(ad, self.advertisement2)
 

--- a/adserver/tests/test_middleware.py
+++ b/adserver/tests/test_middleware.py
@@ -6,7 +6,8 @@ from django_dynamic_fixture import get
 class TestMiddleware(TestCase):
     def test_server_middleware(self):
         response = self.client.get("/")
-        self.assertFalse("X-Server" in response)
+        self.assertTrue("X-Server" in response)
+        self.assertFalse("X-Adserver-Version" in response)
 
         # Login as staff
         staff_user = get(get_user_model(), is_staff=True, username="staff-user")
@@ -14,6 +15,7 @@ class TestMiddleware(TestCase):
 
         response = self.client.get("/")
         self.assertTrue("X-Server" in response)
+        self.assertTrue("X-Adserver-Version" in response)
 
     def test_cloudflare_middleware(self):
         response = self.client.get("/")

--- a/adserver/tests/test_middleware.py
+++ b/adserver/tests/test_middleware.py
@@ -93,6 +93,20 @@ class TestMiddleware(TestCase):
             request = response.wsgi_request
             self.assertEqual(request.ip_address, "127.0.0.1")
 
+            # Login as staff
+            staff_user = get(get_user_model(), is_staff=True, username="staff-user")
+            self.client.force_login(staff_user)
+
+            # The provider header should be present for staff
+            ip = "10.10.10.10"
+            response = self.client.get("/", HTTP_X_FORWARDED_FOR=ip)
+            request = response.wsgi_request
+            self.assertEqual(request.ip_address, ip)
+            self.assertTrue("X-Adserver-IpAddress-Provider" in response)
+            self.assertEqual(
+                response["X-Adserver-IpAddress-Provider"], "X-Forwarded-For"
+            )
+
     def test_cloudflare_geoip_middleware(self):
         with self.modify_settings(
             MIDDLEWARE={

--- a/adserver/tests/test_middleware.py
+++ b/adserver/tests/test_middleware.py
@@ -21,6 +21,7 @@ class TestMiddleware(TestCase):
         with self.modify_settings(
             MIDDLEWARE={
                 "append": "adserver.middleware.CloudflareIpAddressMiddleware",
+                "remove": "adserver.middleware.IpAddressMiddleware",
             }
         ):
             response = self.client.get("/")
@@ -55,6 +56,7 @@ class TestMiddleware(TestCase):
         with self.modify_settings(
             MIDDLEWARE={
                 "append": "adserver.middleware.XForwardedForMiddleware",
+                "remove": "adserver.middleware.IpAddressMiddleware",
             }
         ):
             response = self.client.get("/")
@@ -111,6 +113,7 @@ class TestMiddleware(TestCase):
         with self.modify_settings(
             MIDDLEWARE={
                 "append": "adserver.middleware.CloudflareGeoIpMiddleware",
+                "remove": "adserver.middleware.GeoIpMiddleware",
             }
         ):
             country = "CA"
@@ -139,6 +142,7 @@ class TestMiddleware(TestCase):
         with self.modify_settings(
             MIDDLEWARE={
                 "append": "adserver.middleware.GeoIpDatabaseMiddleware",
+                "remove": "adserver.middleware.GeoIpMiddleware",
             }
         ):
             # Note: Because we can't ship the GeoIP database,

--- a/adserver/tests/test_middleware.py
+++ b/adserver/tests/test_middleware.py
@@ -1,34 +1,94 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django_dynamic_fixture import get
 
 
 class TestMiddleware(TestCase):
-    def test_xforwarded_for_middleware(self):
+    def test_server_middleware(self):
+        response = self.client.get("/")
+        self.assertFalse("X-Server" in response)
+
+        # Login as staff
+        staff_user = get(get_user_model(), is_staff=True, username="staff-user")
+        self.client.force_login(staff_user)
+
+        response = self.client.get("/")
+        self.assertTrue("X-Server" in response)
+
+    def test_cloudflare_middleware(self):
         response = self.client.get("/")
         request = response.wsgi_request
         self.assertTrue(hasattr(request, "ip_address"))
         self.assertEqual(request.ip_address, "127.0.0.1")
 
-        response = self.client.get("/", HTTP_X_FORWARDED_FOR="10.10.10.10")
-        request = response.wsgi_request
-        self.assertEqual(request.ip_address, "10.10.10.10")
-
-        # Multiple proxies in the chain
         ip = "10.10.10.10"
-        x_forwarded_for = f"{ip}, 11.11.11.11, 12.12.12.12"
-        response = self.client.get("/", HTTP_X_FORWARDED_FOR=x_forwarded_for)
+        response = self.client.get("/", HTTP_CF_CONNECTING_IP=ip)
         request = response.wsgi_request
         self.assertEqual(request.ip_address, ip)
+        self.assertFalse("X-Adserver-GeoIPProvider" in response)
 
-        # client ip (ipv4), other clients with port
-        ip = "10.10.10.10"
-        x_forwarded_for = f"{ip}:1234, 11.11.11.11, 12.12.12.12"
-        response = self.client.get("/", HTTP_X_FORWARDED_FOR=x_forwarded_for)
+        ip = "invalid"
+        response = self.client.get("/", HTTP_CF_CONNECTING_IP=ip)
         request = response.wsgi_request
-        self.assertEqual(request.ip_address, ip)
+        self.assertEqual(request.ip_address, "127.0.0.1")
 
-        # client ip (ipv6), other clients with port
-        ip = "2001:abc:def:012:345:6789:abcd:ef12"
-        x_forwarded_for = f"{ip}, 11.11.11.11:2345, 12.12.12.12:3456"
-        response = self.client.get("/", HTTP_X_FORWARDED_FOR=x_forwarded_for)
+        country = "CA"
+        response = self.client.get("/", HTTP_CF_IPCOUNTRY=country)
         request = response.wsgi_request
-        self.assertEqual(request.ip_address, ip)
+        self.assertEqual(request.user_country, country)
+
+        country = "XX"
+        response = self.client.get("/", HTTP_CF_IPCOUNTRY=country)
+        request = response.wsgi_request
+        self.assertEqual(request.user_country, None)
+
+        # Login as staff
+        staff_user = get(get_user_model(), is_staff=True, username="staff-user")
+        self.client.force_login(staff_user)
+
+        country = "CA"
+        response = self.client.get("/", HTTP_CF_IPCOUNTRY=country)
+        self.assertEqual(response["X-Adserver-GeoIPProvider"], "Cloudflare")
+
+    def test_xforwarded_for_middleware(self):
+        with self.modify_settings(
+            MIDDLEWARE={
+                "append": "adserver.middleware.XForwardedForMiddleware",
+                "remove": "adserver.middleware.CloudflareMiddleware",
+            }
+        ):
+            response = self.client.get("/")
+            request = response.wsgi_request
+            self.assertTrue(hasattr(request, "ip_address"))
+            self.assertEqual(request.ip_address, "127.0.0.1")
+
+            response = self.client.get("/", HTTP_X_FORWARDED_FOR="10.10.10.10")
+            request = response.wsgi_request
+            self.assertEqual(request.ip_address, "10.10.10.10")
+
+            # Multiple proxies in the chain
+            ip = "10.10.10.10"
+            x_forwarded_for = f"{ip}, 11.11.11.11, 12.12.12.12"
+            response = self.client.get("/", HTTP_X_FORWARDED_FOR=x_forwarded_for)
+            request = response.wsgi_request
+            self.assertEqual(request.ip_address, ip)
+
+            # client ip (ipv4), other clients with port
+            ip = "10.10.10.10"
+            x_forwarded_for = f"{ip}:1234, 11.11.11.11, 12.12.12.12"
+            response = self.client.get("/", HTTP_X_FORWARDED_FOR=x_forwarded_for)
+            request = response.wsgi_request
+            self.assertEqual(request.ip_address, ip)
+
+            # client ip (ipv6), other clients with port
+            ip = "2001:abc:def:012:345:6789:abcd:ef12"
+            x_forwarded_for = f"{ip}, 11.11.11.11:2345, 12.12.12.12:3456"
+            response = self.client.get("/", HTTP_X_FORWARDED_FOR=x_forwarded_for)
+            request = response.wsgi_request
+            self.assertEqual(request.ip_address, ip)
+
+            # Invalid client IP
+            ip = "invalid"
+            response = self.client.get("/", HTTP_X_FORWARDED_FOR=ip)
+            request = response.wsgi_request
+            self.assertEqual(request.ip_address, "127.0.0.1")

--- a/adserver/tests/test_models.py
+++ b/adserver/tests/test_models.py
@@ -17,6 +17,7 @@ from ..models import Flight
 from ..models import Offer
 from ..models import Publisher
 from ..reports import AdvertiserReport
+from ..utils import GeolocationData
 from ..utils import get_ad_day
 from .common import BaseAdModelsTestCase
 
@@ -39,32 +40,32 @@ class TestProtectedModels(BaseAdModelsTestCase):
 class TestAdModels(BaseAdModelsTestCase):
     def test_geo_include(self):
         # Show to countries if no targeting/excludes
-        self.assertTrue(self.flight.show_to_geo("US"))
-        self.assertTrue(self.flight.show_to_geo("UK"))
-        self.assertTrue(self.flight.show_to_geo("CA"))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("US")))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("UK")))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("CA")))
 
         self.flight.targeting_parameters = {"include_countries": ["US", "UK"]}
         self.flight.save()
 
-        self.assertTrue(self.flight.show_to_geo("US"))
-        self.assertTrue(self.flight.show_to_geo("UK"))
-        self.assertFalse(self.flight.show_to_geo("CA"))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("US")))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("UK")))
+        self.assertFalse(self.flight.show_to_geo(GeolocationData("CA")))
 
         # Unknown geo
-        self.assertFalse(self.flight.show_to_geo(None))
+        self.assertFalse(self.flight.show_to_geo(GeolocationData()))
 
     def test_geo_exclude(self):
-        self.assertTrue(self.flight.show_to_geo("AZ"))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("AZ")))
 
         self.flight.targeting_parameters = {"exclude_countries": ["US", "AZ"]}
         self.flight.save()
 
-        self.assertTrue(self.flight.show_to_geo("UK"))
-        self.assertFalse(self.flight.show_to_geo("AZ"))
-        self.assertFalse(self.flight.show_to_geo("US"))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("UK")))
+        self.assertFalse(self.flight.show_to_geo(GeolocationData("AZ")))
+        self.assertFalse(self.flight.show_to_geo(GeolocationData("US")))
 
     def test_geo_state_metro_include(self):
-        self.assertTrue(self.flight.show_to_geo("US", "CA", 825))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("US", "CA", 825)))
 
         self.flight.targeting_parameters = {
             "include_countries": ["US"],
@@ -72,8 +73,8 @@ class TestAdModels(BaseAdModelsTestCase):
         }
         self.flight.save()
 
-        self.assertTrue(self.flight.show_to_geo("US", "CA", 825))
-        self.assertFalse(self.flight.show_to_geo("US", "WA", 819))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("US", "CA", 825)))
+        self.assertFalse(self.flight.show_to_geo(GeolocationData("US", "WA", 819)))
 
         self.flight.targeting_parameters = {
             "include_countries": ["US"],
@@ -81,8 +82,8 @@ class TestAdModels(BaseAdModelsTestCase):
         }
         self.flight.save()
 
-        self.assertFalse(self.flight.show_to_geo("US", "CA", 825))
-        self.assertTrue(self.flight.show_to_geo("US", "WA", 819))
+        self.assertFalse(self.flight.show_to_geo(GeolocationData("US", "CA", 825)))
+        self.assertTrue(self.flight.show_to_geo(GeolocationData("US", "WA", 819)))
 
     def test_keyword_targeting(self):
         self.assertTrue(self.flight.show_to_keywords(["django"]))

--- a/adserver/tests/test_utils.py
+++ b/adserver/tests/test_utils.py
@@ -4,7 +4,6 @@ from unittest import mock
 
 import pytz
 from django.contrib.gis.geoip2 import GeoIP2Exception
-from django.test import override_settings
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.utils import timezone
@@ -18,6 +17,7 @@ from ..utils import generate_client_id
 from ..utils import get_ad_day
 from ..utils import get_client_id
 from ..utils import get_client_user_agent
+from ..utils import get_geoipdb_geolocation
 from ..utils import get_geolocation
 from ..utils import is_blocklisted_ip
 from ..utils import is_blocklisted_referrer
@@ -160,8 +160,9 @@ class UtilsTest(TestCase):
 
     def test_geolocation(self):
         """The GeoIP database is not available in CI."""
-        geolocation = get_geolocation(self.request, "invalid-ip")
-        self.assertIsNone(geolocation["country_code"])
+        self.request.ip_address = "invalid-ip"
+        geolocation = get_geolocation(self.request)
+        self.assertIsNone(geolocation.country)
 
         with mock.patch("adserver.utils.geoip") as geoip:
             geoip.city.return_value = {
@@ -169,19 +170,20 @@ class UtilsTest(TestCase):
                 "region": None,
                 "dma_code": None,
             }
-            geolocation = get_geolocation(self.request, "8.8.8.8")
+            self.request.ip_address = "8.8.8.8"
+            geolocation = get_geoipdb_geolocation(self.request)
             self.assertIsNotNone(geolocation)
-            self.assertEqual(geolocation["country_code"], "FR")
+            self.assertEqual(geolocation.country, "FR")
 
         with mock.patch("adserver.utils.geoip") as geoip:
             geoip.city.side_effect = AddressNotFoundError()
-            geolocation = get_geolocation(self.request, "8.8.8.8")
-            self.assertIsNone(geolocation["country_code"])
+            geolocation = get_geoipdb_geolocation(self.request)
+            self.assertIsNone(geolocation.country)
 
         with mock.patch("adserver.utils.geoip") as geoip:
             geoip.city.side_effect = GeoIP2Exception()
-            geolocation = get_geolocation(self.request, "8.8.8.8")
-            self.assertIsNone(geolocation["country_code"])
+            geolocation = get_geoipdb_geolocation(self.request)
+            self.assertIsNone(geolocation.country)
 
     def test_parse_date_string(self):
         self.assertIsNone(parse_date_string("not-a-date"))

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -135,7 +135,7 @@ def get_client_country(request, ip_address=None):
 
 
 def get_country_name(country_code):
-    return COUNTRY_DICT.get(country_code)
+    return COUNTRY_DICT.get(country_code, country_code)
 
 
 def anonymize_ip_address(ip_address):

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -4,11 +4,11 @@ import ipaddress
 import logging
 import os
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from datetime import timedelta
 
 import IP2Proxy
-from dataclasses import dataclass
 from django.conf import settings
 from django.contrib.gis.geoip2 import GeoIP2
 from django.contrib.gis.geoip2 import GeoIP2Exception

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -4,11 +4,11 @@ import ipaddress
 import logging
 import os
 import re
-from collections import namedtuple
 from datetime import datetime
 from datetime import timedelta
 
 import IP2Proxy
+from dataclasses import dataclass
 from django.conf import settings
 from django.contrib.gis.geoip2 import GeoIP2
 from django.contrib.gis.geoip2 import GeoIP2Exception
@@ -31,13 +31,23 @@ from .constants import PAID_CAMPAIGN
 log = logging.getLogger(__name__)  # noqa
 
 
-GeolocationTuple = namedtuple(
-    "GeolocationTuple", ["country_code", "region_code", "metro_code"]
-)
-
-
 # Put this here so we don't reload it on each call
 COUNTRY_DICT = dict(countries)
+COUNTRY_DICT["T1"] = "Tor"
+
+
+@dataclass
+class GeolocationData:
+
+    """Dataclass for (temporarily) storing geolocation information for ad viewers."""
+
+    country: str = (
+        None  # Should be a 2 character ISO 3166-1 country code (or T1 for Tor)
+    )
+    region: str = None
+    metro: int = None
+    lat: float = None
+    lng: float = None
 
 
 def get_ad_day():
@@ -87,14 +97,18 @@ def get_client_ip(request):
     Gets the real IP based on a request object.
 
     Checks if ``request.ip_address`` is present from a Middleware
-    (eg. ``RealIPAddressMiddleware``) and returns that.
-    If that is not set, return the value from ``REMOTE_ADDR``.
+    (eg. ``CloudflareIpAddressMiddleware``) and returns that.
+    If that is not set, return the value from ``REMOTE_ADDR`` and raise a warning.
     """
-    ip = getattr(request, "ip_address", None)
-    if ip:
-        return ip
+    if hasattr(request, "ip_address"):
+        return request.ip_address
 
-    return request.META.get("REMOTE_ADDR", "")
+    log.warning(
+        "No IP address set by middleware (see CloudflareIpAddressMiddleware). "
+        "Consider enabling an IP address middleware so IPs can be used for ad targeting."
+    )
+
+    return request.META.get("REMOTE_ADDR", None)
 
 
 def get_client_user_agent(request):
@@ -117,21 +131,10 @@ def get_client_id(request):
     return client_id
 
 
-def get_client_country(request, ip_address=None):
+def get_client_country(request):
     """Get country data for this request."""
-    country = getattr(request, "user_country", None)
-    if country:
-        # Set by Cloudflare's GeoIP header
-        return country
-    if hasattr(request, "geo"):
-        # This is set in all API requests that use the GeoIpMixin
-        country = request.geo.country_code
-    else:
-        geo_data = get_geolocation(request, ip_address)
-        if geo_data:
-            country = geo_data["country_code"]
-
-    return country
+    geo_data = get_geolocation(request)
+    return geo_data.country
 
 
 def get_country_name(country_code):
@@ -252,27 +255,43 @@ def is_proxy_ip(ip):
     return False
 
 
-def get_geolocation(request, ip_address):
+def get_geolocation(request):
     """Gets the geolocation for this IP address."""
-    geolocation = {
-        # Use the Cloudflare GeoIP if available
-        "country_code": getattr(request, "user_country", None),
-        "region": None,
-        "dma_code": None,
-    }
+    if hasattr(request, "geo"):
+        return request.geo
+
+    log.warning(
+        "No geolocation data set by middleware (see CloudflareGeoIpMiddleware). "
+        "Consider enabling a GeoIp middleware for ad targeting."
+    )
+    return GeolocationData()
+
+
+def get_geoipdb_geolocation(request):
+    """Get geolocation using a GeoIP database (such as MaxMind)."""
+    geolocation = GeolocationData()
+    ip_address = get_client_ip(request)
+
     try:
         ipaddress.ip_address(force_text(ip_address))
     except ValueError:
-        # Invalid IP address
+        # Invalid IP address - should be safe to log. It's invalid and not identifying
+        log.warning("Invalid IP address passed to GeoIP database. IP=%s", ip_address)
         return geolocation
 
     if geoip:
         try:
-            geolocation = geoip.city(ip_address)
+            geo = geoip.city(ip_address)
+            geolocation.country = geo["country_code"]
+            geolocation.region = geo["region"]
+            geolocation.metro = geo["dma_code"]
         except AddressNotFoundError:
-            log.debug("Could not get geolocation for %s", ip_address)
+            # This is probably a local address like 127.0.0.1
+            log.debug("Could not get geolocation. IP=%s", ip_address)
         except GeoIP2Exception:
             log.warning("Geolocation configuration error")
+    else:
+        log.warning("No GeoIP database found.")
 
     return geolocation
 

--- a/adserver/validators.py
+++ b/adserver/validators.py
@@ -3,7 +3,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import BaseValidator
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import gettext_lazy as _
-from django_countries import countries
+
+from .utils import COUNTRY_DICT
 
 
 @deconstructible
@@ -39,7 +40,7 @@ class TargetingParametersValidator(BaseValidator):
 
     def __init__(self, message=None):
         """Initialization for the targeting validator."""
-        self.country_set = {cc for cc, name in countries}
+        self.country_set = set(COUNTRY_DICT)
         if message:
             self.message = message
 

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -599,16 +599,12 @@ class BaseProxyView(View):
         parsed_ua = parse_user_agent(user_agent)
         referrer = request.META.get("HTTP_REFERER")
 
-        country_code = None
-        region_code = None
-        metro_code = None
-        geo_data = get_geolocation(ip_address)
-        if geo_data:
-            # One or more of these may be None which is OK
-            # Ads targeting countries/regions/metros won't be counted
-            country_code = geo_data["country_code"]
-            region_code = geo_data["region"]
-            metro_code = geo_data["dma_code"]
+        # One or more of these may be None which is OK
+        # Ads targeting countries/regions/metros won't be counted
+        geo_data = get_geolocation(request, ip_address)
+        country_code = geo_data["country_code"]
+        region_code = geo_data["region"]
+        metro_code = geo_data["dma_code"]
 
         if not offer:
             log.log(self.log_level, "Ad impression for unknown offer")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -77,7 +77,8 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "adserver.middleware.XForwardedForMiddleware",
+    "adserver.middleware.ServerInfoMiddleware",
+    "adserver.middleware.CloudflareMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
 ]
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -77,9 +77,8 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "adserver.middleware.ServerInfoMiddleware",
-    "adserver.middleware.CloudflareMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
+    "adserver.middleware.ServerInfoMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = [
@@ -456,3 +455,13 @@ ADSERVER_SUPPORT_FORM_ACTION = env("ADSERVER_SUPPORT_FORM_ACTION", default=None)
 
 with open(os.path.join(BASE_DIR, "package.json"), encoding="utf-8") as fd:
     ADSERVER_VERSION = json.load(fd)["version"]
+
+# Additional middleware for setting the user's real IP
+# and translating the IP into a geo for ad targeting.
+ADSERVER_GEOIP_MIDDLEWARE = env("ADSERVER_GEOIP_MIDDLEWARE", default=None)
+ADSERVER_IPADDRESS_MIDDLEWARE = env("ADSERVER_IPADDRESS_MIDDLEWARE", default=None)
+
+if ADSERVER_GEOIP_MIDDLEWARE:
+    MIDDLEWARE.append(ADSERVER_GEOIP_MIDDLEWARE)
+if ADSERVER_IPADDRESS_MIDDLEWARE:
+    MIDDLEWARE.append(ADSERVER_IPADDRESS_MIDDLEWARE)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -458,10 +458,13 @@ with open(os.path.join(BASE_DIR, "package.json"), encoding="utf-8") as fd:
 
 # Additional middleware for setting the user's real IP
 # and translating the IP into a geo for ad targeting.
-ADSERVER_GEOIP_MIDDLEWARE = env("ADSERVER_GEOIP_MIDDLEWARE", default=None)
 ADSERVER_IPADDRESS_MIDDLEWARE = env("ADSERVER_IPADDRESS_MIDDLEWARE", default=None)
+ADSERVER_GEOIP_MIDDLEWARE = env("ADSERVER_GEOIP_MIDDLEWARE", default=None)
 
-if ADSERVER_GEOIP_MIDDLEWARE:
-    MIDDLEWARE.append(ADSERVER_GEOIP_MIDDLEWARE)
+# Add the optional middlewares if they are set
+# The IP address middleware should come BEFORE the GeoIP middleware
+# That way the GeoIP middleware will have access to the correct IP
 if ADSERVER_IPADDRESS_MIDDLEWARE:
     MIDDLEWARE.append(ADSERVER_IPADDRESS_MIDDLEWARE)
+if ADSERVER_GEOIP_MIDDLEWARE:
+    MIDDLEWARE.append(ADSERVER_GEOIP_MIDDLEWARE)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -458,8 +458,12 @@ with open(os.path.join(BASE_DIR, "package.json"), encoding="utf-8") as fd:
 
 # Additional middleware for setting the user's real IP
 # and translating the IP into a geo for ad targeting.
-ADSERVER_IPADDRESS_MIDDLEWARE = env("ADSERVER_IPADDRESS_MIDDLEWARE", default=None)
-ADSERVER_GEOIP_MIDDLEWARE = env("ADSERVER_GEOIP_MIDDLEWARE", default=None)
+ADSERVER_IPADDRESS_MIDDLEWARE = env(
+    "ADSERVER_IPADDRESS_MIDDLEWARE", default="adserver.middleware.IpAddressMiddleware"
+)
+ADSERVER_GEOIP_MIDDLEWARE = env(
+    "ADSERVER_GEOIP_MIDDLEWARE", default="adserver.middleware.GeoIpMiddleware"
+)
 
 # Add the optional middlewares if they are set
 # The IP address middleware should come BEFORE the GeoIP middleware

--- a/docs/install/configuration.rst
+++ b/docs/install/configuration.rst
@@ -85,6 +85,35 @@ a backend that chooses ads based on how many more clicks and views are needed.
 Set to ``None`` to disable all ads from serving. This can be useful during migrations.
 
 
+ADSERVER_GEOIP_MIDDLEWARE
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set, this middleware should be used to turn IP addresses into geolocations
+for the purposes of ad targeting.
+
+If the adserver is deployed behind Cloudflare (recommended),
+then use ``adserver.middleware.CloudflareGeoIpMiddleware``.
+You should also enable "Cloudflare IP Geolocation" in the Cloudflare dashboard.
+
+Use ``adserver.middleware.GeoIpDatabaseMiddleware`` to use a GeoIP database.
+
+
+ADSERVER_IPADDRESS_MIDDLEWARE
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set, this middleware should be used to get the real IP address for requests.
+IP addresses are used to get a location for ad targeting.
+These IPs are not stored in full (the last 2 bytes are zeroed out).
+
+If the adserver is deployed behind Cloudflare (recommended),
+then use ``adserver.middleware.CloudflareIpAddressMiddleware``.
+Do not use this middleware if not behind Cloudflare as the real IP address header
+could be spoofed.
+
+Use ``adserver.middleware.XForwardedForMiddleware`` if the x-forwarded-for header
+can be trusted to have a valid, non-spoofed IP address.
+
+
 ADSERVER_HTTPS
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
* Adds new middlewares:
  - one that uses [Cloudflare's IP headers](https://developers.cloudflare.com/fundamentals/get-started/http-request-headers) for IP canonicalization.
  - one that uses Cloudflare's geolocation (country only) headers for geolocation 
  - Adds a middleware that uses the GeoIP database but we probably won't use it
  - Breaks the `X-Server` header into its own middleware ~and makes it a staff-only header~
* Refactors our geolocation data to be in a dataclass attached to `request.geo`
* Adds a bunch of test cases to try to catch errors

The reasoning here is a few fold:

- Cloudflare likely has more up-to-date and complete GeoIP databases than we do
- Cloudflare will keep more up-to-date with Tor exit node lists

**NOTE**: This will be a bit challenging to fully test before it hits production. It might be worth setting up on a different domain briefly to test this change.