### PR TITLE
Use analyzer keyword findings in ad decision

### DIFF
--- a/adserver/tests/test_decision_engine.py
+++ b/adserver/tests/test_decision_engine.py
@@ -7,6 +7,7 @@ from django.test.client import RequestFactory
 from django_dynamic_fixture import get
 from user_agents import parse
 
+from ..analyzer.models import AnalyzedUrl
 from ..constants import AFFILIATE_CAMPAIGN
 from ..constants import CLICKS
 from ..constants import COMMUNITY_CAMPAIGN
@@ -613,9 +614,34 @@ class DecisionEngineTests(TestCase):
             request=self.request, placements=self.placements, publisher=self.publisher
         )
 
-        self.assertTrue(
-            self.backend.keywords, ["foo", "bar", "baz", "machine-learning"]
+        self.assertEqual(
+            sorted(self.backend.keywords), ["bar", "baz", "foo", "machine-learning"]
         )
+
+    def test_analyzer_keywords(self):
+        url = "http://example.com"
+
+        backend = AdvertisingEnabledBackend(
+            request=self.request,
+            placements=self.placements,
+            publisher=self.publisher,
+            url=url,
+        )
+        self.assertEqual(backend.keywords, [])
+
+        AnalyzedUrl.objects.create(
+            url=url,
+            publisher=self.publisher,
+            keywords=["foo", "bar"],
+        )
+
+        backend = AdvertisingEnabledBackend(
+            request=self.request,
+            placements=self.placements,
+            publisher=self.publisher,
+            url=url,
+        )
+        self.assertEqual(backend.keywords, ["foo", "bar"])
 
     def test_publisher_excluded(self):
         flights = self.probabilistic_backend.get_candidate_flights()

--- a/adserver/tests/test_decision_engine.py
+++ b/adserver/tests/test_decision_engine.py
@@ -641,7 +641,7 @@ class DecisionEngineTests(TestCase):
             publisher=self.publisher,
             url=url,
         )
-        self.assertEqual(backend.keywords, ["foo", "bar"])
+        self.assertEqual(sorted(backend.keywords), ["bar", "foo"])
 
     def test_publisher_excluded(self):
         flights = self.probabilistic_backend.get_candidate_flights()


### PR DESCRIPTION
**NOTE:** My goal isn't to merge this until we're ready to roll out the analyzer into wider use.

Uses keywords/topics found by the adserver analyzer during the decision process. This is merged with publisher keywords and ad client keywords.

## Considerations

- This will add an extra query to the ad decision process in most cases. That should add 3-5ms, I'd estimate.
- We could consider caching this but there's a few things to consider there. For very frequently used URLs, that would probably result in some speedup. However, if we use a local memory cache, it will only yield gains for very frequently used URLs that are hit by the same backend process (which are restarted every 10k requests) multiple times. However, if we add it to Redis to be shared by backend processes, then it might add about as much as the DB.