### PR TITLE
Fix a bug that only affects test run after UTC midnight

### DIFF
--- a/adserver/tests/test_decision_engine.py
+++ b/adserver/tests/test_decision_engine.py
@@ -424,9 +424,28 @@ class DecisionEngineTests(TestCase):
             flight.save()
 
         priority_range = [1, 2, 10, 50, 100, 10000]
+        start_date = get_ad_day().date()
+        end_date = start_date + datetime.timedelta(days=30)
+        pacing_interval = 60 * 60 * 24
 
-        flight1 = get(Flight, campaign=self.campaign, live=True, sold_clicks=100)
-        flight2 = get(Flight, campaign=self.campaign, live=True, sold_clicks=100)
+        flight1 = get(
+            Flight,
+            start_date=start_date,
+            end_date=end_date,
+            pacing_interval=pacing_interval,
+            campaign=self.campaign,
+            live=True,
+            sold_clicks=100,
+        )
+        flight2 = get(
+            Flight,
+            start_date=start_date,
+            end_date=end_date,
+            pacing_interval=pacing_interval,
+            campaign=self.campaign,
+            live=True,
+            sold_clicks=100,
+        )
 
         self.advertisement1.flight = flight1
         self.advertisement2.flight = flight2
@@ -441,8 +460,12 @@ class DecisionEngineTests(TestCase):
                 flight1.save()
                 flight2.save()
 
-                flight1_prob = flight1.weighted_clicks_needed_this_interval()
-                flight2_prob = flight2.weighted_clicks_needed_this_interval()
+                flight1_prob = flight1.weighted_clicks_needed_this_interval(
+                    self.publisher
+                )
+                flight2_prob = flight2.weighted_clicks_needed_this_interval(
+                    self.publisher
+                )
                 total = flight1_prob + flight2_prob
 
                 with mock.patch("random.randint") as randint:


### PR DESCRIPTION
This fixes a bug that affects our tests locally or in CI that run when the local system is the previous day and it has already turned to the next day UTC.

## The long version
This bug occurred because with this test case as written the "clicks needed" for each flight was 1 and the code uses `<=` on both ends. In this situation, the 1st flight will have double the probability of the first. https://github.com/readthedocs/ethical-ad-server/blob/afaca1833013c073bc2be570dd95d8634d544e22/adserver/decisionengine/backends.py#L394-L397

For example, if the clicks needed for both flights is 1, then we will generate a random integer [0, 2]. If it is 0 or 1, the first flight will be chosen. Only if it is 2 will the 2nd flight be chosen. This is a bug, but in practice, this actually is mostly fine. We're usually dealing with much larger numbers where this off-by-one isn't a big deal. Secondly, this off by one means the ad is shown a few more times until it hits its threshold and then the other ad is shown. Overall, not a big deal.

## Further work
* The default start and end dates on flights don't use `get_ad_day`. They probably should but this will involve a migration. I think we should still do it for correctness. It's a small change. https://github.com/readthedocs/ethical-ad-server/blob/afaca1833013c073bc2be570dd95d8634d544e22/adserver/models.py#L718-L723
* The backend should use `if min_clicks <= choice < max_clicks:` (2nd is `<` instead of `<=`). However, this will involve more testing.