### PR TITLE
Performance improvement to offer recording

### DIFF
--- a/adserver/api/views.py
+++ b/adserver/api/views.py
@@ -13,7 +13,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_jsonp.renderers import JSONPRenderer
 
-from ..constants import DECISIONS
 from ..decisionengine import get_ad_decision_backend
 from ..models import AdImpression
 from ..models import Advertisement
@@ -174,8 +173,6 @@ class AdDecisionView(GeoIpMixin, APIView):
                     url=url,
                 )
                 return {}
-
-            ad.incr(impression_type=DECISIONS, publisher=publisher)
 
             data = ad.offer_ad(
                 request=self.request,

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -989,6 +989,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
 
         # At this point, the ad has been "offered" but not "viewed"
         impression = self.ad.impressions.filter(publisher=self.publisher1).first()
+        self.assertEqual(impression.decisions, 1)
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.views, 0)
 
@@ -1011,6 +1012,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
 
         # Verify an impression was written
         impression = self.ad.impressions.filter(publisher=self.publisher1).first()
+        self.assertEqual(impression.decisions, 1)
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.views, 1)
 
@@ -1064,8 +1066,34 @@ class AdvertisingIntegrationTests(BaseApiTest):
         self.assertEqual(resp.status_code, 200, resp.content)
 
         impression = self.ad.impressions.filter(publisher=self.publisher2).first()
+        self.assertEqual(impression.decisions, 1)
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.views, 0)
+
+    def test_multiple_ad_offers_views(self):
+        data = {"placements": self.placements, "publisher": self.publisher1.slug}
+        times = 5
+
+        # Simulate some offers and views
+        for _ in range(times):
+            resp = self.client.post(
+                self.url, json.dumps(data), content_type="application/json"
+            )
+            self.assertEqual(resp.status_code, 200, resp.content)
+
+            # Simulate the view
+            view_url = reverse(
+                "view-proxy",
+                kwargs={"advertisement_id": self.ad.pk, "nonce": resp.json()["nonce"]},
+            )
+            resp = self.proxy_client.get(view_url)
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp["X-Adserver-Reason"], "Billed view")
+
+        impression = self.ad.impressions.filter(publisher=self.publisher1).first()
+        self.assertEqual(impression.decisions, times)
+        self.assertEqual(impression.offers, times)
+        self.assertEqual(impression.views, times)
 
     def test_ad_views_for_forced_ads(self):
         data = {
@@ -1094,6 +1122,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
 
         # Verify an impression was written - but not considered viewed
         impression = self.ad.impressions.filter(publisher=self.publisher1).first()
+        self.assertEqual(impression.decisions, 1)
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.views, 0)
 
@@ -1114,6 +1143,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
 
         # At this point, the ad has been "offered" but not "clicked"
         impression = self.ad.impressions.filter(publisher=self.publisher1).first()
+        self.assertEqual(impression.decisions, 1)
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.clicks, 0)
 
@@ -1150,6 +1180,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
 
         # Verify an impression was written
         impression = self.ad.impressions.filter(publisher=self.publisher1).first()
+        self.assertEqual(impression.decisions, 1)
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.clicks, 1)
 
@@ -1188,6 +1219,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
 
         # Verify an impression was written
         impression = self.ad.impressions.filter(publisher=self.publisher1).first()
+        self.assertEqual(impression.decisions, 1)
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.views, 1)
 
@@ -1224,6 +1256,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
 
         # Verify an impression was written
         impression = self.ad.impressions.filter(publisher=self.publisher1).first()
+        self.assertEqual(impression.decisions, 1)
         self.assertEqual(impression.offers, 1)
         self.assertEqual(impression.views, 1)
 


### PR DESCRIPTION
This is a small performance optimization to recording offers. It records the offer and decision at the same time. This should cut down by a read query and a write query.