### PR TITLE
Change the publisher alert from views to revenue

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -897,7 +897,7 @@ def notify_of_publisher_changes(difference_threshold=0.25, min_views=10_000):
         previous_week_report = PublisherReport(queryset)
         previous_week_report.generate()
 
-        for metric in ("views",):
+        for metric in ("revenue",):
             total_views = (
                 last_week_report.total["views"] + previous_week_report.total["views"]
             )

--- a/adserver/tests/test_tasks.py
+++ b/adserver/tests/test_tasks.py
@@ -276,12 +276,14 @@ class TasksTest(BaseAdModelsTestCase):
         backend.reset_messages()
         notify_of_publisher_changes(min_views=100)
 
-        # Should be 1 message: one for views with CTR being within the threshold
+        # Should be 1 message: one for revenue with CTR being within the threshold
+        # Ads are $2 CPC
         messages = backend.retrieve_messages()
         self.assertEqual(len(messages), 1, messages)
         self.assertTrue(
-            '"views" was 55 last week and 111 the previous week (-50.45%)'
-            in messages[0]["text"]
+            '"revenue" was 10 last week and 22 the previous week (-54.55%)'
+            in messages[0]["text"],
+            messages[0]["text"],
         )
 
         backend.reset_messages()


### PR DESCRIPTION
Currently we're alerting on changes in views which is more volatile based on global campaigns. Alerting on revenue should be more predictable with fewer false positives.