### PR TITLE
Stop updating inactive publishers

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -704,7 +704,7 @@ def calculate_publisher_ctrs(days=7):
     """Calculate average CTRs for paid ads on a publisher for the last X days."""
     sample_cutoff = get_ad_day() - datetime.timedelta(days=days)
 
-    for publisher in Publisher.objects.all():
+    for publisher in Publisher.objects.filter(allow_paid_campaigns=True):
         queryset = AdImpression.objects.filter(
             date__gte=sample_cutoff,
             publisher=publisher,
@@ -713,8 +713,9 @@ def calculate_publisher_ctrs(days=7):
         report = PublisherReport(queryset)
         report.generate()
 
-        publisher.sampled_ctr = report.total["ctr"]
-        publisher.save()
+        if report.total["views"] > 0:
+            publisher.sampled_ctr = report.total["ctr"]
+            publisher.save()
 
 
 @app.task()

--- a/adserver/tests/test_tasks.py
+++ b/adserver/tests/test_tasks.py
@@ -70,6 +70,9 @@ class TasksTest(BaseAdModelsTestCase):
         self.assertIsNone(offer.client_id)
 
     def test_calculate_publisher_ctrs(self):
+        self.publisher.allow_paid_campaigns = True
+        self.publisher.save()
+
         calculate_publisher_ctrs()
 
         self.publisher.refresh_from_db()


### PR DESCRIPTION
We currently run a task nightly to update the sampled CTR of publishers for paid ads. This changes that task as follows:

- Only run this on publishers approved for paid ads
- Don't update the publisher if there were 0 views in the time period (1 week usually)

This was interfering with how we disable inactive publishers (ref: #807) and while this doesn't stop the problem of us switching somebody to paid and then they are disabled automatically again, it should drastically reduce the updates and make any changes we make to disabling inactive publishers easier.

I did consider checking the modified time (like #807 does) when disabling publishers but that does sort of come with its own set of issues and publishers can affect their own modified times.