### PR TITLE
Advertiser eCPC in flight list

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1396,6 +1396,13 @@ class Flight(TimeStampedModel, IndestructibleModel):
         views = self.total_views
         return calculate_ctr(clicks, views)
 
+    def ecpc(self):
+        clicks = self.total_clicks
+        value_delivered = self.total_value()
+        if clicks > 0:
+            return value_delivered / clicks
+        return 0
+
     @cached_property
     def active_invoices(self):
         """Get invoices excluding drafts, void, and uncollectable ones."""

--- a/adserver/templates/adserver/advertiser/flight-list.html
+++ b/adserver/templates/adserver/advertiser/flight-list.html
@@ -45,6 +45,7 @@
               <th><strong>{% trans 'End date' %}</strong></th>
               <th class="text-right"><strong>{% trans 'Budget' %}</strong></th>
               <th class="text-right"><strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong></th>
+              <th class="text-right"><strong>{% blocktrans %}<abbr title="Effective cost per click">eCPC</abbr>{% endblocktrans %}</strong></th>
               <th class="text-right"><strong>{% trans 'Options' %}</strong></th>
             </tr>
           </thead>
@@ -61,6 +62,7 @@
                 <td>{{ flight.end_date }}</td>
                 <td class="text-right">${{ flight.projected_total_value|floatformat:2 }}</td>
                 <td class="text-right">{{ flight.ctr|floatformat:3 }}%</td>
+                <td class="text-right">${{ flight.ecpc|floatformat:2 }}</td>
                 <td class="text-right">
                   <ul class="list-inline">
 

--- a/adserver/templates/adserver/advertiser/overview.html
+++ b/adserver/templates/adserver/advertiser/overview.html
@@ -100,11 +100,15 @@
                     <table class="table table-hover">
                       <thead>
                         <tr>
-                          <th><strong>{% trans 'Flight' %}</strong></th>
+                          <th width="33%"><strong>{% trans 'Flight' %}</strong></th>
                           <th><strong>{% trans 'End date' %}</strong></th>
-                          <th>
+                          <th class="text-right">
                             <strong>{% blocktrans %}<abbr title="Click through rate">CTR</abbr>{% endblocktrans %}</strong>
                             <span class="fa fa-info-circle fa-fw" aria-hidden="true" data-toggle="tooltip" title="{% trans 'This CTR is all-time, not month to date' %}" data-original-title="{% trans 'This CTR is all-time, not month to date' %}"></span>
+                          </th>
+                          <th class="text-right">
+                            <strong>{% blocktrans %}<abbr title="Effective cost per click">eCPC</abbr>{% endblocktrans %}</strong>
+                            <span class="fa fa-info-circle fa-fw" aria-hidden="true" data-toggle="tooltip" title="{% trans 'eCPC is all-time, not month to date' %}" data-original-title="{% trans 'eCPC is all-time, not month to date' %}"></span>
                           </th>
                           <th><strong>{% trans 'Progress' %}</strong></th>
                         </tr>
@@ -116,7 +120,8 @@
                               <a href="{% url 'flight_detail' advertiser.slug flight.slug %}">{{ flight.name }}</a>
                             </td>
                             <td>{{ flight.end_date }}</td>
-                            <td>{{ flight.ctr|floatformat:3 }}%</td>
+                            <td class="text-right">{{ flight.ctr|floatformat:3 }}%</td>
+                            <td class="text-right">${{ flight.ecpc|floatformat:2 }}</td>
                             <td>
                               <div class="progress" style="height: 1.5rem">
                                 <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: {{ flight.percent_complete|floatformat:0 }}%;" aria-valuenow="{{ flight.percent_complete|floatformat:0 }}" aria-valuemin="0" aria-valuemax="100">


### PR DESCRIPTION
Puts an advertiser eCPC into the flight list view. We could also add this into the report view although showing eCPC on a day-by-day basis will be noisy for some small advertisers.


## Screenshot

![Screenshot from 2024-04-12 16-18-15](https://github.com/readthedocs/ethical-ad-server/assets/185043/37272508-34aa-48ee-9a35-ed4d0b0aa50b)
