### PR TITLE
Region and metro targeting from CF

### DIFF
--- a/adserver/middleware.py
+++ b/adserver/middleware.py
@@ -181,8 +181,13 @@ class CloudflareGeoIpMiddleware(GeoIpMiddleware):
         Also, Cloudflare IP Geolocation must be enabled.
     """
 
-    COUNTRY_HEADER = "CF-IPCountry"
     PROVIDER_NAME = "Cloudflare"
+    COUNTRY_HEADER = "CF-IPCountry"
+
+    # These fields will require a custom transform rule
+    # https://developers.cloudflare.com/rules/transform/
+    REGION_HEADER = "X-Cloudflare-Geo-Region"  # ip.src.region_code
+    METRO_HEADER = "X-Cloudflare-Geo-Metro"  # ip.src.metro_code
 
     def get_geoip(self, request):
         geo = super().get_geoip(request)
@@ -194,6 +199,8 @@ class CloudflareGeoIpMiddleware(GeoIpMiddleware):
             country_code = None
 
         geo.country = country_code
+        geo.region = request.headers.get(self.REGION_HEADER, None)
+        geo.metro = request.headers.get(self.METRO_HEADER, None)
 
         return geo
 

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -1292,7 +1292,7 @@ class AdvertisingIntegrationTests(BaseApiTest):
             "user_ua": self.user_agent,
         }
         with mock.patch("adserver.utils.get_geoipdb_geolocation") as get_geo:
-            get_geo.return_value = GeolocationData("CA")
+            get_geo.return_value = GeolocationData("US", "NY")
 
             resp = self.client.post(
                 self.url, json.dumps(data), content_type="application/json"
@@ -1301,7 +1301,8 @@ class AdvertisingIntegrationTests(BaseApiTest):
 
         # Check that the new IP was used for ad targeting
         self.assertEqual(resp["X-Adserver-RealIP"], new_ip)
-        self.assertEqual(resp["X-Adserver-Country"], "CA")
+        self.assertEqual(resp["X-Adserver-Country"], "US")
+        self.assertEqual(resp["X-Adserver-Region"], "NY")
 
     @override_settings(ADSERVER_RECORD_VIEWS=False)
     def test_record_views_false(self):

--- a/adserver/tests/test_middleware.py
+++ b/adserver/tests/test_middleware.py
@@ -138,9 +138,16 @@ class TestMiddleware(TestCase):
             self.client.force_login(staff_user)
 
             country = "US"
-            response = self.client.get("/", headers={"cf-ipcountry": country})
+            response = self.client.get(
+                "/",
+                headers={
+                    "cf-ipcountry": country,
+                    "X-Cloudflare-Geo-Region": "NY",
+                },
+            )
             request = response.wsgi_request
             self.assertEqual(request.geo.country, country)
+            self.assertEqual(request.geo.region, "NY")
             self.assertTrue("X-Adserver-GeoIP-Provider" in response)
             self.assertEqual(response["X-Adserver-GeoIP-Provider"], "Cloudflare")
 


### PR DESCRIPTION
Cloudflare can send down state/territory/region and metro data. I added this to our custom transform rule. We can use these for targeting, but I'd be hesitant to use them outside of the US as I suspect data won't be extremely reliable.

Note: campaigns that target by region should target a single country (eg. US and CA/NY/TX/FL). There could be some oddities where a region from one country has the same region code as a region in another country. Weird results could ensue.