### PR TITLE
Define placement priority order

### DIFF
--- a/adserver/api/serializers.py
+++ b/adserver/api/serializers.py
@@ -3,6 +3,7 @@ import logging
 
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from ..constants import ALL_CAMPAIGN_TYPES
@@ -28,7 +29,13 @@ class AdPlacementSerializer(serializers.Serializer):
     div_id = serializers.CharField()
     ad_type = serializers.CharField(required=True)
     priority = serializers.IntegerField(
-        default=1, min_value=1, max_value=10, required=False
+        default=1,
+        min_value=1,
+        max_value=10,
+        required=False,
+        help_text=_(
+            "The lowest priority placement should be 1 (the default) while the highest possible priority is 10."
+        ),
     )
 
 

--- a/adserver/api/views.py
+++ b/adserver/api/views.py
@@ -63,6 +63,7 @@ class AdDecisionView(GeoIpMixin, APIView):
             The number and order must correspond to the ``div_ids``.
         :<json string priorities: An optional ``|`` delimited string of priorities for different ad types.
             The number and order matter, applying to ``div_ids`` and ``ad_types``.
+            The lowest priority is 1 and the maximum priority is 10.
         :<json array keywords: An optional ``|`` delimited string of case-insensitive keywords
             that describe content on the page where the ad is requested (eg. ``python|docker|kubernetes``).
             Used for ad targeting and is additive with any publisher settings.

--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -397,13 +397,14 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
         """
         Choose an ad from the selected flight.
 
-        Apply weighting to the ad based on the requested placement priority.
+        Apply weighting to the ad based:
+
+        - Requested placement priority
         """
         if not flight:
             return None
 
         chosen_ad = None
-        max_priority = 10
         weighted_ad_choices = []
 
         if self.ad_slug:
@@ -427,8 +428,11 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
                     self.placements,
                 )
                 continue
+
+            # The serializer has verified that the maximum value is 10
             priority = placement.get("priority", 1)
-            for _ in range(max_priority + 1 - priority):
+
+            for _ in range(priority):
                 weighted_ad_choices.append(advertisement)
 
         if weighted_ad_choices:


### PR DESCRIPTION
We didn't actually define the placement priority in our docs other than to mention it. Nothing said what the highest priority or lowest priority was.

Confusingly, the priorities were "reversed" with priority=1 being the highest. Firstly, I don't think anybody is using this. RTD used to use this, but doesn't anymore. The ad client doesn't support it. We should consider removing or deprecating it.

However, I wanted to at least define it as I was making changes to this code.