### PR TITLE
Fix typo with keyword aggregation

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -319,7 +319,7 @@ def daily_update_keywords(day=None):
                 decisions=F("decisions") + values["total_decisions"],
                 offers=F("offers") + values["total_offers"],
                 views=F("views") + values["total_views"],
-                clicks=F("clicks") + values["total_views"],
+                clicks=F("clicks") + values["total_clicks"],
             )
 
 


### PR DESCRIPTION
Fixes a bug with keyword aggregation introduced in version v0.44.0 (January 26, 2022). All aggregations since then are wrong and will need to be re-run after this is merged.

I had verified that the query generated was correct but didn't verify the actual writing to the database. That has been corrected with a unit test.