### PR TITLE
Upgrade celery

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ Django==3.2.20
 pytz==2021.3
 
 # Asynchronous tasks
-celery[redis]<5.0
+celery[redis]==5.3.1
 
 # Static files
 whitenoise==6.0.0


### PR DESCRIPTION
We've seen some prod issues with celery spawning more than one worker for the analyzer and supervisor not handling things correctly. Since this doesn't happen with our non-analyzer queue, I suspect it has something to do with high memory usage.

Hopefully upgrading celery (which is probably a good idea anyway) will fix it.