### PR TITLE
Add an existing user to an advertiser

### DIFF
--- a/adserver/forms.py
+++ b/adserver/forms.py
@@ -731,7 +731,12 @@ class PublisherSettingsForm(forms.ModelForm):
 
 class InviteUserForm(forms.ModelForm):
 
-    """Used to invite users to collaborate on an advertiser/publisher."""
+    """
+    Used to invite users to collaborate on an advertiser/publisher.
+
+    If the user already exists, the user will be returned from ``save()``
+    without a duplicate being created.
+    """
 
     def __init__(self, *args, **kwargs):
         """Add the form helper and customize the look of the form."""
@@ -751,9 +756,21 @@ class InviteUserForm(forms.ModelForm):
         email = self.cleaned_data.get("email")
         return User.objects.normalize_email(email)
 
+    def get_existing_user(self):
+        """Return an existing user with the email or None if no user exists."""
+        email = self.cleaned_data["email"]
+        return User.objects.filter(email=email).first()
+
+    def validate_unique(self):
+        """Remove the uniqueness check on email. Handle this in save()."""
+
     def save(self, commit=True):
-        user = super().save(commit)
-        user.invite_user()
+        # Get the user if it already exists
+        user = self.get_existing_user()
+        if not user:
+            # Invite the user if they're new
+            user = super().save(commit)
+            user.invite_user()
 
         # Track who added this user
         update_change_reason(user, "Invited via authorized users view")

--- a/adserver/tests/test_advertiser_dashboard.py
+++ b/adserver/tests/test_advertiser_dashboard.py
@@ -18,6 +18,9 @@ from ..utils import get_ad_day
 from .common import ONE_PIXEL_PNG_BYTES
 
 
+User = get_user_model()
+
+
 class TestAdvertiserDashboardViews(TestCase):
 
     """Test the advertiser dashboard interface for creating and updating ads."""
@@ -546,3 +549,39 @@ class TestAdvertiserDashboardViews(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Successfully invited")
+
+    def test_authorized_users_invite_existing(self):
+        url = reverse(
+            "advertiser_users_invite",
+            kwargs={
+                "advertiser_slug": self.advertiser.slug,
+            },
+        )
+
+        self.client.force_login(self.user)
+
+        name = "Another User"
+        email = "another@example.com"
+
+        response = self.client.post(
+            url,
+            data={"name": name, "email": email},
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Successfully invited")
+        self.assertEqual(User.objects.filter(email=email).count(), 1)
+
+        # Invite the same user again to check that the user isn't created again
+        response = self.client.post(
+            url,
+            data={"name": "Yet Another User", "email": email},
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Successfully invited")
+        self.assertEqual(User.objects.filter(email=email).count(), 1)
+        self.assertEqual(User.objects.filter(name=name).count(), 1)
+
+        # The 2nd request didn't create a user or update the user's name
+        self.assertEqual(User.objects.filter(name="Yet Another User").count(), 0)


### PR DESCRIPTION
This is just a QoL improvement that simplifies the workflow of adding an existing user.