### PR TITLE
Pass the `topics` to the template string for advertisers

### DIFF
--- a/adserver/views.py
+++ b/adserver/views.py
@@ -870,7 +870,7 @@ class AdClickProxyView(BaseProxyView):
             topics = Topic.load_from_cache()
             for topic, topic_keywords in topics.items():
                 for topic_keyword in topic_keywords:
-                    if topic_keyword in keywords:
+                    if topic_keyword in offer.keywords:
                         topic_set.add(topic)
         topic_string = ",".join(topic_set)
 


### PR DESCRIPTION
This lets them capture that information based on the keywords in the offer.
This could pass multiple topics for an ad that is only targeting one,
so I'm not sure if we want to match this against the campaign or not,
but that would add additional processing.
