### PR TITLE
Ubuntu 22.04 - Python 3.10 upgrade

### DIFF
--- a/docker-compose/django/Dockerfile
+++ b/docker-compose/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG en_US.UTF-8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/developer/quickstart.rst
+++ b/docs/developer/quickstart.rst
@@ -43,8 +43,8 @@ This section is more to document steps than to encourage you to develop outside 
 Requirements
 ~~~~~~~~~~~~
 
-- Python 3.8
-- Nodejs (tested with v12.3)
+- Python 3.10
+- Nodejs (tested with v14)
 
 Front-end assets
 ~~~~~~~~~~~~~~~~

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -14,13 +14,10 @@ reorder-python-imports>=2.6.0,<3.0
 pre-commit==2.17.0
 
 # Sphinx for docs
-Sphinx<4.0
+Sphinx >=6.0, <7.0
 sphinx-autobuild==2021.3.14
-sphinx-rtd-theme
-sphinxcontrib-httpdomain==1.8.0
-# Various doc issues with the latest Jinja with Sphinx
-Jinja2<3.0
-MarkupSafe<2.0
+sphinx-rtd-theme== 1.2.2
+sphinxcontrib-httpdomain==1.8.1
 
 # Various testing tools
 pytest==7.0.0


### PR DESCRIPTION
Upgrade Ubuntu 20.04 -> 22.04
Upgrade Python 3.8 -> 3.10