### PR TITLE
Payout improvements

### DIFF
--- a/adserver/forms.py
+++ b/adserver/forms.py
@@ -760,7 +760,7 @@ class PublisherSettingsForm(forms.ModelForm):
             )
             stripe_block = HTML(
                 format_html(
-                    "<a href='{}' target='_blank' class='btn btn-sm btn-outline-info'>"
+                    "<a href='{}' target='_blank' class='btn btn-sm btn-outline-info mb-4'>"
                     "<span class='fa fa-cc-stripe fa-fw mr-2' aria-hidden='true'></span> {}"
                     "</a>",
                     link_obj.url,
@@ -773,7 +773,7 @@ class PublisherSettingsForm(forms.ModelForm):
             )
             stripe_block = HTML(
                 format_html(
-                    "<a href='{}' target='_blank' class='btn btn-sm btn-outline-info'>"
+                    "<a href='{}' target='_blank' class='btn btn-sm btn-outline-info mb-4'>"
                     "<span class='fa fa-cc-stripe fa-fw mr-2' aria-hidden='true'></span> {}"
                     "</a>",
                     connect_url,

--- a/adserver/staff/forms.py
+++ b/adserver/staff/forms.py
@@ -342,9 +342,12 @@ class StartPublisherPayoutForm(forms.Form):
     # Advertiser information
     sender = forms.CharField(label=_("Sender"), max_length=200)
     subject = forms.CharField(label=_("Subject"), max_length=200)
-    body = forms.CharField(label=_("body"), widget=forms.Textarea)
+    body = forms.CharField(label=_("Body"), widget=forms.Textarea)
     amount = forms.DecimalField(
         label=_("Amount"), disabled=True, max_digits=8, decimal_places=2
+    )
+    payout_method = forms.CharField(
+        label=_("Payout method"), disabled=True, max_length=200, required=False
     )
     archive = forms.BooleanField(
         label=_("Archive after sending?"), initial=True, required=False
@@ -386,13 +389,13 @@ class StartPublisherPayoutForm(forms.Form):
             # Author is required on drafts..
             payload["author_id"] = getattr(settings, "FRONT_AUTHOR")
 
-        log.info(
+        log.debug(
             "Sending email draft=%s archive=%s",
             self.cleaned_data["draft"],
             self.cleaned_data["archive"],
         )
         response = requests.request("POST", url, json=payload, headers=headers)
-        log.info("Response: %s", response.status_code)
+        log.debug("Response: %s", response.status_code)
 
     def save(self):
         """Do the work to save the payout."""

--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -212,6 +212,7 @@ class PublisherStartPayoutView(StaffUserMixin, FormView):
         initial["subject"] = f"EthicalAds Payout - {self.publisher.name}"
         initial["body"] = email_html
         initial["amount"] = "%.2f" % self.get_amount(self.data["due_report"])
+        initial["payout_method"] = self.publisher.get_payout_method_display()
         return initial
 
     def form_valid(self, form):

--- a/adserver/templates/adserver/staff/publisher-payout-finish.html
+++ b/adserver/templates/adserver/staff/publisher-payout-finish.html
@@ -52,7 +52,7 @@
 <div id="content" class="colM delete-confirmation">
   <form method="post">
     {% csrf_token %}
-    <input type="submit" value="{% trans "Finish payout" %}">
+    <input type="submit" value="{% trans "Finish payout" %}" class="btn btn-primary">
     <p class="small">{% trans "This will mark the payout as paid" %}</p>
   </form>
 </div>


### PR DESCRIPTION
- Fix some missing styles
- Set the payout method on a successful connected account setup
- Show payout method on start payout form
- Save missing connected account object (not just ID) on successful account setup