### PR TITLE
Allow running multiple analyzer models

### DIFF
--- a/adserver/analyzer/backends/textacynlp.py
+++ b/adserver/analyzer/backends/textacynlp.py
@@ -19,7 +19,7 @@ class TextacyAnalyzerBackend(NaiveKeywordAnalyzerBackend):
     https://textacy.readthedocs.io/en/latest/quickstart.html
     """
 
-    TOP_PHRASE_COUNT = 20
+    TOP_PHRASE_COUNT = 50
 
     # Minimum phrase length where each word isn't required to be in the output phrase
     MIN_PHRASE_LENGTH = 6

--- a/adserver/analyzer/management/commands/runmodel.py
+++ b/adserver/analyzer/management/commands/runmodel.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 from django.core.validators import URLValidator
 from django.utils.translation import gettext_lazy as _
 
-from ...utils import get_url_analyzer_backend
+from ...utils import get_url_analyzer_backends
 
 
 class Command(BaseCommand):
@@ -24,7 +24,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         """Entrypoint to the command."""
         self.stdout.write(
-            _("Using the model from %s") % settings.ADSERVER_ANALYZER_BACKEND
+            _("Using the model(s) from %s") % settings.ADSERVER_ANALYZER_BACKEND
         )
 
         for url in kwargs["urls"]:
@@ -36,10 +36,16 @@ class Command(BaseCommand):
         """Dump questions from metabase to a file."""
         self.stdout.write(_("Running against %s") % url)
 
-        backend = get_url_analyzer_backend()(url)
-        keywords = backend.analyze()
+        keywords = []
+        for backend in get_url_analyzer_backends():
+            backend_instance = backend(url)
+            analyzed_keywords = backend_instance.analyze()
+            self.stdout.write(
+                _("Keywords from '%s': %s") % (backend.__name__, analyzed_keywords)
+            )
 
-        if keywords is None:
-            self.stderr.write(_("Failed to connect/process %s") % url)
+            if analyzed_keywords:
+                for kw in analyzed_keywords:
+                    keywords.append(kw)
 
         self.stdout.write(_("Keywords/topics: %s") % keywords)

--- a/adserver/analyzer/utils.py
+++ b/adserver/analyzer/utils.py
@@ -7,8 +7,18 @@ from django.utils.module_loading import import_string
 from .constants import IGNORED_QUERY_PARAMS
 
 
+def get_url_analyzer_backends():
+    for backend in settings.ADSERVER_ANALYZER_BACKEND:
+        if backend:
+            yield import_string(backend)
+
+
 def get_url_analyzer_backend():
-    return import_string(settings.ADSERVER_ANALYZER_BACKEND)
+    backends = list(get_url_analyzer_backends())
+    if backends:
+        return backends[0]
+
+    return None
 
 
 def normalize_url(url):

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -487,12 +487,12 @@ ADSERVER_DECISION_BACKEND = env(
     default="adserver.decisionengine.backends.ProbabilisticFlightBackend",
 )
 
-# The backend to be used by the ad server
+# The backend(s) to be used by the ad server
 # for topic and keyword analysis
-# Set to `None` to disable the analyzer entirely
-ADSERVER_ANALYZER_BACKEND = env(
+# Set to `None` or an empty string to disable the analyzer entirely
+ADSERVER_ANALYZER_BACKEND = env.list(
     "ADSERVER_ANALYZER_BACKEND",
-    default="adserver.analyzer.backends.TextacyAnalyzerBackend",
+    default=["adserver.analyzer.backends.TextacyAnalyzerBackend"],
 )
 if ADSERVER_ANALYZER_BACKEND:
     INSTALLED_APPS.append("adserver.analyzer")


### PR DESCRIPTION
The setting `settings.ADSERVER_ANALYZER_BACKEND` can now be a list and multiple analyzers will be run and combined.

## Testing

Ensure the docker container is built with the eatopics model. Due to some versioning issues with the model (not being in the form of `vX.Y.Z`), I built a new wheel for it.

```
ADSERVER_ANALYZER_BACKEND=adserver.analyzer.backends.TextacyAnalyzerBackend,adserver.analyzer.backends.EthicalAdsTopicsBackend  ./manage.py shell
from adserver.analyzer.tasks import analyze_url
analyze_url('https://pytorch.org/get-started/locally/', 'readthedocs')
```