### PR TITLE
Automate sending flight wrapup emails

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -737,10 +737,6 @@ def notify_of_completed_flights():
                     to=to_addresses,
                     connection=connection,
                 )
-
-                # Make this a draft instead of just sending it directly
-                message.draft = True
-
                 message.send()
 
 

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -729,7 +729,10 @@ def notify_of_completed_flights():
                 ],
             }
 
-            with mail.get_connection(settings.FRONT_BACKEND) as connection:
+            with mail.get_connection(
+                settings.FRONT_BACKEND,
+                sender_name=f"{site.name} Flight Tracker",
+            ) as connection:
                 message = mail.EmailMessage(
                     _("Advertising flight wrapup - %(name)s") % {"name": site.name},
                     render_to_string("adserver/email/flight_wrapup.html", context),

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -141,7 +141,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "every-day-notify-completed-flights": {
         "task": "adserver.tasks.notify_of_completed_flights",
-        "schedule": crontab(hour="0", minute="0"),
+        "schedule": crontab(hour="5", minute="0"),
     },
     "every-week-notify-publisher-changes": {
         "task": "adserver.tasks.notify_of_publisher_changes",


### PR DESCRIPTION
This will send them directly rather than leaving them as drafts.

Currently, our production Front Backend settings use @ericholscher's account with the "name" set to `EthicalAds by Read the Docs`. These can be customized in our private -ops repo. We could also set a custom name *just* for flight wrapups if we want to (eg. "EthicalAds Flight Tracker") with a couple modifications.