### PR TITLE
Display negative keywords in the targeting details

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1131,7 +1131,7 @@ class Flight(TimeStampedModel, IndestructibleModel):
                 return False
 
         if self.excluded_keywords:
-            # If any keyworks from the page in the exclude list, don't show this flight
+            # If any keywords from the page in the exclude list, don't show this flight
             if keyword_set.intersection(self.excluded_keywords):
                 return False
 

--- a/adserver/templates/adserver/includes/flight-metadata.html
+++ b/adserver/templates/adserver/includes/flight-metadata.html
@@ -106,6 +106,9 @@
         {% if flight.targeting_parameters.include_keywords %}
          <li>{% blocktrans with value=flight.targeting_parameters.include_keywords|join:", " %}Include keywords: {{ value }}{% endblocktrans %}</li>
         {% endif %}
+        {% if flight.targeting_parameters.exclude_keywords %}
+         <li>{% blocktrans with value=flight.targeting_parameters.exclude_keywords|join:", " %}Exclude keywords: {{ value }}{% endblocktrans %}</li>
+        {% endif %}
         {% if flight.targeting_parameters.include_publishers %}
          <li>{% blocktrans with value=flight.targeting_parameters.include_publishers|join:", " %}Include publishers: {{ value }}{% endblocktrans %}</li>
         {% endif %}


### PR DESCRIPTION
This feature was already supported in the ad server but not displayed in the UI.

![Screenshot from 2024-03-01 16-55-55](https://github.com/readthedocs/ethical-ad-server/assets/185043/52ac393f-3962-44aa-8496-083a4468a505)
