### PR TITLE
Prioritize overdue flights

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1056,6 +1056,12 @@ class Flight(TimeStampedModel, IndestructibleModel):
         # (eg. 23 hours, 59 minutes, 59 seconds, 999ms)
         return max(0, int(remaining_seconds / self.pacing_interval)) + 1
 
+    def days_overdue(self):
+        """Number of days (NOT intervals) past the end date on the flight."""
+        # A negative number means the flight is not overdue
+        days_overdue = (self.end_date - timezone.now().date()).days * -1
+        return max(0, days_overdue)
+
     def days_remaining(self):
         """Number of intervals (default = days) left in a flight."""
         # The flight is considered to end at the end of the day on the `end_date`
@@ -1164,7 +1170,14 @@ class Flight(TimeStampedModel, IndestructibleModel):
         price_priority_value = max(float(price_priority_value), 1.0)
         price_priority_value = min(price_priority_value, 10.0)
 
-        return int(impressions_needed * self.priority_multiplier * price_priority_value)
+        prioritized_impressions_needed = int(
+            impressions_needed * self.priority_multiplier * price_priority_value
+        )
+
+        # Prioritize flights the more overdue they are
+        overdue_multiplier = max(1, self.days_overdue())
+
+        return prioritized_impressions_needed * overdue_multiplier
 
     def clicks_remaining(self):
         return max(0, self.sold_clicks - self.total_clicks)

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1175,9 +1175,9 @@ class Flight(TimeStampedModel, IndestructibleModel):
         )
 
         # Prioritize flights the more overdue they are
-        overdue_multiplier = max(1, self.days_overdue())
+        overdue_factor = int(max(1, self.days_overdue()) ** 1.5)
 
-        return prioritized_impressions_needed * overdue_multiplier
+        return int(prioritized_impressions_needed * overdue_factor)
 
     def clicks_remaining(self):
         return max(0, self.sold_clicks - self.total_clicks)

--- a/adserver/tests/test_decision_engine.py
+++ b/adserver/tests/test_decision_engine.py
@@ -891,3 +891,9 @@ class DecisionEngineTests(TestCase):
         self.assertEqual(
             super_high.weighted_clicks_needed_this_interval(), 28 * 10
         )  # maxed out
+
+        # Verify the days overdue priority
+        super_low.end_date = get_ad_day().date() - datetime.timedelta(days=10)
+        self.assertEqual(
+            super_low.weighted_clicks_needed_this_interval(), 10_000 * super_low.cpm
+        )

--- a/adserver/tests/test_decision_engine.py
+++ b/adserver/tests/test_decision_engine.py
@@ -893,7 +893,10 @@ class DecisionEngineTests(TestCase):
         )  # maxed out
 
         # Verify the days overdue priority
-        super_low.end_date = get_ad_day().date() - datetime.timedelta(days=10)
+        days_overdue = 10
+        super_low.end_date = get_ad_day().date() - datetime.timedelta(days=days_overdue)
+        overdue_factor = int(days_overdue**1.5)
         self.assertEqual(
-            super_low.weighted_clicks_needed_this_interval(), 10_000 * super_low.cpm
+            super_low.weighted_clicks_needed_this_interval(),
+            super_low.sold_clicks * super_low.cpm * overdue_factor,
         )


### PR DESCRIPTION
The more overdue, the more prioritized they will be.

This is a pretty naive implementation where each day overdue multiplies the priority.