### PR TITLE
Fix the flight ordering for good

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -811,7 +811,13 @@ class Flight(TimeStampedModel, IndestructibleModel):
 
     @classmethod
     def order_flights(cls, flights):
-        """Orders flights by our normal ordering of state, then date, then name."""
+        """
+        Orders flights by our normal ordering of state, then date, then name.
+
+        Previously, we were using database ordering, but that cannot deterministically
+        order flights by state. Flights can be upcoming if they start after today
+        or if they start before today (but end after today) but aren't live.
+        """
         state_order = {
             FLIGHT_STATE_CURRENT: 0,
             FLIGHT_STATE_UPCOMING: 1,

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -809,6 +809,19 @@ class Flight(TimeStampedModel, IndestructibleModel):
             return FLIGHT_STATE_UPCOMING
         return FLIGHT_STATE_PAST
 
+    @classmethod
+    def order_flights(cls, flights):
+        """Orders flights by our normal ordering of state, then date, then name."""
+        state_order = {
+            FLIGHT_STATE_CURRENT: 0,
+            FLIGHT_STATE_UPCOMING: 1,
+            FLIGHT_STATE_PAST: 2,
+        }
+        return sorted(
+            flights,
+            key=lambda f: (state_order[f.state], -1 * f.start_date.toordinal(), f.name),
+        )
+
     def get_absolute_url(self):
         return reverse(
             "flight_detail",

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -202,8 +202,8 @@ class AdvertiserMainView(
         flights = [
             f
             for f in (
-                Flight.objects.filter(campaign__advertiser=self.advertiser).order_by(
-                    "-live", "start_date", "name"
+                Flight.order_flights(
+                    Flight.objects.filter(campaign__advertiser=self.advertiser)
                 )
             )
             if f.state in (FLIGHT_STATE_UPCOMING, FLIGHT_STATE_CURRENT)
@@ -268,8 +268,8 @@ class FlightListView(AdvertiserAccessMixin, UserPassesTestMixin, ListView):
         self.advertiser = get_object_or_404(
             Advertiser, slug=self.kwargs["advertiser_slug"]
         )
-        return Flight.objects.filter(campaign__advertiser=self.advertiser).order_by(
-            "-live", "-start_date", "name"
+        return Flight.order_flights(
+            Flight.objects.filter(campaign__advertiser=self.advertiser)
         )
 
 
@@ -1034,10 +1034,10 @@ class AdvertiserReportView(AdvertiserAccessMixin, BaseReportView):
         report = AdvertiserReport(queryset)
         report.generate()
 
-        flights = (
-            Flight.objects.filter(campaign__advertiser=advertiser)
-            .order_by("-live", "start_date", "name")
-            .select_related("campaign")
+        flights = Flight.order_flights(
+            Flight.objects.filter(campaign__advertiser=advertiser).select_related(
+                "campaign"
+            )
         )
 
         context.update(


### PR DESCRIPTION
Fixed in a way that https://github.com/readthedocs/ethical-ad-server/pull/466 didn't quite fix.

Based on flights being delayed or overlapping other flights (startdate1 before startdate2 but enddate1 after enddate2) you can have our flight headers get duplicated.

## Illustration of the problem
![Screenshot from 2022-06-17 13-33-50](https://user-images.githubusercontent.com/185043/174403757-e1fbea64-22bd-47eb-98cf-7f5222ee416d.png)

