### PR TITLE
Consolidate tox into single environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,38 @@
 [tox]
-envlist = py3,lint,migrations,docs,coverage
+# You can run a specific section with `tox -e py3`
+# You can run a specific test with `tox -e py3 adserver/auth/tests.py`
+envlist = all
 skipsdist = True
 
 
 [testenv]
+description = Run the full test suite
+setenv =
+    PYTHONPATH={toxinidir}/ethicaladserver:{toxinidir}
+    DJANGO_SETTINGS_MODULE=config.settings.testing
+    DJANGO_SETTINGS_SKIP_LOCAL=True
+deps = -r{toxinidir}/requirements/development.txt
+
+commands =
+    # Run the unit tests
+    coverage run -m pytest {posargs}
+
+    # Run the coverage reports
+    coverage html
+    coverage report --show-missing --fail-under=93
+
+    # Linting
+    pre-commit run --all-files
+    prospector .
+
+    # Migrations checks
+    python manage.py makemigrations --check --dry-run
+
+    # Docs checks
+    sphinx-build -W --keep-going -b html -d {envtmpdir}/docs/doctrees docs {envtmpdir}/docs/html
+
+
+[testenv:py3]
 description = run test suite for the application with {basepython}
 setenv =
     PYTHONPATH={toxinidir}/ethicaladserver:{toxinidir}
@@ -19,7 +48,7 @@ commands =
 description = check for missing migrations
 changedir = {toxinidir}
 commands =
-    ./manage.py makemigrations --check --dry-run
+    python manage.py makemigrations --check --dry-run
 
 
 [testenv:lint]


### PR DESCRIPTION
**IMPORTANT:** This merges into https://github.com/readthedocs/ethical-ad-server/pull/677 not `main`.

This consolidates the tox environments into a single environment that runs the whole CI suite. This should avoid the problem of installing dependencies multiple times during CI.