### PR TITLE
Improve copying ads logic

### DIFF
--- a/adserver/templates/adserver/advertiser/advertisement-copy.html
+++ b/adserver/templates/adserver/advertiser/advertisement-copy.html
@@ -5,7 +5,7 @@
 {% load crispy_forms_tags %}
 
 
-{% block title %}{% trans 'Copy advertisement' %}{% endblock %}
+{% block title %}{% trans 'Copy advertisements' %}{% endblock %}
 
 
 {% block breadcrumbs %}
@@ -22,89 +22,17 @@
 
 <section>
 
-  <h1>{% block heading %}{% trans 'Copy advertisement' %}{% endblock heading %}</h1>
-  <p>{% blocktrans with flight_name=flight.name %}Re-use one of your previous ads in "{{ flight_name }}".{% endblocktrans %}</p>
+  <h1>{% block heading %}{% trans 'Copy advertisements' %}{% endblock heading %}</h1>
+  <p>{% blocktrans with flight_name=flight.name %}Re-use your previous ads in "{{ flight_name }}".{% endblocktrans %}</p>
 
-  {% if source_advertisement %}
-    {# Confirm the copy to this source #}
-    <div class="row">
-      {# Show the ad #}
-      <div class="col">
-        {% with advertisement=source_advertisement ad_type=source_advertisement.ad_types.first %}
-          {% include "adserver/includes/ad-preview.html" %}
-        {% endwith %}
-      </div>
 
-      {# Ad metadata #}
-      <div class="col">
-        <dl>
-          <dt>{% trans 'Source advertisement' %}</dt>
-          <dd>{{ source_advertisement.name }}</dd>
-          <dt>{% trans 'Source flight' %}</dt>
-          <dd>{{ source_advertisement.flight.name }}</dd>
-          <dt>{% trans 'Display' %}</dt>
-          <dd>{{ source_advertisement.ad_types.all | join:"<br>" }}</dd>
-          {% if source_advertisement.link %}
-            <dt>{% trans 'Click-through link' %}</dt>
-            <dd><small><a href="{{ source_advertisement.link }}">{{ source_advertisement.link|truncatechars:50 }}</a></small></dd>
-          {% endif %}
-        </dl>
-      </div>
+  <div class="row">
+
+    <div class="col-md-8">
+      {% crispy form form.helper %}
     </div>
 
-    <form method="post">
-      {% csrf_token %}
-      <input type="hidden" name="source_advertisement" value="{{ source_advertisement.pk }}">
-      <input type="Submit" class="btn btn-primary" value="{% trans 'Copy advertisement' %}">
-      <p class="form-text text-muted small">{% trans 'You will have a chance to edit the copy before it goes live.' %}</p>
-    </form>
-  {% elif advertisements %}
-    {# Choose an ad to copy #}
-    <form method="get">
-      <div class="table-responsive">
-        <table class="table">
-          <thead>
-            <tr>
-              <th><!-- Intentionally blank --></th>
-              <th><strong>{% trans 'Name' %}</strong></th>
-              <th><strong>{% trans 'Flight' %}</strong></th>
-              <th><strong>{% trans 'Preview' %}</strong></th>
-              <th><strong>{% trans 'Ad types' %}</strong></th>
-              <th><strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for advertisement in advertisements %}
-              <tr>
-                <td>
-                  <div class="form-check">
-                    <input class="form-check-input" type="radio" name="source_advertisement" value="{{ advertisement.pk }}">
-                  </div>
-                </td>
-                <td>{{ advertisement.name }}</td>
-                <td>{{ advertisement.flight.name }}</td>
-                <td>
-                  <details>
-                    <summary>Preview</summary>
-                    {% with ad_type=advertisement.ad_types.first %}
-                      {% include "adserver/includes/ad-preview.html" %}
-                    {% endwith %}
-                  </details>
-                </td>
-                <td>{{ advertisement.ad_types.all | join:"<br>" }}</td>
-                <td>{{ advertisement.ctr|floatformat:3 }}%</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-
-      <input type="Submit" class="btn btn-primary" value="{% trans 'Review & copy advertisement' %}">
-      <p class="form-text text-muted small">{% trans 'You will have a chance to review before copying.' %}</p>
-    </form>
-  {% else %}
-    <p>{% trans 'You have no advertisements to copy.' %}</p>
-  {% endif %}
+  </div>
 
 </section>
 

--- a/adserver/templates/adserver/advertiser/flight-detail.html
+++ b/adserver/templates/adserver/advertiser/flight-detail.html
@@ -54,7 +54,7 @@
       </a>
       <a href="{% url 'advertisement_copy' advertiser.slug flight.slug %}" class="btn btn-sm btn-outline-primary mb-3" role="button" aria-pressed="true">
         <span class="fa fa-clone mr-1" aria-hidden="true"></span>
-        <span>{% trans 'Copy existing ad' %}</span>
+        <span>{% trans 'Copy existing ads' %}</span>
       </a>
     </aside>
   </div>

--- a/adserver/templates/adserver/includes/widgets/advertisement-form-option.html
+++ b/adserver/templates/adserver/includes/widgets/advertisement-form-option.html
@@ -45,6 +45,6 @@
       {% endif %}
     </div>
   {% empty %}
-    <div>{% trans 'No advertisements to renew' %}</div>
+    <div>{% trans 'No advertisements to re-use' %}</div>
   {% endfor %}
 </div>

--- a/adserver/tests/test_advertiser_dashboard.py
+++ b/adserver/tests/test_advertiser_dashboard.py
@@ -581,17 +581,12 @@ class TestAdvertiserDashboardViews(TestCase):
 
         self.client.force_login(self.user)
         response = self.client.get(url)
-        self.assertContains(response, "Copy advertisement")
+        self.assertContains(response, "Re-use your previous ads")
         self.assertContains(response, self.ad1.name)
-
-        # Goes to the confirm screen
-        response = self.client.get(url, data={"source_advertisement": self.ad1.pk})
-        self.assertContains(response, "Copy advertisement")
-        self.assertContains(response, "Source advertisement")
 
         # Perform the copy
         count_ads = Advertisement.objects.all().count()
-        response = self.client.post(url, data={"source_advertisement": self.ad1.pk})
+        response = self.client.post(url, data={"advertisements": [self.ad1.pk]})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(Advertisement.objects.all().count(), count_ads + 1)
 


### PR DESCRIPTION
- Re-use the same form widgets as renewing flights
- Improve the logic around new names/slugs for copies. This ensures the name doesn't become "X Copy Copy Copy"
- Allow copying multiple ads at a time