### PR TITLE
Add a management command for ease of running the model in dev

### DIFF
--- a/adserver/analyzer/backends/base.py
+++ b/adserver/analyzer/backends/base.py
@@ -48,7 +48,8 @@ class BaseAnalyzerBackend:
 
         if resp and resp.ok:
             return self.analyze_response(resp)
-        elif not resp:
+
+        if not resp:
             log.debug("Failed to connect. Url=%s", self.url)
         else:
             log.debug(

--- a/adserver/analyzer/backends/base.py
+++ b/adserver/analyzer/backends/base.py
@@ -48,6 +48,12 @@ class BaseAnalyzerBackend:
 
         if resp and resp.ok:
             return self.analyze_response(resp)
+        elif not resp:
+            log.debug("Failed to connect. Url=%s", self.url)
+        else:
+            log.debug(
+                "Failed to connect. Url=%s, Status=%s", self.url, resp.status_code
+            )
 
         # A failed request results in `None`.
         return None

--- a/adserver/analyzer/backends/eatopics.py
+++ b/adserver/analyzer/backends/eatopics.py
@@ -1,5 +1,11 @@
 """Spacy-based topic classifier that uses our trained model and gives a likelihood that text is about our topics."""
+import logging
+import textwrap
+
 from .textacynlp import TextacyAnalyzerBackend
+
+
+log = logging.getLogger(__name__)  # noqa
 
 
 class EthicalAdsTopicsBackend(TextacyAnalyzerBackend):
@@ -21,6 +27,11 @@ class EthicalAdsTopicsBackend(TextacyAnalyzerBackend):
         """Analyze text and return major topics (topics we are interested in) that the text is about."""
         if len(text) < self.MIN_TEXT_LENGTH:
             return []
+
+        wrapped_output = "\n".join(
+            textwrap.wrap(text, initial_indent="    ", subsequent_indent="    ")
+        )
+        log.debug("Analyzing text of len=%s:\n%s", len(text), wrapped_output)
 
         output = self.pretrained_model(text)
         return [k for k, v in output.cats.items() if v > self.MODEL_THRESHOLD]

--- a/adserver/analyzer/backends/eatopics.py
+++ b/adserver/analyzer/backends/eatopics.py
@@ -34,4 +34,5 @@ class EthicalAdsTopicsBackend(TextacyAnalyzerBackend):
         log.debug("Analyzing text of len=%s:\n%s", len(text), wrapped_output)
 
         output = self.pretrained_model(text)
+        log.debug("Model classification: %s", output.cats.items())
         return [k for k, v in output.cats.items() if v > self.MODEL_THRESHOLD]

--- a/adserver/analyzer/management/__init__.py
+++ b/adserver/analyzer/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for the analyzer."""

--- a/adserver/analyzer/management/commands/__init__.py
+++ b/adserver/analyzer/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for the analyzer."""

--- a/adserver/analyzer/management/commands/runmodel.py
+++ b/adserver/analyzer/management/commands/runmodel.py
@@ -1,0 +1,45 @@
+"""Run the ML model on the specified URLs."""
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.core.validators import URLValidator
+from django.utils.translation import gettext_lazy as _
+
+from ...utils import get_url_analyzer_backend
+
+
+class Command(BaseCommand):
+
+    """Run the ML model on the specified URLs."""
+
+    help = "Run the ML model on the specified URLs. Results are not stored to the database."
+
+    def add_arguments(self, parser):
+        """Add command line args for this command."""
+        parser.add_argument(
+            "urls",
+            nargs="+",
+            help=_("URL to run against"),
+        )
+
+    def handle(self, *args, **kwargs):
+        """Entrypoint to the command."""
+        self.stdout.write(
+            _("Using the model from %s") % settings.ADSERVER_ANALYZER_BACKEND
+        )
+
+        for url in kwargs["urls"]:
+            # raises ValidationError on an invalid URL
+            if not URLValidator()(url):
+                self.handle_url(url)
+
+    def handle_url(self, url):
+        """Dump questions from metabase to a file."""
+        self.stdout.write(_("Running against %s") % url)
+
+        backend = get_url_analyzer_backend()(url)
+        keywords = backend.analyze()
+
+        if keywords is None:
+            self.stderr.write(_("Failed to connect/process %s") % url)
+
+        self.stdout.write(_("Keywords/topics: %s") % keywords)

--- a/machine_learning_experiments/README.md
+++ b/machine_learning_experiments/README.md
@@ -11,6 +11,14 @@ This will generate our training data and then build and train the model.
 	python -m spacy project run all . --vars.train=train --vars.dev=test --vars.name=ethicalads_topics --vars.version=`date "+%Y%m%d_%H_%M_%S"`
 
 
+### Running the analyzer
+
+After installing the analyzer (it's installed in staging already),
+you can run it against an arbitrary URL to see how that page was classified.
+
+    ADSERVER_ANALYZER_BACKEND=adserver.analyzer.backends.EthicalAdsTopicsBackend ./manage.py runmodel https://example.com
+
+
 ## 📋 project.yml
 
 The [`project.yml`](project.yml) defines the data assets required by the


### PR DESCRIPTION
You can run the model easily against any URL with our exact preprocessing with the following:

```bash
ADSERVER_ANALYZER_BACKEND=adserver.analyzer.backends.EthicalAdsTopicsBackend ./manage.py runmodel https://example.com
```

Results are printed to the terminal but not stored anywhere. This is for development primarily but could be run in prod without affecting prod.