### PR TITLE
Record data for forced ads if they are unpaid.

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1208,9 +1208,10 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
             ad_type_slug=ad_type_slug,
         )
 
-        if forced:
-            # Ad offers forced to a specific ad or campaign should never be billed
-            # By discarding the nonce, the ad view/click will never count
+        if forced and self.flight.campaign.campaign_type == PAID_CAMPAIGN:
+            # Ad offers forced to a specific ad or campaign should never be billed.
+            # By discarding the nonce, the ad view/click will never count.
+            # We will still record data for unpaid campaign in reporting though.
             nonce = "forced"
         else:
             nonce = offer.pk


### PR DESCRIPTION
This is required for the PSF sponsor use case,
and I think makes sense with never billing for them..