### PR TITLE
Don't link to expired invoices

### DIFF
--- a/adserver/templates/adserver/includes/flight-metadata.html
+++ b/adserver/templates/adserver/includes/flight-metadata.html
@@ -126,9 +126,9 @@
     {% for invoice in flight.active_invoices %}
       <tr>
         <td>
-          {% if invoice.hosted_invoice_url %}<a href="{{ invoice.hosted_invoice_url }}" target="_blank" rel="nofollow noopener">{% endif %}
+          {% if invoice.hosted_invoice_url and not invoice.paid %}<a href="{{ invoice.hosted_invoice_url }}" target="_blank" rel="nofollow noopener">{% endif %}
             <span>{% if invoice.number %}#{{ invoice.number }}{% else %}{% trans 'Draft' %}{% endif %}</span>
-          {% if invoice.hosted_invoice_url %}</a>{% endif %}
+          {% if invoice.hosted_invoice_url and not invoice.paid %}</a>{% endif %}
         </td>
         <td>${{ invoice.total }}</td>
         <td>
@@ -141,4 +141,11 @@
     {% endfor %}
     </tbody>
   </table>
+
+  {% if advertiser.djstripe_customer %}
+  <p class='form-text small text-muted'>
+    {% url 'advertiser_stripe_portal' advertiser.slug as billing_history_url %}
+    {% blocktrans trimmed %}View all invoices in your <a href="{{ billing_history_url }}">billing history</a>.{% endblocktrans %}
+  </p>
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
Invoice links don't last forever (anymore) in Stripe. As a result, we don't want to have expired links. This change will only link to open invoices and otherwise just show the status of the invoice if it is already paid. This also adds a link to the billing portal.

## Screenshot

### Unpaid invoice
![Screenshot from 2023-02-28 16-20-52](https://user-images.githubusercontent.com/185043/222013573-f32d8caa-3f32-48f8-b721-3aa6e936a103.png)

### Paid invoice
![Screenshot from 2023-02-28 16-24-25](https://user-images.githubusercontent.com/185043/222013647-2b987823-00e2-4a6c-b375-b0aed560acff.png)

