### PR TITLE
Add more explicit substitions to ad replacement

### DIFF
--- a/adserver/views.py
+++ b/adserver/views.py
@@ -981,11 +981,18 @@ class AdClickProxyView(BaseProxyView):
         template = string.Template(advertisement.link)
 
         publisher_slug = "unknown"
+        publisher_Name = "unknown"
         if publisher:
             publisher_slug = publisher.slug
+            publisher_name = publisher.name
 
         url = template.safe_substitute(
-            publisher=publisher_slug, advertisement=advertisement.slug
+            publisher=publisher_slug,
+            advertisement=advertisement.slug,
+            publisher_slug=publisher_slug,
+            advertisement_slug=advertisement.slug,
+            publisher_name=publisher_name,
+            advertisement_name=advertisement.name,
         )
 
         # Append a query string param ?ea-publisher=${publisher}

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -981,7 +981,7 @@ class AdClickProxyView(BaseProxyView):
         template = string.Template(advertisement.link)
 
         publisher_slug = "unknown"
-        publisher_Name = "unknown"
+        publisher_name = "unknown"
         if publisher:
             publisher_slug = publisher.slug
             publisher_name = publisher.name

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -988,10 +988,10 @@ class AdClickProxyView(BaseProxyView):
 
         url = template.safe_substitute(
             publisher=publisher_slug,
-            advertisement=advertisement.slug,
             publisher_slug=publisher_slug,
-            advertisement_slug=advertisement.slug,
             publisher_name=publisher_name,
+            advertisement=advertisement.slug,
+            advertisement_slug=advertisement.slug,
             advertisement_name=advertisement.name,
         )
 


### PR DESCRIPTION
Had an advertiser want the name,
and it seems better to let them use something they control.
Was planning to document the new variables,
and keep the old ones for backwards compat.
