### PR TITLE
Rework the payout email view/form

### DIFF
--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -207,7 +207,7 @@ class PublisherStartPayoutView(StaffUserMixin, FormView):
             get_template("adserver/email/publisher-payout.html")
             .render(self.data)
             .replace("\n\n", "\n")
-        )
+        ).strip()
         initial["sender"] = "EthicalAds by Read the Docs"
         initial["subject"] = f"EthicalAds Payout - {self.publisher.name}"
         initial["body"] = email_html

--- a/adserver/templates/adserver/email/publisher-payout.html
+++ b/adserver/templates/adserver/email/publisher-payout.html
@@ -10,24 +10,14 @@ but for now I think we can't avoid it because of linking to content on our marke
 </p>
 
 <p>
-  <strong>Stay up to date:</strong>
-  If you want to keep up to date with the latest features and updates from EthicalAds,
-  we recommend reading our <a href="https://www.ethicalads.io/blog/">blog</a> or <a href="https://twitter.com/ethicaladsio">Twitter</a>.
-  If you prefer getting updates in your inbox,
-  you can subscribe to our <a href="https://ethicalads.us17.list-manage.com/subscribe/post?u=ca5e74de3ea2867d373058271&id=5746f18bb8">mailing list</a> as well.
-</p>
-
-<p>
-  Thanks for being one of our publishers on the EthicalAds network.
-  We do payouts by the 15th of the month,
-  as noted in our <a href="https://www.ethicalads.io/publisher-policy/">Publisher Policy</a>.
-  If you haven't had a chance to look it over, please do,
-  as it sets expectations around ad placements, payments, and more.
+  We are now processing payments for <strong>{{ today|date:"F" }} {{ today|date:"Y" }}</strong>,
+  and you made a total of <strong>${{ due_report.total.revenue_share|floatformat:2 }}</strong> for ads displayed between {{ start_date|date:"F j" }}-{{ end_date|date:"F j" }}.
+  You can find the full report for this billing cycle on our <a href="{{ due_report_url }}">revenue report</a>.
 </p>
 
 {% if due_report.total.ctr < .07 %} {# Only warn is a good deal below .1 #}
 <p>
-  We generally expect all our publishers to maintain a CTR (click though rate) around or above .1%.
+  We generally expect all our publishers to maintain a CTR (click though rate) around or above 0.1%.
   Your CTR is currently <strong>{{ due_report.total.ctr|floatformat:3 }}%</strong>,
   which is below our current minimum.
   We have a few suggestions in our <a href="https://www.ethicalads.io/publisher-guide/">Publisher Guide</a> around improving placements,
@@ -35,15 +25,11 @@ but for now I think we can't avoid it because of linking to content on our marke
 </p>
 {% endif %}
 
-<p>
-We are now processing payments for <strong>{{ today|date:"F" }} {{ today|date:"Y" }}</strong>,
-and you made a total of <strong>${{ due_report.total.revenue_share|floatformat:2 }}</strong> for ads displayed between <strong>{{ start_date|date:"F j" }}-{{ end_date|date:"F j" }}</strong>.
-You can find the full report for this billing cycle on our <a href="{{ due_report_url }}">revenue report</a>.
-</p>
 
 {% if first %}
 <p>
-We need a few pieces of information from you in order to process a payment:
+  <strong>Information required!</strong>
+  We need a few pieces of information from you in order to process a payment:
 </p>
 
 <p>
@@ -55,10 +41,10 @@ We need a few pieces of information from you in order to process a payment:
 </p>
 
 <p>
-  <strong>Please reply to this email with the name & address of the person or organization receiving this payment.</strong>
+  Please reply to this email with the name & address of the person or organization receiving this payment.
   Once we have this information, we will process the payment.
   These will show up in the <a href="{{ payouts_url }}">payouts dashboard</a>,
-  once they have been started.
+  once they have been processed.
 </p>
 {% else %}
 <p>
@@ -70,11 +56,20 @@ We need a few pieces of information from you in order to process a payment:
 {% endif %}
 
 <p>
+  <strong>Stay up to date:</strong>
+  If you want to keep up to date with the latest features and updates from EthicalAds,
+  we recommend reading our <a href="https://www.ethicalads.io/blog/">blog</a> or <a href="https://twitter.com/ethicaladsio">Twitter</a>.
+  If you prefer getting updates in your inbox,
+  you can subscribe to our <a href="https://ethicalads.us17.list-manage.com/subscribe/post?u=ca5e74de3ea2867d373058271&id=5746f18bb8">mailing list</a> as well.
+</p>
+
+<p>
   Thanks again for being part of the EthicalAds network.
   If you are enjoying EthicalAds,
   we'd love to ask you to recommend us to a friend.
-  We are looking to grow our publisher network,
-  and are always on the look out for other developer-focused publishers.
+  If there's a feature or change that would improve EthicalAds
+  or would have made your onboarding or payout process better,
+  please respond to this email and let us know!
 </p>
 
 <p>

--- a/adserver/templates/adserver/staff/publisher-payout-start.html
+++ b/adserver/templates/adserver/staff/publisher-payout-start.html
@@ -17,6 +17,12 @@
   <div class="col-md">
     {% crispy form form.helper %}
   </div>
+
+  <div class="col-md-6 ml-md-5">
+    <h5>{% trans 'Preview' %}</h5>
+
+    <div class="border bg-light p-2" data-bind="html: displayBody()"></div>
+  </div>
 </div>
 
 {% endblock content_container %}

--- a/assets/src/views/index.js
+++ b/assets/src/views/index.js
@@ -2,3 +2,4 @@ export * from './publisher_settings';
 export * from './advertisement-form';
 export * from './flight_update';
 export * from './dashboard-home';
+export * from './payout-create';

--- a/assets/src/views/payout-create.js
+++ b/assets/src/views/payout-create.js
@@ -1,0 +1,15 @@
+const ko = require('knockout');
+
+
+function PayoutStartViewModel() {
+  this.body = ko.observable(document.querySelector("#id_body").value);
+
+  this.displayBody = function () {
+    return this.body;
+  };
+}
+
+
+if (document.querySelectorAll("#payout-start").length > 0) {
+  ko.applyBindings(new PayoutStartViewModel());
+}


### PR DESCRIPTION
This doesn't actually rework the email itself which I'll do in another PR.

* Show preview of the email
* Use the same front backend used elsewhere (this code predates that backend)

## Screenshot
![Screenshot from 2023-06-12 16-34-13](https://github.com/readthedocs/ethical-ad-server/assets/185043/d294dd4e-e536-4563-bc3e-de5858112d57)
