### PR TITLE
Aggregation task performance improvements

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -12,11 +12,7 @@ from django.utils.timezone import is_naive
 from django.utils.timezone import utc
 from django_slack import slack_message
 
-from .constants import CLICKS
-from .constants import IMPRESSION_TYPES
-from .constants import OFFERS
 from .constants import PAID_CAMPAIGN
-from .constants import VIEWS
 from .models import AdImpression
 from .models import Flight
 from .models import GeoImpression
@@ -67,26 +63,6 @@ def _get_day(day):
     return (start_date, end_date)
 
 
-def _default_filters(impression_type, start_date, end_date):
-    """Filter the queryset by date and impression type."""
-    # Use the replica for this query, since it's how we do all our reporting queries,
-    # and it currently hammers the prod DB.
-    queryset = Offer.objects.using(settings.REPLICA_SLUG).filter(
-        date__gte=start_date,
-        date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
-        # is_refunded=False,  # This causes the query to be a filtered index and is much slower
-    )
-
-    if impression_type == CLICKS:
-        queryset = queryset.filter(clicked=True)
-    elif impression_type == VIEWS:
-        queryset = queryset.filter(viewed=True)
-    elif impression_type == OFFERS:
-        queryset = queryset.filter(advertisement__isnull=False)
-
-    return queryset
-
-
 @app.task()
 def daily_update_geos(
     day=None, geo=True, region=True
@@ -114,71 +90,96 @@ def daily_update_geos(
             date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
         ).delete()
 
-    for impression_type in IMPRESSION_TYPES:
-        topic_mapping = defaultdict(int)
-        queryset = _default_filters(impression_type, start_date, end_date)
-        for values in (
-            queryset.values("advertisement", "country", "publisher")
-            .annotate(total=Count("country"))
-            .filter(total__gt=0)
-            .order_by("-total")
-            .iterator()
-        ):
-            country = values["country"]
-            if geo:
-                impression, _ = GeoImpression.objects.using("default").get_or_create(
-                    publisher_id=values["publisher"],
-                    advertisement_id=values["advertisement"],
-                    country=country,
-                    date=start_date,
-                )
-                GeoImpression.objects.using("default").filter(pk=impression.pk).update(
-                    **{impression_type: values["total"]}
-                )
-
-            if region:
-
-                if country in us_ca:
-                    _region = "us-ca"
-                elif country in eu_aus_nz:
-                    _region = "eu-aus-nz"
-                elif country in wider_apac:
-                    _region = "wider-apac"
-                elif country in latin_america:
-                    _region = "latin-america"
-                elif country in africa:
-                    _region = "africa"
-                elif country in exclude:
-                    _region = "exclude"
-                elif country in south_asia:
-                    _region = "south-asia"
-                else:
-                    _region = "global"
-
-                publisher = values["publisher"]
-                advertisement = values["advertisement"]
-                topic_mapping[f"{advertisement}:{publisher}:{_region}"] += values[
-                    "total"
-                ]
+    topic_mapping = defaultdict(
+        lambda: {
+            "decisions": 0,
+            "offers": 0,
+            "views": 0,
+            "clicks": 0,
+        }
+    )
+    queryset = Offer.objects.using(settings.REPLICA_SLUG).filter(
+        date__gte=start_date,
+        date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
+    )
+    for values in (
+        queryset.values("advertisement", "country", "publisher")
+        .annotate(
+            total_decisions=Count("country"),
+            total_offers=Count("country", filter=Q(advertisement__isnull=False)),
+            total_views=Count("country", filter=Q(viewed=True)),
+            total_clicks=Count("country", filter=Q(clicked=True)),
+        )
+        .filter(total_decisions__gt=0)
+        .order_by("-total_decisions")
+        .iterator()
+    ):
+        country = values["country"]
+        if geo:
+            impression, _ = GeoImpression.objects.using("default").get_or_create(
+                publisher_id=values["publisher"],
+                advertisement_id=values["advertisement"],
+                country=country,
+                date=start_date,
+            )
+            GeoImpression.objects.using("default").filter(pk=impression.pk).update(
+                decisions=values["total_decisions"],
+                offers=values["total_offers"],
+                views=values["total_views"],
+                clicks=values["total_clicks"],
+            )
 
         if region:
-            log.info(
-                "Saving %s RegionImpressions: %s", len(topic_mapping), impression_type
+            if country in us_ca:
+                _region = "us-ca"
+            elif country in eu_aus_nz:
+                _region = "eu-aus-nz"
+            elif country in wider_apac:
+                _region = "wider-apac"
+            elif country in latin_america:
+                _region = "latin-america"
+            elif country in africa:
+                _region = "africa"
+            elif country in exclude:
+                _region = "exclude"
+            elif country in south_asia:
+                _region = "south-asia"
+            else:
+                _region = "global"
+
+            publisher = values["publisher"]
+            advertisement = values["advertisement"]
+            topic_mapping[f"{advertisement}:{publisher}:{_region}"][
+                "decisions"
+            ] += values["total_decisions"]
+            topic_mapping[f"{advertisement}:{publisher}:{_region}"]["offers"] += values[
+                "total_offers"
+            ]
+            topic_mapping[f"{advertisement}:{publisher}:{_region}"]["views"] += values[
+                "total_views"
+            ]
+            topic_mapping[f"{advertisement}:{publisher}:{_region}"]["clicks"] += values[
+                "total_clicks"
+            ]
+
+    if region:
+        for data, value in topic_mapping.items():
+            ad, publisher, _region = data.split(":")
+            # Handle the conversion of None
+            if ad == "None":
+                ad = None
+            impression, _ = RegionImpression.objects.using("default").get_or_create(
+                publisher_id=publisher,
+                advertisement_id=ad,
+                region=_region,
+                date=start_date,
             )
-            for data, value in topic_mapping.items():
-                ad, publisher, _region = data.split(":")
-                # Handle the conversion of None
-                if ad == "None":
-                    ad = None
-                impression, _ = RegionImpression.objects.using("default").get_or_create(
-                    publisher_id=publisher,
-                    advertisement_id=ad,
-                    region=_region,
-                    date=start_date,
-                )
-                RegionImpression.objects.using("default").filter(
-                    pk=impression.pk
-                ).update(**{impression_type: F(impression_type) + value})
+            RegionImpression.objects.using("default").filter(pk=impression.pk).update(
+                decisions=F("decisions") + value["decisions"],
+                offers=F("offers") + value["offers"],
+                views=F("views") + value["views"],
+                clicks=F("clicks") + value["clicks"],
+            )
 
 
 @app.task()
@@ -192,28 +193,39 @@ def daily_update_placements(day=None):
 
     log.info("Updating PlacementImpressions for %s-%s", start_date, end_date)
 
-    for impression_type in IMPRESSION_TYPES:
-        queryset = _default_filters(impression_type, start_date, end_date)
-        for values in (
-            queryset.values("publisher", "advertisement", "div_id", "ad_type_slug")
-            .annotate(total=Count("div_id"))
-            .filter(total__gt=0)
-            .filter(publisher__record_placements=True)
-            .exclude(div_id__regex=r"(rtd-\w{4}|ad_\w{4}).*")
-            .order_by("-total")
-            .iterator()
-        ):
+    for values in (
+        Offer.objects.using(settings.REPLICA_SLUG)
+        .filter(
+            date__gte=start_date,
+            date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
+        )
+        .values("publisher", "advertisement", "div_id", "ad_type_slug")
+        .annotate(
+            total_decisions=Count("div_id"),
+            total_offers=Count("div_id", filter=Q(advertisement__isnull=False)),
+            total_views=Count("div_id", filter=Q(viewed=True)),
+            total_clicks=Count("div_id", filter=Q(clicked=True)),
+        )
+        .filter(total_decisions__gt=0)
+        .filter(publisher__record_placements=True)
+        .exclude(div_id__regex=r"(rtd-\w{4}|ad_\w{4}).*")
+        .order_by("-total_decisions")
+        .iterator()
+    ):
 
-            impression, _ = PlacementImpression.objects.using("default").get_or_create(
-                publisher_id=values["publisher"],
-                advertisement_id=values["advertisement"],
-                div_id=values["div_id"],
-                ad_type_slug=values["ad_type_slug"],
-                date=start_date,
-            )
-            PlacementImpression.objects.using("default").filter(
-                pk=impression.pk
-            ).update(**{impression_type: values["total"]})
+        impression, _ = PlacementImpression.objects.using("default").get_or_create(
+            publisher_id=values["publisher"],
+            advertisement_id=values["advertisement"],
+            div_id=values["div_id"],
+            ad_type_slug=values["ad_type_slug"],
+            date=start_date,
+        )
+        PlacementImpression.objects.using("default").filter(pk=impression.pk).update(
+            decisions=values["total_decisions"],
+            offers=values["total_offers"],
+            views=values["total_views"],
+            clicks=values["total_clicks"],
+        )
 
 
 @app.task()
@@ -227,26 +239,36 @@ def daily_update_impressions(day=None):
 
     log.info("Updating AdImpressions for %s-%s", start_date, end_date)
 
-    for impression_type in IMPRESSION_TYPES:
-        queryset = _default_filters(impression_type, start_date, end_date)
+    for values in (
+        Offer.objects.using(settings.REPLICA_SLUG)
+        .filter(
+            date__gte=start_date,
+            date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
+        )
+        .values("publisher", "advertisement")
+        # This needs to be publisher and not advertisement to gets decisions properly
+        .annotate(
+            total_decisions=Count("publisher"),
+            total_offers=Count("publisher", filter=Q(advertisement__isnull=False)),
+            total_views=Count("publisher", filter=Q(viewed=True)),
+            total_clicks=Count("publisher", filter=Q(clicked=True)),
+        )
+        .filter(total_decisions__gt=0)
+        .order_by("-total_decisions")
+        .iterator()
+    ):
 
-        for values in (
-            queryset.values("publisher", "advertisement")
-            # This needs to be publisher and not advertisement to gets decisions properly
-            .annotate(total=Count("publisher"))
-            .filter(total__gt=0)
-            .order_by("-total")
-            .iterator()
-        ):
-
-            impression, _ = AdImpression.objects.using("default").get_or_create(
-                publisher_id=values["publisher"],
-                advertisement_id=values["advertisement"],
-                date=start_date,
-            )
-            AdImpression.objects.using("default").filter(pk=impression.pk).update(
-                **{impression_type: values["total"]}
-            )
+        impression, _ = AdImpression.objects.using("default").get_or_create(
+            publisher_id=values["publisher"],
+            advertisement_id=values["advertisement"],
+            date=start_date,
+        )
+        AdImpression.objects.using("default").filter(pk=impression.pk).update(
+            decisions=values["total_decisions"],
+            offers=values["total_offers"],
+            views=values["total_views"],
+            clicks=values["total_clicks"],
+        )
 
 
 @app.task()
@@ -341,90 +363,115 @@ def daily_update_regiontopic(day=None):  # pylint: disable=too-many-branches
         date__gte=start_date, date__lt=end_date
     ).delete()
 
-    for impression_type in IMPRESSION_TYPES:
-        topic_mapping = defaultdict(int)
-        queryset = _default_filters(impression_type, start_date, end_date)
-        for values in (
-            queryset.values("advertisement", "keywords", "country")
-            .annotate(total=Count("country"))
-            .filter(total__gt=0)
-            .order_by("-total")
-            .values("keywords", "advertisement", "country", "total")
-            .iterator()
-        ):
-            if not (values["keywords"] and values["country"]):
+    topic_mapping = defaultdict(
+        lambda: {
+            "decisions": 0,
+            "offers": 0,
+            "views": 0,
+            "clicks": 0,
+        }
+    )
+    queryset = Offer.objects.using(settings.REPLICA_SLUG).filter(
+        date__gte=start_date,
+        date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
+    )
+    for values in (
+        queryset.values("advertisement", "keywords", "country")
+        .annotate(
+            total_decisions=Count("country"),
+            total_offers=Count("country", filter=Q(advertisement__isnull=False)),
+            total_views=Count("country", filter=Q(viewed=True)),
+            total_clicks=Count("country", filter=Q(clicked=True)),
+        )
+        .filter(total_decisions__gt=0)
+        .order_by("-total_decisions")
+        .values(
+            "keywords",
+            "advertisement",
+            "country",
+            "total_decisions",
+            "total_offers",
+            "total_views",
+            "total_clicks",
+        )
+        .iterator()
+    ):
+        if not (values["keywords"] and values["country"]):
+            continue
+
+        keywords = values["keywords"]
+        country = values["country"]
+        ad = values["advertisement"]
+        publisher_keywords = set(keywords)
+
+        topics = set()
+        for keyword in publisher_keywords:
+            if keyword in data_science:
+                topic = "data-science"
+            elif keyword in backend_web:
+                topic = "backend-web"
+            elif keyword in frontend_web:
+                topic = "frontend-web"
+            elif keyword in security_privacy:
+                topic = "security-privacy"
+            elif keyword in devops:
+                topic = "devops"
+            elif keyword in python:
+                topic = "python"
+            elif keyword in blockchain:
+                topic = "blockchain"
+            elif keyword in game_dev:
+                topic = "game-dev"
+            else:
                 continue
 
-            keywords = values["keywords"]
-            country = values["country"]
-            ad = values["advertisement"]
-            publisher_keywords = set(keywords)
+            topics.add(topic)
 
-            topics = set()
-            for keyword in publisher_keywords:
-                if keyword in data_science:
-                    topic = "data-science"
-                elif keyword in backend_web:
-                    topic = "backend-web"
-                elif keyword in frontend_web:
-                    topic = "frontend-web"
-                elif keyword in security_privacy:
-                    topic = "security-privacy"
-                elif keyword in devops:
-                    topic = "devops"
-                elif keyword in python:
-                    topic = "python"
-                elif keyword in blockchain:
-                    topic = "blockchain"
-                elif keyword in game_dev:
-                    topic = "game-dev"
-                else:
-                    continue
+        # If nothing gets set as a topic, assign it other
+        if not topics:
+            topics.add("other")
 
-                topics.add(topic)
+        if country in us_ca:
+            region = "us-ca"
+        elif country in eu_aus_nz:
+            region = "eu-aus-nz"
+        elif country in wider_apac:
+            region = "wider-apac"
+        elif country in latin_america:
+            region = "latin-america"
+        elif country in africa:
+            region = "africa"
+        else:
+            region = "global"
 
-            # If nothing gets set as a topic, assign it other
-            if not topics:
-                topics.add("other")
+        # Aggregate data into topic_mapping to save doing queries until we have everything counted
+        # This is important because we can't query on keywords, so we have a lot of records that increment
+        # the total count on the region & topic.
+        for topic in topics:
+            topic_mapping[f"{ad}:{region}:{topic}"]["decisions"] += values[
+                "total_decisions"
+            ]
+            topic_mapping[f"{ad}:{region}:{topic}"]["offers"] += values["total_offers"]
+            topic_mapping[f"{ad}:{region}:{topic}"]["views"] += values["total_views"]
+            topic_mapping[f"{ad}:{region}:{topic}"]["clicks"] += values["total_clicks"]
 
-            if country in us_ca:
-                region = "us-ca"
-            elif country in eu_aus_nz:
-                region = "eu-aus-nz"
-            elif country in wider_apac:
-                region = "wider-apac"
-            elif country in latin_america:
-                region = "latin-america"
-            elif country in africa:
-                region = "africa"
-            else:
-                region = "global"
-
-            # Aggregate data into topic_mapping to save doing queries until we have everything counted
-            # This is important because we can't query on keywords, so we have a lot of records that increment
-            # the total count on the region & topic.
-            for topic in topics:
-                topic_mapping[f"{ad}:{region}:{topic}"] += values["total"]
-
-        log.info(
-            "Saving %s RegionTopicImpressions: %s", len(topic_mapping), impression_type
+    for data, value in topic_mapping.items():
+        ad, region, topic = data.split(":")
+        # Handle the conversion of
+        if ad == "None":
+            ad = None
+        impression, _ = RegionTopicImpression.objects.using("default").get_or_create(
+            date=start_date, advertisement_id=ad, region=region, topic=topic
         )
-        for data, value in topic_mapping.items():
-            ad, region, topic = data.split(":")
-            # Handle the conversion of
-            if ad == "None":
-                ad = None
-            impression, _ = RegionTopicImpression.objects.using(
-                "default"
-            ).get_or_create(
-                date=start_date, advertisement_id=ad, region=region, topic=topic
-            )
-            # these are a sum because we can't query for specific keywords from postgres,
-            # so a specific publisher and advertisement set could return the same keyword:
-            # ['python', 'django'] and ['python, 'flask'] both are `python` in this case.
-            RegionTopicImpression.objects.using("default").filter(
-                pk=impression.pk
-            ).update(**{impression_type: F(impression_type) + value})
+        # these are a sum because we can't query for specific keywords from postgres,
+        # so a specific publisher and advertisement set could return the same keyword:
+        # ['python', 'django'] and ['python, 'flask'] both are `python` in this case.
+        RegionTopicImpression.objects.using("default").filter(pk=impression.pk).update(
+            decisions=F("decisions") + value["decisions"],
+            offers=F("offers") + value["offers"],
+            views=F("views") + value["views"],
+            clicks=F("clicks") + value["clicks"],
+        )
 
 
 @app.task()
@@ -438,26 +485,42 @@ def daily_update_uplift(day=None):
 
     log.info("Updating uplift for %s-%s", start_date, end_date)
 
-    for impression_type in IMPRESSION_TYPES:
-        queryset = _default_filters(impression_type, start_date, end_date)
+    queryset = Offer.objects.using(settings.REPLICA_SLUG).filter(
+        date__gte=start_date,
+        date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
+    )
 
-        for values in (
-            queryset.values("publisher", "advertisement")
-            .annotate(total=Count("uplifted"))
-            .filter(total__gt=0)
-            .order_by("-total")
-            .values("publisher", "advertisement", "total")
-            .iterator()
-        ):
-
-            impression, _ = UpliftImpression.objects.using("default").get_or_create(
-                publisher_id=values["publisher"],
-                advertisement_id=values["advertisement"],
-                date=start_date,
-            )
-            UpliftImpression.objects.using("default").filter(pk=impression.pk).update(
-                **{impression_type: values["total"]}
-            )
+    for values in (
+        queryset.values("publisher", "advertisement")
+        .annotate(
+            total_decisions=Count("uplifted"),
+            total_offers=Count("uplifted", filter=Q(advertisement__isnull=False)),
+            total_views=Count("uplifted", filter=Q(viewed=True)),
+            total_clicks=Count("uplifted", filter=Q(clicked=True)),
+        )
+        .filter(total_decisions__gt=0)
+        .order_by("-total_decisions")
+        .values(
+            "publisher",
+            "advertisement",
+            "total_decisions",
+            "total_offers",
+            "total_views",
+            "total_clicks",
+        )
+        .iterator()
+    ):
+        impression, _ = UpliftImpression.objects.using("default").get_or_create(
+            publisher_id=values["publisher"],
+            advertisement_id=values["advertisement"],
+            date=start_date,
+        )
+        UpliftImpression.objects.using("default").filter(pk=impression.pk).update(
+            decisions=values["total_decisions"],
+            offers=values["total_offers"],
+            views=values["total_views"],
+            clicks=values["total_clicks"],
+        )
 
 
 @app.task(time_limit=60 * 60 * 4)

--- a/adserver/tests/common.py
+++ b/adserver/tests/common.py
@@ -72,10 +72,16 @@ class BaseAdModelsTestCase(TestCase):
         )
 
         self.text_ad_type = get(
-            AdType, has_text=True, max_text_length=100, has_image=False, template=None
+            AdType,
+            slug="text-slug",
+            has_text=True,
+            max_text_length=100,
+            has_image=False,
+            template=None,
         )
         self.image_ad_type = get(
             AdType,
+            slug="image-slug",
             has_text=True,
             has_image=True,
             image_height=None,

--- a/adserver/tests/test_tasks.py
+++ b/adserver/tests/test_tasks.py
@@ -5,11 +5,20 @@ from django_dynamic_fixture import get
 from django_slack.utils import get_backend
 
 from ..models import AdImpression
+from ..models import GeoImpression
 from ..models import KeywordImpression
 from ..models import Offer
+from ..models import PlacementImpression
+from ..models import RegionImpression
+from ..models import RegionTopicImpression
+from ..models import UpliftImpression
 from ..tasks import calculate_publisher_ctrs
+from ..tasks import daily_update_geos
 from ..tasks import daily_update_impressions
 from ..tasks import daily_update_keywords
+from ..tasks import daily_update_placements
+from ..tasks import daily_update_regiontopic
+from ..tasks import daily_update_uplift
 from ..tasks import notify_of_completed_flights
 from ..tasks import notify_of_publisher_changes
 from ..tasks import remove_old_client_ids
@@ -71,79 +80,6 @@ class TasksTest(BaseAdModelsTestCase):
 
         self.publisher.refresh_from_db()
         self.assertEqual(self.publisher.sampled_ctr, 20)
-
-    def test_daily_update_keywords(self):
-        # Keyword Aggregation requires some targeting
-        self.flight.targeting_parameters = {
-            "include_keywords": ["django"],
-        }
-        self.flight.save()
-
-        # Add some views and clicks
-        # Ad1 - offered/decision=4, views=3, clicks=1
-        # Ad2 - offered/decisions=2, views=2, clicks=0
-        get(
-            Offer,
-            advertisement=self.ad1,
-            publisher=self.publisher,
-            viewed=False,
-            keywords=["django", "python"],
-        )
-        get(
-            Offer,
-            advertisement=self.ad1,
-            publisher=self.publisher,
-            viewed=True,
-            keywords=["django", "python"],
-        )
-        get(
-            Offer,
-            advertisement=self.ad1,
-            publisher=self.publisher,
-            viewed=True,
-            keywords=["django", "python"],
-        )
-        get(
-            Offer,
-            advertisement=self.ad2,
-            publisher=self.publisher,
-            viewed=True,
-            keywords=["django", "python"],
-        )
-        get(
-            Offer,
-            advertisement=self.ad2,
-            publisher=self.publisher,
-            viewed=True,
-            keywords=["django", "python"],
-        )
-        get(
-            Offer,
-            advertisement=self.ad1,
-            publisher=self.publisher,
-            viewed=True,
-            clicked=True,
-            keywords=["django", "python"],
-        )
-
-        daily_update_keywords()
-
-        # Verify that the aggregation task worked correctly
-        ki_ad1 = KeywordImpression.objects.filter(
-            keyword="django", publisher=self.publisher, advertisement=self.ad1
-        ).first()
-        self.assertIsNotNone(ki_ad1)
-        self.assertEqual(ki_ad1.offers, 4)
-        self.assertEqual(ki_ad1.views, 3)
-        self.assertEqual(ki_ad1.clicks, 1)
-
-        ki_ad2 = KeywordImpression.objects.filter(
-            keyword="django", publisher=self.publisher, advertisement=self.ad2
-        ).first()
-        self.assertIsNotNone(ki_ad2)
-        self.assertEqual(ki_ad2.offers, 2)
-        self.assertEqual(ki_ad2.views, 2)
-        self.assertEqual(ki_ad2.clicks, 0)
 
     def test_notify_completed_flights(self):
         backend = get_backend()
@@ -243,3 +179,259 @@ class TasksTest(BaseAdModelsTestCase):
         notify_of_publisher_changes(min_views=1000)
         messages = backend.retrieve_messages()
         self.assertEqual(len(messages), 0)
+
+
+class AggregationTaskTests(BaseAdModelsTestCase):
+    def setUp(self):
+        super().setUp()
+
+        # Keyword Aggregation requires some targeting
+        self.flight.targeting_parameters = {
+            "include_keywords": ["backend", "security"],
+        }
+        self.flight.save()
+
+        # Required for placement impression aggregation
+        self.publisher.record_placements = True
+        self.publisher.save()
+
+        get(
+            Offer,
+            advertisement=self.ad1,
+            publisher=self.publisher,
+            country="CA",
+            viewed=False,
+            keywords=["backend"],
+            div_id="id_1",
+            ad_type_slug=self.text_ad_type.slug,
+        )
+        get(
+            Offer,
+            advertisement=self.ad1,
+            publisher=self.publisher,
+            country="CA",
+            viewed=True,
+            keywords=["backend"],
+            div_id="id_1",
+            ad_type_slug=self.text_ad_type.slug,
+        )
+        get(
+            Offer,
+            advertisement=self.ad1,
+            publisher=self.publisher,
+            country="CA",
+            viewed=True,
+            clicked=True,
+            uplifted=True,
+            keywords=["backend"],
+            div_id="id_1",
+            ad_type_slug=self.text_ad_type.slug,
+        )
+        get(
+            Offer,
+            advertisement=self.ad1,
+            publisher=self.publisher,
+            country="DE",
+            viewed=True,
+            keywords=["backend"],
+            div_id="id_2",
+            ad_type_slug=self.text_ad_type.slug,
+        )
+        get(
+            Offer,
+            advertisement=self.ad2,
+            publisher=self.publisher,
+            country="DE",
+            viewed=True,
+            uplifted=True,
+            keywords=["security"],
+            div_id="id_2",
+            ad_type_slug=self.text_ad_type.slug,
+        )
+        get(
+            Offer,
+            advertisement=self.ad2,
+            publisher=self.publisher,
+            country="DE",
+            viewed=True,
+            uplifted=True,
+            keywords=["security"],
+            div_id="id_2",
+            ad_type_slug=self.text_ad_type.slug,
+        )
+
+    def test_daily_update_impressions(self):
+        # Ad1 - offered/decision=4, views=3, clicks=1
+        # Ad2 - offered/decisions=2, views=2, clicks=0
+        daily_update_impressions()
+
+        # Verify that the aggregation task worked correctly
+        ai1 = AdImpression.objects.filter(
+            publisher=self.publisher, advertisement=self.ad1
+        ).first()
+        self.assertIsNotNone(ai1)
+        self.assertEqual(ai1.offers, 4)
+        self.assertEqual(ai1.views, 3)
+        self.assertEqual(ai1.clicks, 1)
+
+        ai2 = AdImpression.objects.filter(
+            publisher=self.publisher, advertisement=self.ad2
+        ).first()
+        self.assertIsNotNone(ai2)
+        self.assertEqual(ai2.offers, 2)
+        self.assertEqual(ai2.views, 2)
+        self.assertEqual(ai2.clicks, 0)
+
+    def test_daily_update_keywords(self):
+        # Ad1 - offered/decision=4, views=3, clicks=1
+        # Ad2 - offered/decisions=2, views=2, clicks=0
+        daily_update_keywords()
+
+        # Verify that the aggregation task worked correctly
+        ki_ad1 = KeywordImpression.objects.filter(
+            keyword="backend", publisher=self.publisher, advertisement=self.ad1
+        ).first()
+        self.assertIsNotNone(ki_ad1)
+        self.assertEqual(ki_ad1.offers, 4)
+        self.assertEqual(ki_ad1.views, 3)
+        self.assertEqual(ki_ad1.clicks, 1)
+
+        ki_ad2 = KeywordImpression.objects.filter(
+            keyword="security", publisher=self.publisher, advertisement=self.ad2
+        ).first()
+        self.assertIsNotNone(ki_ad2)
+        self.assertEqual(ki_ad2.offers, 2)
+        self.assertEqual(ki_ad2.views, 2)
+        self.assertEqual(ki_ad2.clicks, 0)
+
+    def test_daily_update_geos(self):
+        # Ad1/CA - offered/decision=3, views=2, clicks=1
+        # Ad1/DE - offered/decision=1, views=1, clicks=0
+        # Ad2/DE - offered/decisions=2, views=2, clicks=0
+        daily_update_geos()
+
+        # Verify that the aggregation task worked correctly
+        geo_ad1_ca = GeoImpression.objects.filter(
+            country="CA", publisher=self.publisher, advertisement=self.ad1
+        ).first()
+        self.assertIsNotNone(geo_ad1_ca)
+        self.assertEqual(geo_ad1_ca.offers, 3)
+        self.assertEqual(geo_ad1_ca.views, 2)
+        self.assertEqual(geo_ad1_ca.clicks, 1)
+
+        geo_ad1_de = GeoImpression.objects.filter(
+            country="DE", publisher=self.publisher, advertisement=self.ad1
+        ).first()
+        self.assertIsNotNone(geo_ad1_de)
+        self.assertEqual(geo_ad1_de.offers, 1)
+        self.assertEqual(geo_ad1_de.views, 1)
+        self.assertEqual(geo_ad1_de.clicks, 0)
+
+        geo_ad2_de = GeoImpression.objects.filter(
+            country="DE", publisher=self.publisher, advertisement=self.ad2
+        ).first()
+        self.assertIsNotNone(geo_ad2_de)
+        self.assertEqual(geo_ad2_de.offers, 2)
+        self.assertEqual(geo_ad2_de.views, 2)
+        self.assertEqual(geo_ad2_de.clicks, 0)
+
+        reg_na_ad1 = RegionImpression.objects.filter(
+            region="us-ca", publisher=self.publisher, advertisement=self.ad1
+        ).first()
+        self.assertIsNotNone(reg_na_ad1)
+        self.assertEqual(reg_na_ad1.offers, 3)
+        self.assertEqual(reg_na_ad1.views, 2)
+        self.assertEqual(reg_na_ad1.clicks, 1)
+
+        reg_eu_ad1 = RegionImpression.objects.filter(
+            region="eu-aus-nz", publisher=self.publisher, advertisement=self.ad1
+        ).first()
+        self.assertIsNotNone(reg_eu_ad1)
+        self.assertEqual(reg_eu_ad1.offers, 1)
+        self.assertEqual(reg_eu_ad1.views, 1)
+        self.assertEqual(reg_eu_ad1.clicks, 0)
+
+        reg_eu_ad2 = RegionImpression.objects.filter(
+            region="eu-aus-nz", publisher=self.publisher, advertisement=self.ad2
+        ).first()
+        self.assertIsNotNone(reg_eu_ad2)
+        self.assertEqual(reg_eu_ad2.offers, 2)
+        self.assertEqual(reg_eu_ad2.views, 2)
+        self.assertEqual(reg_eu_ad2.clicks, 0)
+
+    def test_daily_update_regiontopic(self):
+        # Ad1/backend/CA - offered/decision=3, views=2, clicks=1
+        # Ad1/backend/DE - offered/decision=1, views=1, clicks=0
+        # Ad2/security/DE - offered/decisions=2, views=2, clicks=0
+        daily_update_regiontopic()
+
+        na_backend_ad1 = RegionTopicImpression.objects.filter(
+            region="us-ca", topic="backend-web", advertisement=self.ad1
+        ).first()
+        self.assertIsNotNone(na_backend_ad1)
+        self.assertEqual(na_backend_ad1.offers, 3)
+        self.assertEqual(na_backend_ad1.views, 2)
+        self.assertEqual(na_backend_ad1.clicks, 1)
+
+        eu_backend_ad1 = RegionTopicImpression.objects.filter(
+            region="eu-aus-nz", topic="backend-web", advertisement=self.ad1
+        ).first()
+        self.assertIsNotNone(eu_backend_ad1)
+        self.assertEqual(eu_backend_ad1.offers, 1)
+        self.assertEqual(eu_backend_ad1.views, 1)
+        self.assertEqual(eu_backend_ad1.clicks, 0)
+
+        eu_security_ad2 = RegionTopicImpression.objects.filter(
+            region="eu-aus-nz", topic="security-privacy", advertisement=self.ad2
+        ).first()
+        self.assertIsNotNone(eu_security_ad2)
+        self.assertEqual(eu_security_ad2.offers, 2)
+        self.assertEqual(eu_security_ad2.views, 2)
+        self.assertEqual(eu_security_ad2.clicks, 0)
+
+    def test_daily_update_uplift(self):
+        # Ad1 - offered/decision=1, views=1, clicks=1
+        # Ad2 - offered/decisions=2, views=2, clicks=0
+        daily_update_uplift()
+
+        uplift1 = UpliftImpression.objects.filter(advertisement=self.ad1).first()
+        self.assertIsNotNone(uplift1)
+        self.assertEqual(uplift1.offers, 1)
+        self.assertEqual(uplift1.views, 1)
+        self.assertEqual(uplift1.clicks, 1)
+
+        uplift2 = UpliftImpression.objects.filter(advertisement=self.ad2).first()
+        self.assertIsNotNone(uplift2)
+        self.assertEqual(uplift2.offers, 2)
+        self.assertEqual(uplift2.views, 2)
+        self.assertEqual(uplift2.clicks, 0)
+
+    def test_daily_update_placements(self):
+        # Ad1/id_1 - offered/decision=3, views=2, clicks=1
+        # Ad1/id_2 - offered/decisions=1, views=1, clicks=0
+        # Ad2/id_2 - offered/decisions=2, views=2, clicks=0
+        daily_update_placements()
+
+        pi1_ad1 = PlacementImpression.objects.filter(
+            advertisement=self.ad1, div_id="id_1"
+        ).first()
+        self.assertIsNotNone(pi1_ad1)
+        self.assertEqual(pi1_ad1.offers, 3)
+        self.assertEqual(pi1_ad1.views, 2)
+        self.assertEqual(pi1_ad1.clicks, 1)
+
+        pi2_ad1 = PlacementImpression.objects.filter(
+            advertisement=self.ad1, div_id="id_2"
+        ).first()
+        self.assertIsNotNone(pi2_ad1)
+        self.assertEqual(pi2_ad1.offers, 1)
+        self.assertEqual(pi2_ad1.views, 1)
+        self.assertEqual(pi2_ad1.clicks, 0)
+
+        pi2_ad2 = PlacementImpression.objects.filter(
+            advertisement=self.ad2, div_id="id_2"
+        ).first()
+        self.assertIsNotNone(pi2_ad2)
+        self.assertEqual(pi2_ad2.offers, 2)
+        self.assertEqual(pi2_ad2.views, 2)
+        self.assertEqual(pi2_ad2.clicks, 0)


### PR DESCRIPTION
This adds performance improvements to our daily aggregations. This builds on the improvements in https://github.com/readthedocs/ethical-ad-server/pull/508 and uses similar ones for the other aggregations. This should cut down both our read and write queries by a factor of ~4. I expect this to cut the time taken to do a daily aggregation by 50-66% or so.

Notably, the tests added in this PR work with or without the changes to `tasks.py`.