### PR TITLE
Fix support link in flight metadata

### DIFF
--- a/adserver/templates/adserver/includes/flight-metadata.html
+++ b/adserver/templates/adserver/includes/flight-metadata.html
@@ -108,6 +108,7 @@
     </dd>
   {% endif %}
   <p class='form-text small text-muted'>
+    {% url 'support' as support_url %}
     {% blocktrans with flight_name=flight.name|urlencode %}Flight targeting information can only be changed by your account manager. Please <a href="{{ support_url }}?subject=Flight+ready&body=Flight+{{ flight_name }}+needs+a+change:">contact our team</a>.{% endblocktrans %}
   </p>
 </dl>


### PR DESCRIPTION
This wasn't always set depending on the page.
It was not set on the default flight metadata view.