### PR TITLE
Show the publisher's allowed domains

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -472,6 +472,9 @@ class Publisher(TimeStampedModel, IndestructibleModel):
         today = get_ad_day().date()
         return f"daily-earn::{self.slug}::{today:%Y-%m-%d}"
 
+    def allowed_domains_as_list(self):
+        return self.allowed_domains.split()
+
     def total_payout_sum(self):
         """The total amount ever paid out to this publisher."""
         total = self.payouts.filter(status=PAID).aggregate(

--- a/adserver/templates/adserver/publisher/settings.html
+++ b/adserver/templates/adserver/publisher/settings.html
@@ -23,6 +23,18 @@
     <div class="row">
 
       <div class="col-md-8 col">
+
+        {% if publisher.allowed_domains %}
+          <fieldset class="my-3 ">
+            <legend>{% trans 'Domains' %}</legend>
+            <p class="form-text">{{ publisher.allowed_domains }}</p>
+            <p class='form-text small text-muted'>
+              {% url 'support' as support_url %}
+              {% blocktrans %}These are your domains where ads may be displayed. Please <a href="{{ support_url }}?subject=New+Publisher+Domain">let us know</a> if you plan to run ads on additional domains so we may review them.{% endblocktrans %}
+            </p>
+          </fieldset>
+        {% endif %}
+
         {% crispy form form.helper %}
       </div>
 

--- a/adserver/templates/adserver/publisher/settings.html
+++ b/adserver/templates/adserver/publisher/settings.html
@@ -27,7 +27,11 @@
         {% if publisher.allowed_domains %}
           <fieldset class="my-3 ">
             <legend>{% trans 'Domains' %}</legend>
-            <p class="form-text">{{ publisher.allowed_domains }}</p>
+            <ul>
+              {% for domain in publisher.allowed_domains_as_list %}
+                <li>{{ domain }}</li>
+              {% endfor %}
+            </ul>
             <p class='form-text small text-muted'>
               {% url 'support' as support_url %}
               {% blocktrans %}These are your domains where ads may be displayed. Please <a href="{{ support_url }}?subject=New+Publisher+Domain">let us know</a> if you plan to run ads on additional domains so we may review them.{% endblocktrans %}

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -789,7 +789,7 @@ class BaseProxyView(View):
             )
             reason = "Mismatched browser"
         elif offer.publisher.allowed_domains and not is_allowed_domain(
-            offer.url, offer.publisher.allowed_domains.split()
+            offer.url, offer.publisher.allowed_domains_as_list()
         ):
             log.log(
                 self.log_security_level,


### PR DESCRIPTION
The allowed domains are not yet enforcing but I think we should display this to publishers so they know they need to contact us.

We might also need to add the domains to the create publisher form.

## Screenshot

![Screenshot from 2023-06-06 14-01-40](https://github.com/readthedocs/ethical-ad-server/assets/185043/7a778af2-872f-4cfa-8a59-c7c06624a199)
