### PR TITLE
Show excluded publishers from the campaign

### DIFF
--- a/adserver/templates/adserver/includes/flight-metadata.html
+++ b/adserver/templates/adserver/includes/flight-metadata.html
@@ -105,6 +105,10 @@
         {% if flight.targeting_parameters.exclude_publishers %}
          <li>{% blocktrans with value=flight.targeting_parameters.exclude_publishers|join:", " %}Exclude publishers: {{ value }}{% endblocktrans %}</li>
         {% endif %}
+        {% if flight.campaign.exclude_publishers.exists %}
+         {# Excluded publishers from the campaign #}
+         <li>{% blocktrans with value=flight.campaign.exclude_publishers.all|join:", " %}Exclude publishers: {{ value }}{% endblocktrans %}</li>
+        {% endif %}
         {% if flight.targeting_parameters.include_domains %}
          <li>{% blocktrans with value=flight.targeting_parameters.include_domains|join:", " %}Include domains: {{ value }}{% endblocktrans %}</li>
         {% endif %}


### PR DESCRIPTION
There's two ways to exclude a publisher on an ad flight: for just that flight or for all flights on a campaign.