### PR TITLE
Handle a bug with a forced ad but mismatched ad type

### DIFF
--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -373,6 +373,13 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
 
         for advertisement in candidate_ads:
             placement = self.get_placement(advertisement)
+            if not placement:
+                log.warning(
+                    "Couldn't find a matching ad placement. ad=%s, placements=%s",
+                    advertisement,
+                    self.placements,
+                )
+                continue
             priority = placement.get("priority", 1)
             for _ in range(max_priority + 1 - priority):
                 weighted_ad_choices.append(advertisement)


### PR DESCRIPTION
I found this issue in [Sentry](https://sentry.io/organizations/read-the-docs/issues/2998521932/events/?project=1846644). This can happen when you force a specific ad (rare, usually only in debug) but the ad types don't match the requested placements.