### PR TITLE
Still more Django 3.2 upgrade fixes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -293,6 +293,7 @@ LOGGING = {
 # --------------------------------------------------------------------------
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 X_FRAME_OPTIONS = "DENY"
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_HTTPONLY = True

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -16,5 +16,5 @@ django-redis==5.2.0
 django-storages[azure]==1.12.3
 
 # Logging and monitoring
-newrelic==5.4.0.132
-sentry-sdk==0.13.4
+newrelic==7.4.0.172
+sentry-sdk==1.5.5


### PR DESCRIPTION
- Django sets the referrer-policy header which prevents the cross-origin support form from working correctly. Set `SECURE_REFERRER_POLICY` to fix.
- Upgraded New Relic and Sentry