### PR TITLE
Use a dedicated analyzer queue for analyzer tasks

### DIFF
--- a/adserver/analyzer/tasks.py
+++ b/adserver/analyzer/tasks.py
@@ -130,4 +130,6 @@ def daily_analyze_urls(days=7, min_visits=50):
 
     log.debug("URLs to analyze: %s", analyzed_urls.count())
     for analyzed_url in analyzed_urls:
-        analyze_url.apply_async(args=[analyzed_url.url, analyzed_url.publisher.slug])
+        analyze_url.apply_async(
+            args=[analyzed_url.url, analyzed_url.publisher.slug], queue="analyzer"
+        )

--- a/docker-compose/local/django/celery/beat/start
+++ b/docker-compose/local/django/celery/beat/start
@@ -5,4 +5,4 @@ set -o nounset
 
 
 rm -f './celerybeat.pid'
-celery -A config.celery_app beat -l INFO
+celery -A config.celery_app beat -l INFO -Q celery,analyzer

--- a/docker-compose/local/django/celery/worker/start
+++ b/docker-compose/local/django/celery/worker/start
@@ -4,4 +4,4 @@ set -o errexit
 set -o nounset
 
 
-celery -A config.celery_app worker -l INFO
+celery -A config.celery_app worker -l INFO -Q celery,analyzer


### PR DESCRIPTION
This will seperate them in production,
so they don't stomp on our normal workers.
