### PR TITLE
Stop using deprecated campaign.publishers

### DIFF
--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -206,12 +206,7 @@ class AdvertisingEnabledBackend(BaseAdDecisionBackend):
                 campaign__campaign_type__in=self.campaign_types,
             )
             .filter(
-                # Deprecated: remove after publisher groups are rolled out and configured in production
-                # At that point, only filter by publisher groups
-                models.Q(campaign__publishers=self.publisher)
-                | models.Q(
-                    campaign__publisher_groups__in=self.publisher.publisher_groups.all()
-                )
+                campaign__publisher_groups__in=self.publisher.publisher_groups.all()
             )
             .exclude(campaign__exclude_publishers=self.publisher)
         )

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -621,7 +621,7 @@ class Campaign(TimeStampedModel, IndestructibleModel):
         help_text=_("Ads for this campaign will not be shown on these publishers"),
     )
 
-    # Deprecated and scheduled for removal
+    # Deprecated and no longer used. Will be removed in future releases
     publishers = models.ManyToManyField(
         Publisher,
         related_name="campaigns",

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -198,8 +198,6 @@ class BaseApiTest(TestCase):
             slug="campaign-slug",
             advertiser=self.advertiser1,
             publisher_groups=[self.publisher_group],
-            # Deprecated - will be removed
-            publishers=[self.publisher],
         )
         self.flight = get(
             Flight, live=True, campaign=self.campaign, sold_clicks=1000, cpc=1.0
@@ -524,7 +522,7 @@ class AdDecisionApiTests(BaseApiTest):
         self.assertEqual(resp.json(), {})
 
         # Allow this publisher on the campaign
-        self.campaign.publishers.add(self.publisher2)
+        self.publisher_group.publishers.add(self.publisher2)
         resp = self.client.post(
             self.url, json.dumps(data), content_type="application/json"
         )
@@ -588,10 +586,14 @@ class AdDecisionApiTests(BaseApiTest):
 
     def test_campaign_types(self):
         community_campaign = get(
-            Campaign, publishers=[self.publisher], campaign_type=COMMUNITY_CAMPAIGN
+            Campaign,
+            publisher_groups=[self.publisher_group],
+            campaign_type=COMMUNITY_CAMPAIGN,
         )
         house_campaign = get(
-            Campaign, publishers=[self.publisher], campaign_type=HOUSE_CAMPAIGN
+            Campaign,
+            publisher_groups=[self.publisher_group],
+            campaign_type=HOUSE_CAMPAIGN,
         )
 
         data = {
@@ -1005,7 +1007,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
         super().setUp()
 
         self.user.publishers.add(self.publisher2)
-        self.campaign.publishers.add(self.publisher2)
+        self.publisher_group.publishers.add(self.publisher2)
 
         self.page_url = "http://example.com"
 

--- a/adserver/tests/test_decision_engine.py
+++ b/adserver/tests/test_decision_engine.py
@@ -23,6 +23,7 @@ from ..models import Advertisement
 from ..models import Campaign
 from ..models import Flight
 from ..models import Publisher
+from ..models import PublisherGroup
 from ..utils import GeolocationData
 from ..utils import get_ad_day
 
@@ -32,8 +33,11 @@ class DecisionEngineTests(TestCase):
         self.publisher = get(
             Publisher, slug="test-publisher", allow_paid_campaigns=True
         )
+        self.publisher_group = get(PublisherGroup)
+        self.publisher_group.publishers.add(self.publisher)
+
         self.ad_type = get(AdType, has_image=False, slug="z")
-        self.campaign = get(Campaign, publishers=[self.publisher])
+        self.campaign = get(Campaign, publisher_groups=[self.publisher_group])
         self.include_flight = get(
             Flight,
             live=True,
@@ -546,7 +550,9 @@ class DecisionEngineTests(TestCase):
 
         # Paid
         paid_campaign = get(
-            Campaign, campaign_type=PAID_CAMPAIGN, publishers=[self.publisher]
+            Campaign,
+            campaign_type=PAID_CAMPAIGN,
+            publisher_groups=[self.publisher_group],
         )
         paid_flight = get(
             Flight,
@@ -569,7 +575,9 @@ class DecisionEngineTests(TestCase):
 
         # Affiliate
         affiliate_campaign = get(
-            Campaign, campaign_type=AFFILIATE_CAMPAIGN, publishers=[self.publisher]
+            Campaign,
+            campaign_type=AFFILIATE_CAMPAIGN,
+            publisher_groups=[self.publisher_group],
         )
         affiliate_flight = get(
             Flight,
@@ -592,7 +600,9 @@ class DecisionEngineTests(TestCase):
 
         # Community
         community_campaign = get(
-            Campaign, campaign_type=COMMUNITY_CAMPAIGN, publishers=[self.publisher]
+            Campaign,
+            campaign_type=COMMUNITY_CAMPAIGN,
+            publisher_groups=[self.publisher_group],
         )
         community_flight = get(
             Flight,
@@ -614,7 +624,9 @@ class DecisionEngineTests(TestCase):
 
         # House
         house_campaign = get(
-            Campaign, campaign_type=HOUSE_CAMPAIGN, publishers=[self.publisher]
+            Campaign,
+            campaign_type=HOUSE_CAMPAIGN,
+            publisher_groups=[self.publisher_group],
         )
         house_campaign.campaign_type = HOUSE_CAMPAIGN
         house_campaign.save()


### PR DESCRIPTION
A while back, we introduced the concept of publisher groups. These are much more useful than manually specifying the allowed publishers for an advertiser.

I audited our production data. Only a few current advertisers used this setting and I made sure they were transitioned to publisher groups.