### PR TITLE
Remove the end date filter

### DIFF
--- a/adserver/views.py
+++ b/adserver/views.py
@@ -206,7 +206,7 @@ class AdvertiserMainView(AdvertiserAccessMixin, UserPassesTestMixin, DetailView)
             {
                 "advertiser": self.advertiser,
                 "advertiser_new": self.is_advertiser_new(),
-                "has_views_this_month": self.has_views_this_month(start_date, end_date),
+                "has_views_this_month": self.has_views_this_month(start_date),
                 "are_ads_set_up": self.are_ads_set_up(),
                 "has_paid_invoice": self.has_paid_invoice(),
                 "flights": flights,
@@ -225,13 +225,13 @@ class AdvertiserMainView(AdvertiserAccessMixin, UserPassesTestMixin, DetailView)
             advertisement__flight__campaign__advertiser_id=self.advertiser.id
         ).exists()
 
-    def has_views_this_month(self, start_date, end_date):
-        """Detect if advertisers have impressions in the time frame."""
+    def has_views_this_month(self, start_date):
+        """Detect if advertisers have impressions since the start date (first of the month)."""
         return (
             AdImpression.objects.filter(
                 advertisement__flight__campaign__advertiser_id=self.advertiser.id
             )
-            .filter(date__gte=start_date, date__lte=end_date)
+            .filter(date__gte=start_date)
             .exists()
         )
 


### PR DESCRIPTION
This filter wasn't even correct. It would filter before the beginning of the last day of the month.

I've seen some performance issues with this query but `EXPLAIN ANALYZE` doesn't show anything useful. It shows the query as fast and using indexes. It is fast when cached.

```
                                                                                      QUERY PLAN                                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=2.10..3.37 rows=1 width=819) (actual time=26.780..26.782 rows=1 loops=1)
   ->  Nested Loop  (cost=2.10..555.36 rows=435 width=819) (actual time=26.779..26.781 rows=1 loops=1)
         ->  Nested Loop  (cost=1.67..25.69 rows=10 width=767) (actual time=0.046..0.324 rows=90 loops=1)
               ->  Nested Loop  (cost=1.39..23.46 rows=4 width=372) (actual time=0.041..0.102 rows=47 loops=1)
                     ->  Seq Scan on adserver_campaign  (cost=0.00..16.19 rows=2 width=65) (actual time=0.006..0.006 rows=1 loops=1)
                           Filter: (advertiser_id = 7)
                           Rows Removed by Filter: 3
                     ->  Bitmap Heap Scan on adserver_flight  (cost=1.39..3.62 rows=2 width=307) (actual time=0.030..0.063 rows=47 loops=1)
                           Recheck Cond: (campaign_id = adserver_campaign.id)
                           Heap Blocks: exact=23
                           ->  Bitmap Index Scan on adserver_flight_campaign_id_0fad2a54  (cost=0.00..1.39 rows=2 width=0) (actual time=0.022..0.022 rows=54 loops=1)
                                 Index Cond: (campaign_id = adserver_campaign.id)
               ->  Index Scan using adserver_advertisement_flight_id_d5cabfae on adserver_advertisement  (cost=0.28..0.52 rows=4 width=395) (actual time=0.002..0.003 rows=2 loops=47)
                     Index Cond: (flight_id = adserver_flight.id)
         ->  Index Scan using adserver_adimpression_advertisement_id_64947b93 on adserver_adimpression  (cost=0.43..52.38 rows=59 width=52) (actual time=0.294..0.294 rows=0 loops=90)
               Index Cond: (advertisement_id = adserver_advertisement.id)
               Filter: (date >= '2022-10-01'::date)
               Rows Removed by Filter: 366
 Planning Time: 5.862 ms
 Execution Time: 26.923 ms
(20 rows)
```