### PR TITLE
Adds a Front (front.com) email backend

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ plugins =
     django_coverage_plugin
 source =
     adserver
+    frontbackend
     templates
 omit =
     # Skip django AppConfig files

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -188,6 +188,7 @@ DEFAULT_FROM_EMAIL = SERVER_EMAIL
 EMAIL_TIMEOUT = 5
 
 # For sending email through Front.
+FRONT_BACKEND = "frontbackend.backend.EmailBackend"
 FRONT_TOKEN = env("FRONT_TOKEN", default=None)
 FRONT_CHANNEL = env("FRONT_CHANNEL", default=None)
 FRONT_AUTHOR = env("FRONT_AUTHOR", default=None)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -187,10 +187,13 @@ SERVER_EMAIL = "noreply@ethicalads.io"
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
 EMAIL_TIMEOUT = 5
 
-# For sending Front email. Only used for Payouts.
+# For sending email through Front.
 FRONT_TOKEN = env("FRONT_TOKEN", default=None)
 FRONT_CHANNEL = env("FRONT_CHANNEL", default=None)
 FRONT_AUTHOR = env("FRONT_AUTHOR", default=None)
+FRONT_SENDER_NAME = env("FRONT_SENDER_NAME", default=None)
+FRONT_ARCHIVE = env.bool("FRONT_ARCHIVE", default=False)
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/

--- a/frontbackend/__init__.py
+++ b/frontbackend/__init__.py
@@ -1,0 +1,1 @@
+"""Front email backend module."""

--- a/frontbackend/backend.py
+++ b/frontbackend/backend.py
@@ -1,0 +1,127 @@
+"""
+Front (front.com) email backend.
+
+There's some differences from normal email:
+
+- There are a few settings:
+  * FRONT_TOKEN - the API token used in the Authorization header
+  * FRONT_CHANNEL - the Front inbox to use
+  * FRONT_AUTHOR - the author for a draft message; ONLY used with drafts
+  * FRONT_ARCHIVE (default=False) - whether to archive sent messages
+- "From" and "Reply to" aren't used.
+  Instead, the from address is set by the channel (FRONT_CHANNEL).
+- By appending an attribute "draft" to an email message,
+  the backend will create a draft instead of sending the message.
+"""
+import logging
+
+import requests
+from django.core.mail.backends.base import BaseEmailBackend
+from django.core.mail.message import sanitize_address
+
+from . import settings
+
+
+log = logging.getLogger(__name__)  # noqa
+
+
+class EmailBackend(BaseEmailBackend):
+
+    """
+    Custom email backend to send messages through Front (front.com).
+
+    See: https://docs.djangoproject.com/en/3.2/topics/email/#defining-a-custom-email-backend
+    """
+
+    def __init__(self, **kwargs):
+        """Init override."""
+        super().__init__(**kwargs)
+
+        token = settings.FRONT_TOKEN
+        channel = settings.FRONT_CHANNEL
+
+        if not token or not channel:
+            raise NotImplementedError(
+                "For the Front email backend, "
+                "settings.FRONT_TOKEN and settings.FRONT_CHANNEL "
+                "must be set."
+            )
+
+        # Whether to archive messages on send
+        self.archive = settings.FRONT_ARCHIVE
+
+        # Front API urls for creating a conversation or creating a draft
+        # https://dev.frontapp.com/reference/post_channels-channel-id-messages
+        # https://dev.frontapp.com/reference/post_conversations-conversation-id-drafts
+        self.message_url = f"https://api2.frontapp.com/channels/{channel}/messages"
+        self.draft_url = f"https://api2.frontapp.com/channels/{channel}/drafts"
+
+        self.headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+        }
+
+    def send_messages(self, email_messages):
+        """Write all messages to the stream in a thread-safe way."""
+        if not email_messages:
+            return 0
+
+        num_sent = 0
+        for message in email_messages:
+            sent = self._send(message)
+            if sent:
+                num_sent += 1
+
+        return num_sent
+
+    def _send(self, email_message):
+        """A helper method that does the actual sending through the Front API."""
+        if not email_message.recipients():
+            return False
+
+        # Whether this email should be created as a draft or simply sent (the default)
+        draft = getattr(email_message, "draft", False)
+
+        encoding = email_message.encoding or settings.DEFAULT_CHARSET
+        recipients = [
+            sanitize_address(addr, encoding) for addr in email_message.recipients()
+        ]
+
+        if email_message.attachments:
+            log.warning("Front email backend does not yet implement attachments!")
+
+        payload = {
+            "to": recipients,
+            "cc": email_message.cc,
+            "bcc": email_message.bcc,
+            "sender_name": settings.FRONT_SENDER_NAME,
+            "subject": email_message.subject,
+            "options": {"archive": self.archive},
+            "body": email_message.body,
+        }
+
+        if draft:
+            url = self.draft_url
+            payload["mode"] = "shared"
+            payload["author_id"] = settings.FRONT_AUTHOR
+            if not settings.FRONT_AUTHOR:
+                raise NotImplementedError(
+                    "Can't save a draft message without setting FRONT_AUTHOR."
+                )
+            log.debug("Creating Front draft message: %s", email_message.subject)
+        else:
+            url = self.message_url
+            log.debug("Starting Front conversation: %s", email_message.subject)
+
+        response = requests.post(url, json=payload, headers=self.headers)
+
+        if response.ok:
+            return True
+
+        if not self.fail_silently:
+            log.error(
+                "Failed to send front message: %s, to=%s", response.content, recipients
+            )
+            response.raise_for_status()
+
+        return False

--- a/frontbackend/settings.py
+++ b/frontbackend/settings.py
@@ -1,4 +1,8 @@
-"""Default settings for the Front email backend."""
+"""
+Default settings for the Front email backend.
+
+These can be overridden when initializing the backend.
+"""
 from django.conf import settings
 
 
@@ -19,6 +23,8 @@ FRONT_SENDER_NAME = getattr(settings, "FRONT_SENDER_NAME", None)
 
 # The author for a draft message
 # This is *ONLY* used when saving drafts
+# This should be set to a "Teammate ID"
+# https://dev.frontapp.com/reference/get_teammates
 FRONT_AUTHOR = getattr(settings, "FRONT_AUTHOR", None)
 
 # Whether to archive messages after they are sent

--- a/frontbackend/settings.py
+++ b/frontbackend/settings.py
@@ -1,0 +1,29 @@
+"""Default settings for the Front email backend."""
+from django.conf import settings
+
+
+# The FRONT_TOKEN is the token set in the authorization header
+# Do not include the phrase "Bearer".
+# https://dev.frontapp.com/docs/authentication
+FRONT_TOKEN = getattr(settings, "FRONT_TOKEN", None)
+
+# FRONT_CHANNEL should be the channel ID in front.
+# This usually should be of the form `cha_XXX`.
+# Retrieve a list of channels with
+# https://dev.frontapp.com/reference/get_channels
+FRONT_CHANNEL = getattr(settings, "FRONT_CHANNEL", None)
+
+# FRONT_SENDER_NAME customizes the display of the sender
+# If not set, it will be the default for the channel
+FRONT_SENDER_NAME = getattr(settings, "FRONT_SENDER_NAME", None)
+
+# The author for a draft message
+# This is *ONLY* used when saving drafts
+FRONT_AUTHOR = getattr(settings, "FRONT_AUTHOR", None)
+
+# Whether to archive messages after they are sent
+FRONT_ARCHIVE = getattr(settings, "FRONT_ARCHIVE", False)
+
+# This is just a setting from Django used in the backend
+# https://docs.djangoproject.com/en/3.2/ref/settings/#default-charset
+DEFAULT_CHARSET = settings.DEFAULT_CHARSET

--- a/frontbackend/tests.py
+++ b/frontbackend/tests.py
@@ -1,0 +1,106 @@
+from unittest import mock
+
+import requests
+import responses
+from django.core import mail
+from django.test import TestCase
+
+from .backend import EmailBackend
+
+
+class FrontEmailBackendTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.channel = "cha_XXX"
+        self.token = "fake-token"
+        self.sender_name = "Sender Name"
+        self.archive = True
+        self.author = "tea_XXX"
+
+        self.message = mail.EmailMessage(
+            "Test subject",
+            "This is a test body",
+            "noreply@ethicalads.io",  # From (not used)
+            ["test@ethicalads.io"],  # To
+        )
+
+    def test_bad_setup(self):
+        with self.assertRaises(NotImplementedError):
+            self.backend = EmailBackend()
+
+    @responses.activate
+    def test_send_message(self):
+        with mock.patch("frontbackend.backend.settings") as front_settings:
+            front_settings.FRONT_CHANNEL = self.channel
+            front_settings.FRONT_TOKEN = self.token
+            front_settings.FRONT_SENDER_NAME = self.sender_name
+            front_settings.FRONT_ARCHIVE = self.archive
+
+            self.backend = EmailBackend()
+
+            self.assertEqual(self.backend.send_messages([]), 0)
+
+            responses.add(
+                responses.POST,
+                f"https://api2.frontapp.com/channels/{self.channel}/messages",
+            )
+            self.assertEqual(self.backend.send_messages([self.message]), 1)
+
+            # Test with attachments (not currently implemented)
+            self.message.attach("test.txt", b"123", "text/plain")
+            self.assertEqual(self.backend.send_messages([self.message]), 1)
+
+    @responses.activate
+    def test_send_message_failure(self):
+        with mock.patch("frontbackend.backend.settings") as front_settings:
+            front_settings.FRONT_CHANNEL = self.channel
+            front_settings.FRONT_TOKEN = self.token
+            front_settings.FRONT_SENDER_NAME = self.sender_name
+            front_settings.FRONT_ARCHIVE = self.archive
+
+            self.backend = EmailBackend(fail_silently=True)
+
+            # No recipients (no http request, etc.)
+            self.message.to = []
+            self.assertEqual(self.backend.send_messages([self.message]), 0)
+
+            self.message.to = ["test@ethicalads.io"]
+
+            # Fail silently
+            responses.add(
+                responses.POST,
+                f"https://api2.frontapp.com/channels/{self.channel}/messages",
+                status=400,
+            )
+            self.assertEqual(self.backend.send_messages([self.message]), 0)
+
+            # Fail LOUDLY
+            self.backend = EmailBackend(fail_silently=False)
+            responses.reset()
+            responses.add(
+                responses.POST,
+                f"https://api2.frontapp.com/channels/{self.channel}/messages",
+                status=400,
+            )
+            with self.assertRaises(requests.RequestException):
+                self.backend.send_messages([self.message])
+
+    @responses.activate
+    def test_create_draft(self):
+        with mock.patch("frontbackend.backend.settings") as front_settings:
+            front_settings.FRONT_CHANNEL = self.channel
+            front_settings.FRONT_TOKEN = self.token
+            front_settings.FRONT_SENDER_NAME = self.sender_name
+            front_settings.FRONT_ARCHIVE = self.archive
+            front_settings.FRONT_AUTHOR = self.author
+
+            self.backend = EmailBackend()
+
+            self.message.draft = True
+
+            responses.add(
+                responses.POST,
+                f"https://api2.frontapp.com/channels/{self.channel}/drafts",
+            )
+            self.assertEqual(self.backend.send_messages([self.message]), 1)

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -14,10 +14,13 @@ reorder-python-imports>=2.6.0,<3.0
 pre-commit<2.0
 
 # Sphinx for docs
-Sphinx<2.0
-sphinx-autobuild<1.0
+Sphinx<4.0
+sphinx-autobuild==2021.3.14
 sphinx-rtd-theme
-sphinxcontrib-httpdomain==1.7.0
+sphinxcontrib-httpdomain==1.8.0
+# Various doc issues with the latest Jinja with Sphinx
+Jinja2<3.0
+MarkupSafe<2.0
 
 # Various testing tools
 pytest==7.0.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -24,6 +24,7 @@ pytest==7.0.0
 pytest-django==4.5.2
 prospector==1.5.2
 django-dynamic-fixture==3.1.2
+responses==0.20.0
 
 # Coverage
 coverage<5.0


### PR DESCRIPTION
Adds a Front email backend to the project. This allows sending messages through Front or creating drafts as easily as sending a regular email through Django. This could be set as the default [EMAIL_BACKEND](https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-EMAIL_BACKEND) but it doesn't have to be and could be used as a secondary backend almost as easily.

In the future, we could consider breaking this out into a separate open source project and using it on RTD.


## Testing

You'll need to set `FRONT_CHANNEL`, `FRONT_AUTHOR` (for drafts), and `FRONT_TOKEN` in `.envs/local/django`.

Then, can be tested with the following:

```python
from django.core import mail

with mail.get_connection("frontbackend.backend.EmailBackend") as connection:
    message = mail.EmailMessage(
        "Test subject",
        "This is a test body.", 
        "from@example.com", 
        ["to@example.com"],
        connection=connection,
    )

    # Optionally make it a draft
    message.draft = True

    # Override archiving a message
    message.archive = False

    message.send()
```
