### PR TITLE
Aggregation changes to only count paid eligible ads

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -2107,6 +2107,7 @@ class AdImpression(BaseImpression):
     advertisement = models.ForeignKey(
         Advertisement, related_name="impressions", on_delete=models.PROTECT, null=True
     )
+    # This field is the sum of all the view time for each ad for this publisher each day
     view_time = models.PositiveIntegerField(
         _("Seconds that the ad was in view"),
         null=True,

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -82,6 +82,9 @@ def daily_update_geos(day=None, geo=True, region=True):
         }
     )
     queryset = Offer.objects.using(settings.REPLICA_SLUG).filter(
+        # For region and topic reports, we are excluding ads that were ineligible to be paid
+        # from the aggregations unless the publisher isn't approved for paid ads.
+        # This will give us more accurate KPIs on fill rates for paid publishers.
         Q(paid_eligible=True) | Q(publisher__allow_paid_campaigns=False),
         date__gte=start_date,
         date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
@@ -375,6 +378,9 @@ def daily_update_regiontopic(day=None):
         }
     )
     queryset = Offer.objects.using(settings.REPLICA_SLUG).filter(
+        # For region and topic reports, we are excluding ads that were ineligible to be paid
+        # from the aggregations unless the publisher isn't approved for paid ads.
+        # This will give us more accurate KPIs on fill rates for paid publishers.
         Q(paid_eligible=True) | Q(publisher__allow_paid_campaigns=False),
         date__gte=start_date,
         date__lt=end_date,  # Things at UTC midnight should count towards tomorrow

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -82,6 +82,7 @@ def daily_update_geos(day=None, geo=True, region=True):
         }
     )
     queryset = Offer.objects.using(settings.REPLICA_SLUG).filter(
+        Q(paid_eligible=True) | Q(publisher__allow_paid_campaigns=False),
         date__gte=start_date,
         date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
     )
@@ -374,6 +375,7 @@ def daily_update_regiontopic(day=None):
         }
     )
     queryset = Offer.objects.using(settings.REPLICA_SLUG).filter(
+        Q(paid_eligible=True) | Q(publisher__allow_paid_campaigns=False),
         date__gte=start_date,
         date__lt=end_date,  # Things at UTC midnight should count towards tomorrow
     )

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -798,10 +798,35 @@ class TestReportViews(TestReportsBase):
         self.assertNotContains(response, "CSV Export")
 
     def test_global_geo_report_contents(self):
-        get(Offer, publisher=self.publisher1, country="US", viewed=True)
-        get(Offer, publisher=self.publisher1, country="US", viewed=True)
-        get(Offer, publisher=self.publisher1, country="US", viewed=True)
-        get(Offer, publisher=self.publisher1, country="FR", viewed=True, clicked=True)
+        get(
+            Offer,
+            publisher=self.publisher1,
+            country="US",
+            paid_eligible=True,
+            viewed=True,
+        )
+        get(
+            Offer,
+            publisher=self.publisher1,
+            country="US",
+            paid_eligible=True,
+            viewed=True,
+        )
+        get(
+            Offer,
+            publisher=self.publisher1,
+            country="US",
+            paid_eligible=True,
+            viewed=True,
+        )
+        get(
+            Offer,
+            publisher=self.publisher1,
+            country="FR",
+            paid_eligible=True,
+            viewed=True,
+            clicked=True,
+        )
 
         # Update reporting
         daily_update_geos()
@@ -832,10 +857,35 @@ class TestReportViews(TestReportsBase):
         self.assertNotContains(response, "CSV Export")
 
     def test_global_region_report_contents(self):
-        get(Offer, publisher=self.publisher1, country="US", viewed=True)
-        get(Offer, publisher=self.publisher1, country="US", viewed=True)
-        get(Offer, publisher=self.publisher1, country="US", viewed=True)
-        get(Offer, publisher=self.publisher1, country="MX", viewed=True, clicked=True)
+        get(
+            Offer,
+            publisher=self.publisher1,
+            country="US",
+            paid_eligible=True,
+            viewed=True,
+        )
+        get(
+            Offer,
+            publisher=self.publisher1,
+            country="US",
+            paid_eligible=True,
+            viewed=True,
+        )
+        get(
+            Offer,
+            publisher=self.publisher1,
+            country="US",
+            paid_eligible=True,
+            viewed=True,
+        )
+        get(
+            Offer,
+            publisher=self.publisher1,
+            country="MX",
+            paid_eligible=True,
+            viewed=True,
+            clicked=True,
+        )
 
         # Update reporting
         daily_update_geos()
@@ -872,6 +922,7 @@ class TestReportViews(TestReportsBase):
             publisher=self.publisher1,
             keywords=["javascript"],
             country="US",
+            paid_eligible=True,
             viewed=True,
         )
         get(
@@ -880,6 +931,7 @@ class TestReportViews(TestReportsBase):
             publisher=self.publisher1,
             keywords=["javascript"],
             country="US",
+            paid_eligible=True,
             viewed=True,
         )
         get(
@@ -888,6 +940,7 @@ class TestReportViews(TestReportsBase):
             publisher=self.publisher1,
             keywords=["javascript"],
             country="US",
+            paid_eligible=True,
             viewed=True,
         )
         get(
@@ -896,6 +949,7 @@ class TestReportViews(TestReportsBase):
             publisher=self.publisher1,
             keywords=["python"],
             country="MX",
+            paid_eligible=True,
             viewed=True,
             clicked=True,
         )


### PR DESCRIPTION
Branched from https://github.com/readthedocs/ethical-ad-server/pull/797.

I did this in a separate PR because the aggregation for the first day after #797 is deployed will need to be run without this change since we aren't yet tracking `paid_eligible` on offers for that day. Once that is merged and deployed and the aggregations are run, then this can be deployed.