### PR TITLE
Log ad rotations

### DIFF
--- a/adserver/api/serializers.py
+++ b/adserver/api/serializers.py
@@ -66,6 +66,13 @@ class AdDecisionSerializer(serializers.Serializer):
         required=False, min_value=0, max_value=999
     )
 
+    # Field sent when an ad is rotated but not sent when an ad is first loaded
+    rotations = serializers.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=9,
+    )
+
     # Used to pass the actual ad viewer's data for targeting purposes
     user_ip = serializers.IPAddressField(required=False)
     user_ua = serializers.CharField(required=False)

--- a/adserver/api/views.py
+++ b/adserver/api/views.py
@@ -287,6 +287,7 @@ class AdDecisionView(GeoIpMixin, APIView):
             url = serializer.validated_data.get("url")
             keywords = serializer.validated_data.get("keywords")
             campaign_types = serializer.validated_data.get("campaign_types")
+            rotations = serializer.validated_data.get("rotations", 1)
 
             forced = False
             paid_eligible = False
@@ -294,6 +295,15 @@ class AdDecisionView(GeoIpMixin, APIView):
             # Ignore keywords from the API for certain publishers
             if not publisher.allow_api_keywords:
                 keywords = []
+
+            if rotations > 1:
+                # This is a temporary log record to see how frequently ads are rotated
+                log.warning(
+                    "Ad rotation. rotations=%s, publisher=%s, url=%s,",
+                    rotations,
+                    publisher.slug,
+                    url,
+                )
 
             if serializer.validated_data.get(
                 "force_ad"


### PR DESCRIPTION
This just logs ad rotations at warnings so we see them in Sentry.