### PR TITLE
Put the advertiser overview dashboard in the report screen

### DIFF
--- a/adserver/templates/adserver/advertiser/flight-list.html
+++ b/adserver/templates/adserver/advertiser/flight-list.html
@@ -58,9 +58,22 @@
                 <td class="text-right">${{ flight.projected_total_value|floatformat:2 }}</td>
                 <td class="text-right">{{ flight.ctr|floatformat:3 }}%</td>
                 <td class="text-right">
-                  <a href="{% url 'flight_report' advertiser.slug flight.slug %}?start_date={{ flight.start_date|date:'Y-m-d' }}" title="{% trans 'View report' %}">
-                    <span class="fa fa-bar-chart fa-fw mr-2 text-muted" aria-hidden="true"></span>
-                  </a>
+                  <ul class="list-inline">
+
+                    {% if "adserver.change_flight" in perms %}
+                      <li class="list-inline-item">
+                        <a href="{% url 'flight_update' advertiser.slug flight.slug %}?start_date={{ flight.start_date|date:'Y-m-d' }}" title="{% trans 'Edit flight' %}">
+                          <span class="fa fa-pencil-square-o fa-fw mr-2 text-muted" aria-hidden="true"></span>
+                        </a>
+                      </li>
+                    {% endif %}
+
+                    <li class="list-inline-item">
+                      <a href="{% url 'flight_report' advertiser.slug flight.slug %}?start_date={{ flight.start_date|date:'Y-m-d' }}" title="{% trans 'View report' %}">
+                        <span class="fa fa-bar-chart fa-fw mr-2 text-muted" aria-hidden="true"></span>
+                      </a>
+                    </li>
+                  </ul>
                 </td>
               </tr>
             {% endfor %}

--- a/adserver/templates/adserver/advertiser/flight-list.html
+++ b/adserver/templates/adserver/advertiser/flight-list.html
@@ -36,11 +36,12 @@
         <table class="table table-hover">
           <thead>
             <tr>
-              <th><strong>{% blocktrans %}{{ state }} flights{% endblocktrans %}</strong></th>
+              <th width="33%"><strong>{% blocktrans %}{{ state }} flights{% endblocktrans %}</strong></th>
               <th><strong>{% trans 'Start date' %}</strong></th>
               <th><strong>{% trans 'End date' %}</strong></th>
-              <th><strong>{% trans 'Budget' %}</strong></th>
-              <th><strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
+              <th class="text-right"><strong>{% trans 'Budget' %}</strong></th>
+              <th class="text-right"><strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
+              <th class="text-right"><strong>{% trans 'Options' %}</strong></th>
             </tr>
           </thead>
           <tbody>
@@ -54,8 +55,13 @@
                 </td>
                 <td>{{ flight.start_date }}</td>
                 <td>{{ flight.end_date }}</td>
-                <td>${{ flight.projected_total_value|floatformat:2 }}</td>
-                <td>{{ flight.ctr|floatformat:3 }}%</td>
+                <td class="text-right">${{ flight.projected_total_value|floatformat:2 }}</td>
+                <td class="text-right">{{ flight.ctr|floatformat:3 }}%</td>
+                <td class="text-right">
+                  <a href="{% url 'flight_report' advertiser.slug flight.slug %}?start_date={{ flight.start_date|date:'Y-m-d' }}" title="{% trans 'View report' %}">
+                    <span class="fa fa-bar-chart fa-fw mr-2 text-muted" aria-hidden="true"></span>
+                  </a>
+                </td>
               </tr>
             {% endfor %}
           </tbody>

--- a/adserver/templates/adserver/reports/advertiser.html
+++ b/adserver/templates/adserver/reports/advertiser.html
@@ -1,6 +1,7 @@
 {% extends "adserver/reports/base.html" %}
 {% load humanize %}
 {% load i18n %}
+{% load metabase %}
 
 
 {% block title %}{% trans 'Advertiser Report' %} - {{ advertiser }}{% endblock %}
@@ -24,45 +25,11 @@
 
 {% block toc %}
 <section class="mb-5">
-  {% if flights %}
-    <h2>{% trans 'Flight report details' %}</h2>
-
-    {% regroup flights by state as flight_groups %}
-    {% for state, flight_list in flight_groups %}
-      {% if flight_list %}
-        <div class="table-responsive">
-          <table class="table table-hover">
-            <thead>
-              <tr>
-                <th><strong>{% blocktrans %}{{ state }} flights{% endblocktrans %}</strong></th>
-                <th><strong>{% trans 'Start date' %}</strong></th>
-                <th><strong>{% trans 'End date' %}</strong></th>
-                <th>
-                  <strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong>
-                  <span class="fa fa-info-circle fa-fw" aria-hidden="true" data-toggle="tooltip" title="{% trans 'This CTR is all-time, not for the specified report period' %}" data-original-title="{% trans 'This CTR is all-time, not for the specified report period' %}"></span>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for flight in flight_list %}
-                <tr>
-                  <td>
-                    <a href="{% url 'flight_report' advertiser.slug flight.slug %}?start_date={{ flight.start_date|date:'Y-m-d' }}">{{ flight.name }}</a>
-                    {% if not flight.live %}
-                      <span class="fa fa-eye-slash fa-fw text-muted" aria-hidden="true" data-toggle="tooltip" title="{% trans 'This flight is disabled' %}"></span>
-                    {% endif %}
-                  </td>
-                  <td>{{ flight.start_date }}</td>
-                  <td>{{ flight.end_date }}</td>
-                  <td>{{ flight.ctr|floatformat:3 }}%</td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      {% endif %}
-    {% endfor %}
-  {% endif %}{# /if flights #}
+  <div class="row mb-5">
+    <div class="col min-vh-75">
+      {% metabase_dashboard_embed metabase_advertiser_dashboard advertiser_slug=advertiser.slug start_date=start_date end_date=end_date %}
+    </div>
+  </div>
 </section>
 {% endblock toc %}
 

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -270,7 +270,6 @@ class TestReportViews(TestReportsBase):
         self.client.force_login(self.staff_user)
         response = self.client.get(url)
         self.assertContains(response, self.advertiser1.name)
-        self.assertContains(response, self.flight1.name)
 
         ad2 = get(
             Advertisement,
@@ -299,8 +298,6 @@ class TestReportViews(TestReportsBase):
         url = reverse("advertiser_report", args=[self.advertiser2.slug])
         response = self.client.get(url)
         self.assertContains(response, self.advertiser2.name)
-        self.assertContains(response, self.flight2.name)
-        self.assertContains(response, self.flight3.name)
 
         # Check staff fields not present since the permission wasn't configured
         self.assertNotContains(response, "eCPM")

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -1057,18 +1057,14 @@ class AdvertiserReportView(AdvertiserAccessMixin, BaseReportView):
         report = AdvertiserReport(queryset)
         report.generate()
 
-        flights = Flight.order_flights(
-            Flight.objects.filter(campaign__advertiser=advertiser).select_related(
-                "campaign"
-            )
-        )
-
         context.update(
             {
                 "advertiser": advertiser,
                 "report": report,
-                "flights": flights,
                 "export_url": self.get_export_url(advertiser_slug=advertiser.slug),
+                "metabase_advertiser_dashboard": settings.METABASE_DASHBOARDS.get(
+                    "ADVERTISER_FIGURES"
+                ),
             }
         )
 


### PR DESCRIPTION
- Replace the flight list. If users want a flight report, they can get it from the flight detail view.
- This allows users to effectively filter this dashboard by date.