### PR TITLE
Advertisers can request a new flight

### DIFF
--- a/adserver/forms.py
+++ b/adserver/forms.py
@@ -687,7 +687,7 @@ class FlightRequestForm(FlightCreateForm):
         self.instance.campaign = (
             self.old_flight.campaign
             if self.old_flight
-            else self.advertiser.campaigns.all().first()
+            else self.advertiser.campaigns.first()
         )
 
         instance = super().save(commit)

--- a/adserver/forms.py
+++ b/adserver/forms.py
@@ -1,5 +1,6 @@
 """Forms for the ad server."""
 import logging
+from datetime import timedelta
 
 import bleach
 import stripe
@@ -353,9 +354,10 @@ class FlightCreateForm(forms.ModelForm):
 
         super().__init__(*args, **kwargs)
 
-        self.fields["campaign"].queryset = Campaign.objects.filter(
-            advertiser=self.advertiser
-        )
+        if "campaign" in self.fields:
+            self.fields["campaign"].queryset = Campaign.objects.filter(
+                advertiser=self.advertiser
+            )
         self.helper = self.create_form_helper()
 
     def create_form_helper(self):
@@ -543,6 +545,170 @@ class FlightRenewForm(FlightMixin, FlightCreateForm):
             "sold_clicks",
             "cpm",
             "sold_impressions",
+        )
+        widgets = {
+            "start_date": forms.DateInput(
+                attrs={"type": "date", "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2}"}
+            ),
+            "end_date": forms.DateInput(
+                attrs={"type": "date", "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2}"}
+            ),
+        }
+
+
+class FlightRequestForm(FlightCreateForm):
+
+    """Used by advertisers to request a new flight."""
+
+    advertisements = AdvertisementMultipleChoiceField(
+        queryset=Advertisement.objects.none(),
+        required=False,
+        help_text=_("Request a new flight with the following advertisements"),
+    )
+
+    budget = forms.IntegerField(
+        label=_("Budget"),
+    )
+
+    note = forms.CharField(label=_("Note"), required=False, widget=forms.Textarea)
+
+    DEFAULT_FLIGHT_BUDGET = 3_000
+
+    def __init__(self, *args, **kwargs):
+        """Set the flight form helper and initial data for renewing a flight."""
+        self.old_flight = kwargs.pop("flight", None)
+
+        advertiser = kwargs["advertiser"]
+        default_name = f"{advertiser} - {timezone.now():%b %Y}"
+
+        if "initial" not in kwargs:
+            kwargs["initial"] = {}
+        kwargs["initial"].update(
+            {
+                "budget": round(self.old_flight.projected_total_value())
+                if self.old_flight
+                else self.DEFAULT_FLIGHT_BUDGET,
+                "name": default_name,
+                "start_date": timezone.now().today(),
+                "end_date": timezone.now().today()
+                + (
+                    (self.old_flight.end_date - self.old_flight.start_date)
+                    if self.old_flight
+                    else timedelta(days=30)
+                ),
+                "advertisements": self.old_flight.advertisements.filter(live=True)
+                if self.old_flight
+                else Advertisement.objects.none(),
+            }
+        )
+
+        # Sets self.advertiser
+        super().__init__(*args, **kwargs)
+
+        self.fields["note"].widget.attrs["rows"] = 3
+        self.fields["note"].help_text = _(
+            "Do you have any changes you'd like to make from previous flights or any special instructions?"
+        )
+        self.fields["start_date"].help_text = _("The target start date for this flight")
+        self.fields["end_date"].help_text = _(
+            "The target end date for this flight (it may go after this date)"
+        )
+        self.fields["advertisements"].queryset = (
+            self.old_flight.advertisements.all()
+            if self.old_flight
+            else Advertisement.objects.none()
+        )
+
+    def create_form_helper(self):
+        helper = FormHelper()
+        helper.attrs = {"id": "flight-request-form"}
+        helper.layout = Layout(
+            Fieldset(
+                "",
+                Field("name"),
+                Div(
+                    Div("start_date", css_class="form-group col-lg-6"),
+                    Div("end_date", css_class="form-group col-lg-6"),
+                    css_class="form-row",
+                ),
+                Div(
+                    PrependedText(
+                        "budget",
+                        "$",
+                        min=0,
+                        data_bind="textInput: budget",
+                    ),
+                ),
+                Field("note"),
+                css_class="my-3",
+            ),
+            Fieldset(
+                _("Advertisements"),
+                Field(
+                    "advertisements",
+                    template="adserver/includes/widgets/advertisement-form-option.html",
+                ),
+                css_class="my-3",
+            ),
+            Submit("submit", _("Request a new flight")),
+            HTML(
+                "<p class='form-text small text-muted'>"
+                + str(
+                    _(
+                        "Your flight will not start automatically. Your account manager will be notified to review your ads and targeting."
+                    )
+                )
+                + "</p>"
+            ),
+        )
+        return helper
+
+    def save(self, commit=True):
+        assert commit, "Delayed saving is not supported on this form"
+
+        # This is already the default but we are setting it explicitly to be defensive
+        self.instance.live = False
+
+        if self.old_flight:
+            # Copy fields not in the form from the old flight if possible
+            # Otherwise, the account manager will need to set these
+            fields = (
+                "targeting_parameters",
+                "priority_multiplier",
+                "cpm",
+                "cpc",
+                "sold_impressions",
+                "sold_clicks",
+            )
+            for field in fields:
+                setattr(self.instance, field, getattr(self.old_flight, field))
+
+        # We must set the campaign
+        self.instance.campaign = (
+            self.old_flight.campaign
+            if self.old_flight
+            else self.advertiser.campaigns.all().first()
+        )
+
+        instance = super().save(commit)
+
+        # Duplicate the advertisements into the new flight
+        if "advertisements" in self.cleaned_data:
+            for ad in self.cleaned_data["advertisements"]:
+                new_ad = ad.__copy__()
+                new_ad.flight = instance
+                new_ad.live = True
+                new_ad.save()  # Automatically gets a new slug
+
+        return instance
+
+    class Meta:
+        model = Flight
+
+        fields = (
+            "name",
+            "start_date",
+            "end_date",
         )
         widgets = {
             "start_date": forms.DateInput(

--- a/adserver/templates/adserver/advertiser/flight-list.html
+++ b/adserver/templates/adserver/advertiser/flight-list.html
@@ -25,6 +25,10 @@
       <span>{% trans 'Create flight' %}</span>
     </a>
   {% endif %}
+  <a href="{% url 'flight_request' advertiser.slug %}" class="btn btn-sm btn-outline-info mb-3" role="button" aria-pressed="true">
+    <span class="fa fa-plus mr-1" aria-hidden="true"></span>
+    <span>{% trans 'Request a new flight' %}</span>
+  </a>
 </aside>
 
 

--- a/adserver/templates/adserver/advertiser/flight-request.html
+++ b/adserver/templates/adserver/advertiser/flight-request.html
@@ -1,0 +1,57 @@
+{% extends "adserver/advertiser/overview.html" %}
+{% load i18n %}
+{% load static %}
+{% load humanize %}
+{% load crispy_forms_tags %}
+
+
+{% block title %}{% trans 'Request a new flight' %}{% endblock %}
+
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item"><a href="{% url 'flight_list' advertiser.slug %}">{% trans 'Flights' %}</a></li>
+  <li class="breadcrumb-item active">{% trans 'Request a new flight' %}</li>
+{% endblock breadcrumbs %}
+
+
+{% block content_container %}
+
+<h1>{% block heading %}{% trans 'Request a new flight' %}{% endblock heading %}</h1>
+
+<p>{% trans 'You can base your new flight on a previous one or set up something completely different.' %}</p>
+
+<section>
+  <div class="row">
+
+    <div class="col-md-8">
+      {% if next %}
+        {% crispy form form.helper %}
+      {% else %}
+        <form>
+
+          <div class="form-group">
+
+            <label class="col-form-label" for="id_old_flight">{% trans 'Base your new flight on' %}</label>
+            <select class="form-control" name="old_flight" id="id_old_flight">
+              <option value="">{% trans 'Something completely different' %}</option>
+              <optgroup label="{% trans 'Past flights' %}">
+                {% for flight in past_flights %}
+                  <option value="{{ flight.slug }}">{{ flight.name }}</option>
+                {% endfor %}
+              </optgroup>
+            </select>
+          </div>
+
+          <input type="hidden" name="next" value="step-2" />
+          <input type="submit"  class="btn btn-primary" value="{% trans 'Next' %}">
+          <p class="help-text"></p>
+        </form>
+      {% endif %}
+    </div>
+
+  </div>
+</section>
+
+
+{% endblock content_container %}

--- a/adserver/templates/adserver/advertiser/overview.html
+++ b/adserver/templates/adserver/advertiser/overview.html
@@ -69,8 +69,8 @@
               <p>{% blocktrans %}You can always look at <a href="{{ flight_list_url }}">past flights</a> or check your past <a href="{{ advertiser_report }}">ad performance</a> for any timeframe.{% endblocktrans %}</p>
             </li>
             <li>
-              {% url "support" as support_url %}
-              <p>{% blocktrans %}If you're interested in running a new ad flight, please <a href="{{ support_url }}?subject=New+campaign&body=I+am+interested+in+running+a+new+campaign.">get in touch</a>.{% endblocktrans %}</p>
+              {% url "flight_request" advertiser.slug as flight_request_url %}
+              <p>{% blocktrans %}If you're ready to run a new ad flight, please <a href="{{ flight_request_url }}">request a new one</a> with your desired budget and targeting details.{% endblocktrans %}</p>
             </li>
           </ul>
         </div>

--- a/adserver/templates/adserver/email/flight-request.html
+++ b/adserver/templates/adserver/email/flight-request.html
@@ -1,0 +1,26 @@
+{% extends 'adserver/email/base.html' %}
+{% load i18n %}
+
+
+{% block body %}
+<p>{% blocktrans %}Ads support team,{% endblocktrans %}</p>
+
+{% url "advertiser_main" advertiser.slug as advertiser_url %}
+{% url "flight_detail" advertiser.slug flight.slug as new_flight_url %}
+{% url "flight_detail" advertiser.slug old_flight.slug as old_flight_url %}
+
+<p>
+{% blocktrans with advertiser_name=advertiser.name %}
+  Advertiser <a href="{{ site_domain }}{{ advertiser_url }}">{{ advertiser_name }}</a> has requested a new flight.
+{% endblocktrans %}
+</p>
+
+<ul>
+  <li>{% trans 'New flight:' %} <a href="{{ site_domain }}{{ new_flight_url }}">{{ flight.name }}</a></li>
+  {% if old_flight %}<li>{% trans 'Modeled on previous flight:' %} <a href="{{ site_domain }}{{ old_flight_url }}">{{ old_flight.name }}</a></li>{% endif %}
+  {% for key, val in extras.items %}
+    {% if val %}<li>{{ key }}: {{ val }}</li>{% endif %}
+  {% endfor %}
+</ul>
+
+{% endblock body %}

--- a/adserver/templates/adserver/email/flight_wrapup.html
+++ b/adserver/templates/adserver/email/flight_wrapup.html
@@ -28,7 +28,7 @@
   with your desired budget and targeting details.
   We can run another campaign with the same creatives,
   or adjust things based on your feedback around what's converting best.
-  If you have any questions, please reply to this email.
+  If you have any questions, you can always reply to this email.
 {% endblocktrans %}</p>
 
 {% url "flight_list" advertiser.slug as advertiser_url %}

--- a/adserver/templates/adserver/email/flight_wrapup.html
+++ b/adserver/templates/adserver/email/flight_wrapup.html
@@ -22,11 +22,13 @@
 </ul>
 
 {% endspaceless %}
-
-<p>{% blocktrans %}
-  If you have any questions or you would like to renew your flight, please reply to this email.
-  We can run another campaign with the same creative and budget,
+{% url "flight_request" as flight_request_url %}
+<p>{% blocktrans with site_domain=site.domain %}
+  If you'd like to renew your flight, you can <a href="{{ site_domain }}{{ flight_request_url }}">request a new one</a>
+  with your desired budget and targeting details.
+  We can run another campaign with the same creatives,
   or adjust things based on your feedback around what's converting best.
+  If you have any questions, please reply to this email.
 {% endblocktrans %}</p>
 
 {% url "flight_list" advertiser.slug as advertiser_url %}

--- a/adserver/urls.py
+++ b/adserver/urls.py
@@ -33,6 +33,7 @@ from .views import FlightCreateView
 from .views import FlightDetailView
 from .views import FlightListView
 from .views import FlightRenewView
+from .views import FlightRequestView
 from .views import FlightUpdateView
 from .views import publisher_stripe_oauth_return
 from .views import PublisherAdvertiserReportView
@@ -193,6 +194,11 @@ urlpatterns = [
         r"advertiser/<slug:advertiser_slug>/flights/create/",
         FlightCreateView.as_view(),
         name="flight_create",
+    ),
+    path(
+        r"advertiser/<slug:advertiser_slug>/flights/request/",
+        FlightRequestView.as_view(),
+        name="flight_request",
     ),
     path(
         r"advertiser/<slug:advertiser_slug>/flights/<slug:flight_slug>/",

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -15,6 +15,8 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.contrib.sites.shortcuts import get_current_site
+from django.core import mail
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.http import Http404
@@ -24,6 +26,7 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.shortcuts import render
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.urls import reverse_lazy
 from django.utils import timezone
@@ -58,6 +61,7 @@ from .forms import AdvertisementForm
 from .forms import FlightCreateForm
 from .forms import FlightForm
 from .forms import FlightRenewForm
+from .forms import FlightRequestForm
 from .forms import InviteUserForm
 from .forms import PublisherSettingsForm
 from .forms import SupportForm
@@ -102,6 +106,7 @@ from .reports import PublisherUpliftReport
 from .utils import anonymize_ip_address
 from .utils import calculate_ctr
 from .utils import calculate_ecpm
+from .utils import generate_absolute_url
 from .utils import generate_publisher_payout_data
 from .utils import get_ad_day
 from .utils import get_client_ip
@@ -443,6 +448,112 @@ class FlightRenewView(LoginRequiredMixin, PermissionRequiredMixin, CreateView):
                 "advertiser_slug": self.advertiser.slug,
                 "flight_slug": self.object.slug,
             },
+        )
+
+
+class FlightRequestView(AdvertiserAccessMixin, UserPassesTestMixin, CreateView):
+
+    """Create a new flight for an advertiser."""
+
+    form_class = FlightRequestForm
+    model = Flight
+    template_name = "adserver/advertiser/flight-request.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        self.advertiser = get_object_or_404(
+            Advertiser, slug=self.kwargs["advertiser_slug"]
+        )
+        self.old_flight = self.get_old_flight_or_404(self.request.GET.get("old_flight"))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["advertiser"] = self.advertiser
+        kwargs["flight"] = self.old_flight
+        return kwargs
+
+    def form_valid(self, form):
+        result = super().form_valid(form)
+        flight = self.object
+
+        # Notify support of the new flight
+        self.send_support_request(
+            flight,
+            {
+                "budget": form.cleaned_data["budget"],
+                "note": form.cleaned_data["note"],
+            },
+        )
+
+        messages.success(
+            self.request,
+            _(
+                "Successfully setup a new (non-live) %(flight)s and notified your account manager"
+            )
+            % {"flight": flight},
+        )
+        return result
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context.update(
+            {
+                "advertiser": self.advertiser,
+                "past_flights": Flight.objects.filter(
+                    campaign__advertiser=self.advertiser
+                ).order_by("-start_date")[:50],
+                "old_flight": self.old_flight,
+                "next": self.request.GET.get("next"),
+            }
+        )
+
+        return context
+
+    def get_success_url(self):
+        return reverse(
+            "flight_detail",
+            kwargs={
+                "advertiser_slug": self.advertiser.slug,
+                "flight_slug": self.object.slug,
+            },
+        )
+
+    def get_old_flight_or_404(self, old_flight_slug):
+        if old_flight_slug:
+            return get_object_or_404(
+                Flight, slug=old_flight_slug, campaign__advertiser=self.advertiser
+            )
+        return None
+
+    def send_support_request(self, new_flight, extras):
+
+        to_email = settings.ADSERVER_SUPPORT_TO_EMAIL
+        if not to_email:
+            site = get_current_site(None)
+            to_email = f"support@{site.domain}"
+            log.warning(
+                "Using the default support email address because ADSERVER_SUPPORT_TO_EMAIL is not configured"
+            )
+
+        context = {
+            "site_domain": generate_absolute_url(""),
+            "user": self.request.user,
+            "advertiser": self.advertiser,
+            "flight": new_flight,
+            "old_flight": self.old_flight,
+            "extras": extras,
+        }
+
+        mail.send_mail(
+            _("New Flight Request - %(advertiser)s")
+            % {"advertiser": self.advertiser.name},
+            message="See HTML message",
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[to_email],
+            html_message=render_to_string(
+                "adserver/email/flight-request.html", context
+            ),
         )
 
 

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -488,7 +488,7 @@ class FlightRequestView(AdvertiserAccessMixin, UserPassesTestMixin, CreateView):
         messages.success(
             self.request,
             _(
-                "Successfully setup a new (non-live) %(flight)s and notified your account manager"
+                "Successfully setup a new draft %(flight)s and notified your account manager"
             )
             % {"flight": flight},
         )

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -557,7 +557,7 @@ class FlightRequestView(AdvertiserAccessMixin, UserPassesTestMixin, CreateView):
         if settings.FRONT_ENABLED:
             with mail.get_connection(
                 settings.FRONT_BACKEND,
-                sender_name=f"{site.name} New Flight Request",
+                sender_name=f"{site.name} Flight Tracker",
             ) as connection:
                 message = mail.EmailMessage(
                     _("New Flight Request - %(advertiser)s")


### PR DESCRIPTION
- They can base it on a previous flight
- They don't specify targeting parameters (yet)
- They can put notes or a target budget in
- Submitting the form emails support

Production note: Ensure `ADSERVER_SUPPORT_TO_EMAIL` is set in prod when this goes out.

## Screenshot
![Screenshot from 2023-06-28 11-49-32](https://github.com/readthedocs/ethical-ad-server/assets/185043/778142c4-90d0-4898-9155-458fe54c24c8)
