### PR TITLE
Shuffle dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,8 @@ PyJWT==2.4.0
 beautifulsoup4==4.11.1
 textacy==0.12.0
 spacy==3.4.1
-spacy-transformers==1.1.8
+# Spacy transformers is listed in the production requirements
+# It installs PyTorch which is hundreds of MB
 langdetect==1.0.9
 # Has to be downloaded directly like this (~30MB)
 https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.4.0/en_core_web_md-3.4.0-py3-none-any.whl

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -18,3 +18,9 @@ django-storages[azure]==1.12.3
 # Logging and monitoring
 newrelic==7.4.0.172
 sentry-sdk==1.5.5
+
+#######################################################################
+# Machine learning production requirements
+#######################################################################
+# This installs PyTorch which is ~250MB
+spacy-transformers==1.1.8


### PR DESCRIPTION
Specifically, move pytorch (a spacy-transformer dep) into the production file. This avoids a 250MB install in CI.