### PR TITLE
Post to Slack when an invoice is paid

### DIFF
--- a/adserver/apps.py
+++ b/adserver/apps.py
@@ -8,3 +8,4 @@ class AdserverConfig(AppConfig):
 
     def ready(self):
         import adserver.tasks  # noqa
+        import adserver.hooks  # noqa

--- a/adserver/hooks.py
+++ b/adserver/hooks.py
@@ -1,0 +1,32 @@
+"""Handle specific Stripe webhooks with special logic."""
+import logging
+
+import stripe
+from django_slack import slack_message
+from djstripe import webhooks
+from djstripe.models import Invoice
+
+
+log = logging.getLogger(__name__)  # noqa
+
+
+@webhooks.handler("invoice.payment_succeeded")
+def invoice_paid_to_slack(event, **kwargs):
+    """Post paid invoices to Slack."""
+    data = event.data["object"]
+
+    # This is a little over-engineered
+    # However, by fetching from Stripe and then syncing,
+    # we ensure there isn't a race condition between the webhook and this handler
+    # Also, this will work in test-mode as well as production
+    invoice_id = data["id"]
+    invoice = Invoice.sync_from_stripe_data(stripe.Invoice.retrieve(invoice_id))
+
+    log.debug("Stripe invoice %s is paid. Posting to Slack...", invoice)
+    slack_message(
+        "adserver/slack/invoice-paid.slack",
+        {
+            "customer": invoice.customer,
+            "invoice": invoice,
+        },
+    )

--- a/adserver/templates/adserver/slack/invoice-paid.slack
+++ b/adserver/templates/adserver/slack/invoice-paid.slack
@@ -1,0 +1,6 @@
+{% extends django_slack %}
+
+
+{% block text %}
+Customer {{ customer.name }} ({{ customer.description }}) paid invoice #{{ invoice.number }} for ${{ invoice.amount_paid }} :money_mouth_face:: {{ invoice.get_stripe_dashboard_url }}
+{% endblock %}


### PR DESCRIPTION
This will post a Slack message when an invoice is paid.

## Testing

* Set `STRIPE_SECRET_KEY` and `STRIPE_TEST_SECRET_KEY` in `.envs/local/django`.
* Follow instructions here: https://dashboard.stripe.com/test/webhooks/create?endpoint_location=local
* Test the hook with `stripe trigger invoice.payment_succeeded`