### PR TITLE
Disable inactive publishers

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -844,8 +844,9 @@ def notify_of_publisher_changes(difference_threshold=0.25, min_views=10_000):
 @app.task()
 def disable_inactive_publishers(days=60, draft_only=False, dry_run=False):
     """Disable publishers who haven't had a paid impression in the specified `days`."""
-    if days < 1:
-        # Prevent the misstep where days is <=0 and all publishers are marked inactive
+    if days < 30:
+        # Prevent the misstep where days is too short and many publishers are marked inactive
+        log.warning("Disabling publishers over too short a timeframe. Task stopped.")
         return
 
     threshold = get_ad_day() - datetime.timedelta(days=days)

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -889,7 +889,7 @@ def disable_inactive_publishers(days=60, draft_only=False, dry_run=False):
                     sender_name=f"{site.name} Admins",
                 ) as connection:
                     message = mail.EmailMessage(
-                        _("Publisher account inactive - %(name)s")
+                        _("Publisher account deactivated - %(name)s")
                         % {"name": site.name},
                         render_to_string(
                             "adserver/email/publisher-inactive.html", context

--- a/adserver/templates/adserver/email/publisher-inactive.html
+++ b/adserver/templates/adserver/email/publisher-inactive.html
@@ -9,7 +9,7 @@
 
 
 <p>
-  <strong>{% blocktrans %}Your publisher account has become inactive.{% endblocktrans %} </strong>
+  <strong>{% blocktrans %}Your publisher account has been marked inactive.{% endblocktrans %} </strong>
   <span>{% blocktrans %}Your site has not shown a paid in a while and as a result, we're marking your account inactive. If you believe this was done by accident or you want to reactivate your account, please respond to this message.{% endblocktrans %}</span>
 </p>
 

--- a/adserver/templates/adserver/email/publisher-inactive.html
+++ b/adserver/templates/adserver/email/publisher-inactive.html
@@ -1,0 +1,23 @@
+{% extends 'adserver/email/base.html' %}
+{% load i18n %}
+
+
+{% block body %}
+
+
+<p>{% blocktrans with publisher_name=publisher.name %}Hello {{ publisher_name }} team,{% endblocktrans %}</p>
+
+
+<p>
+  <strong>{% blocktrans %}Your publisher account has become inactive.{% endblocktrans %} </strong>
+  <span>{% blocktrans %}Your site has not shown a paid in a while and as a result, we're marking your account inactive. If you believe this was done by accident or you want to reactivate your account, please respond to this message.{% endblocktrans %}</span>
+</p>
+
+<p>
+  <span>{% blocktrans %}We are sorry to lose you as a publisher on our network and we're interested to hear your feedback on why you chose to go in another direction. If you're willing to share, please respond and let us know. This helps us tremendously in improving our product and network.{% endblocktrans %}</span>
+</p>
+
+
+<p>{% blocktrans  with site_name=site.name %}Cheers,<br>{{ site_name }} Team{% endblocktrans %}</p>
+
+{% endblock body %}

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -152,6 +152,11 @@ CELERY_BEAT_SCHEDULE = {
         # Runs on Wednesday
         "schedule": crontab(day_of_week=3, hour="5", minute="0"),
     },
+    "every-week-disable-inactive-publishers": {
+        "task": "adserver.tasks.disable_inactive_publishers",
+        # Runs on Tuesday
+        "schedule": crontab(day_of_week=2, hour="6", minute="0"),
+    },
     # Very fast indexes that can be run more frequently
     "halfhourly-advertiser-index": {
         "task": "adserver.tasks.daily_update_advertisers",


### PR DESCRIPTION
Sets a weekly task to disable inactive publishers who haven't shown a paid ad in at least 60 days. They also have to be created at least 60 days ago.

The task has options to create drafts instead of sending emails which might be useful the first time. It also has a dry run option.

## Testing


    ## In config/settings/development.py
    FRONT_BACKEND="django.core.mail.backends.console.EmailBackend"
    FRONT_ENABLED=True

Start a console with `make dockershell` followed by `./manage.py shell`:

    from adserver.tasks import disable_inactive_publishers
    disable_inactive_publishers()
