### PR TITLE
Fix a template inheritance issue with advertiser reports

### DIFF
--- a/adserver/templates/adserver/reports/advertiser.html
+++ b/adserver/templates/adserver/reports/advertiser.html
@@ -24,13 +24,15 @@
 
 
 {% block toc %}
-<section class="mb-5">
-  <div class="row mb-5">
-    <div class="col min-vh-75">
-      {% metabase_dashboard_embed metabase_advertiser_dashboard advertiser_slug=advertiser.slug start_date=start_date end_date=end_date %}
-    </div>
-  </div>
-</section>
+  {% if metabase_advertiser_dashboard %}
+    <section class="mb-5">
+      <div class="row mb-5">
+        <div class="col min-vh-75">
+          {% metabase_dashboard_embed metabase_advertiser_dashboard advertiser_slug=advertiser.slug start_date=start_date end_date=end_date %}
+        </div>
+      </div>
+    </section>
+  {% endif %}
 {% endblock toc %}
 
 

--- a/adserver/templatetags/metabase.py
+++ b/adserver/templatetags/metabase.py
@@ -35,6 +35,9 @@ def metabase_question_embed(question_id, **kwargs):
 
     https://www.metabase.com/learn/embedding/embedding-charts-and-dashboards#an-example-using-django
     """
+    if not question_id:
+        return None
+
     if not settings.METABASE_SECRET_KEY:
         log.warning("Metabase Secret Key is not set - Graphs won't render")
         return None
@@ -61,6 +64,9 @@ def metabase_question_embed(question_id, **kwargs):
 @register.simple_tag
 def metabase_dashboard_embed(dashboard_id, **kwargs):
     """Embeds a dashboard instead of a question."""
+    if not dashboard_id:
+        return None
+
     if not settings.METABASE_SECRET_KEY:
         log.warning("Metabase Secret Key is not set - Graphs won't render")
         return None


### PR DESCRIPTION
We added a dashboard to the advertiser reports page. However, that template is inherited by some others causing the dashboard (which didn't work due to data) to be added on other pages. This will only show the dashboard if the data is present.