### PR TITLE
Add the topic classifier backend

### DIFF
--- a/adserver/analyzer/backends/eatopics.py
+++ b/adserver/analyzer/backends/eatopics.py
@@ -1,0 +1,26 @@
+"""Spacy-based topic classifier that uses our trained model and gives a likelihood that text is about our topics."""
+from .textacynlp import TextacyAnalyzerBackend
+
+
+class EthicalAdsTopicsBackend(TextacyAnalyzerBackend):
+
+    """A model that uses our own custom dataset behind the scenes."""
+
+    # Name of the model package
+    # A Python package of this name will be imported and IOError thrown if not present
+    MODEL_NAME = "en_ethicalads_topics"
+
+    # Below this body/text length, the model is unreliable
+    # Return blank results lower than this length (~100 words)
+    MIN_TEXT_LENGTH = 500
+
+    # Threshold on the model
+    MODEL_THRESHOLD = 0.4
+
+    def analyze_text(self, text):
+        """Analyze text and return major topics (topics we are interested in) that the text is about."""
+        if len(text) < self.MIN_TEXT_LENGTH:
+            return []
+
+        output = self.pretrained_model(text)
+        return [k for k, v in output.cats.items() if v > self.MODEL_THRESHOLD]

--- a/adserver/analyzer/backends/textacynlp.py
+++ b/adserver/analyzer/backends/textacynlp.py
@@ -24,12 +24,15 @@ class TextacyAnalyzerBackend(NaiveKeywordAnalyzerBackend):
     # Minimum phrase length where each word isn't required to be in the output phrase
     MIN_PHRASE_LENGTH = 6
 
+    MODEL_NAME = "en_core_web_md"
+
     def __init__(self, url, **kwargs):
         """Overrides to lemmatize keywords."""
         super().__init__(url, **kwargs)
 
+        # Raises IOError if the model is not installed!
         self.pretrained_model = textacy.load_spacy_lang(
-            "en_core_web_md", disable=("parser",)
+            self.MODEL_NAME, disable=("parser",)
         )
 
         self.preprocessor = preprocessing.make_pipeline(


### PR DESCRIPTION
This is a simple backend for the classifier. It outputs the topic categories as the keywords.

## Considerations

* Possibly we should do keyword extraction as well (maybe using the default textacy model?) and use those keywords as well. This will be useful for advertisers not targeting our major topics but rather something long tail (eg. `two-factor-auth`).
* The model threshold (currently 0.4) is a debatable number. I feel 0.4-0.5 are reasonable.