### PR TITLE
Use the proper permissions for adding advertisers/publishers

### DIFF
--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -4,6 +4,7 @@ import logging
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.cache import cache
 from django.http import Http404
 from django.shortcuts import get_object_or_404
@@ -29,9 +30,10 @@ from adserver.utils import generate_publisher_payout_data
 log = logging.getLogger(__name__)  # noqa
 
 
-class CreateAdvertiserView(StaffUserMixin, FormView):
+class CreateAdvertiserView(PermissionRequiredMixin, FormView):
     form_class = CreateAdvertiserForm
     model = Advertiser
+    permission_required = "adserver.add_advertiser"
     template_name = "adserver/staff/advertiser-create.html"
 
     def form_valid(self, form):
@@ -52,9 +54,10 @@ class CreateAdvertiserView(StaffUserMixin, FormView):
         )
 
 
-class CreatePublisherView(StaffUserMixin, FormView):
+class CreatePublisherView(PermissionRequiredMixin, FormView):
     form_class = CreatePublisherForm
     model = Publisher
+    permission_required = "adserver.add_publisher"
     template_name = "adserver/staff/publisher-create.html"
 
     def form_valid(self, form):

--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -226,18 +226,24 @@
 
             <ul class="nav flex-column mb-5">
 
+              {% if 'adserver.add_advertiser' in perms %}
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'create-advertiser' %}">
                   <span class="fa fa-plus-circle fa-fw mr-2 text-muted" aria-hidden="true"></span>
                   <span>{% trans 'Add advertiser' %}</span>
                 </a>
               </li>
+              {% endif %}
+
+              {% if 'adserver.add_publisher' in perms %}
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'create-publisher' %}">
                   <span class="fa fa-plus-circle fa-fw mr-2 text-muted" aria-hidden="true"></span>
                   <span>{% trans 'Add publisher' %}</span>
                 </a>
               </li>
+              {% endif %}
+
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'staff-publisher-payouts' %}">
                   <span class="fa fa-money fa-fw mr-2 text-muted" aria-hidden="true"></span>

--- a/adserver/tests/test_staff_actions.py
+++ b/adserver/tests/test_staff_actions.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 from django.test import TestCase
 from django.urls import reverse
@@ -17,7 +19,6 @@ from ..models import PublisherGroup
 from ..models import PublisherPayout
 from ..staff.forms import CreateAdvertiserForm
 from ..staff.forms import CreatePublisherForm
-from ..staff.forms import StartPublisherPayoutForm
 from ..tasks import daily_update_impressions
 
 User = get_user_model()
@@ -36,6 +37,11 @@ class CreateAdvertiserTest(TestCase):
             name="Staff User",
             email="staff@example.com",
         )
+        perm = Permission.objects.get(
+            codename="add_advertiser",
+            content_type=ContentType.objects.get_for_model(Advertiser),
+        )
+        self.staff_user.user_permissions.add(perm)
 
         self.pub_group_rtd = get(
             PublisherGroup,
@@ -149,6 +155,12 @@ class CreatePublisherTest(TestCase):
             "user_email": self.user_email,
             "keywords": self.keywords,
         }
+
+        perm = Permission.objects.get(
+            codename="add_publisher",
+            content_type=ContentType.objects.get_for_model(Publisher),
+        )
+        self.staff_user.user_permissions.add(perm)
 
     def test_form(self):
         form = CreatePublisherForm(data=self.data)


### PR DESCRIPTION
This makes the add advertiser/publisher pages use the appropriate permissions rather than just "staff".