### PR TITLE
Add private webhook support app

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -526,6 +526,8 @@ if ADSERVER_ANALYZER_BACKEND:
     INSTALLED_APPS.append("adserver.analyzer")
 if ADSERVER_ANALYZER_BACKEND and ext:
     INSTALLED_APPS.append("ethicalads_ext.embedding")
+if ext:
+    INSTALLED_APPS.append("ethicalads_ext.support")
 
 # Whether Do Not Track is enabled for the ad server
 ADSERVER_DO_NOT_TRACK = False

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -229,7 +229,9 @@ SERVER_EMAIL = env("SERVER_EMAIL", default="noreply@example.com")
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
 EMAIL_TIMEOUT = 5
 
-# For sending email through Front.
+# Front
+# --------------------------------------------------------------------------
+# For sending email through Front and processing Front webhooks
 FRONT_BACKEND = "frontbackend.backend.EmailBackend"
 FRONT_TOKEN = env("FRONT_TOKEN", default=None)
 FRONT_CHANNEL = env("FRONT_CHANNEL", default=None)
@@ -237,6 +239,9 @@ FRONT_AUTHOR = env("FRONT_AUTHOR", default=None)
 FRONT_SENDER_NAME = env("FRONT_SENDER_NAME", default=None)
 FRONT_ARCHIVE = env.bool("FRONT_ARCHIVE", default=False)
 FRONT_ENABLED = FRONT_TOKEN and FRONT_CHANNEL and FRONT_AUTHOR
+# This last value is only needed for processing webhooks.
+# It comes from the webhooks "App" in Front's settings
+FRONT_WEBHOOK_SECRET = env("FRONT_WEBHOOK_SECRET", default=None)
 
 
 # Internationalization

--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -9,7 +9,9 @@ warnings.filterwarnings("ignore", message="No directory at", module="whitenoise.
 
 TESTING = True
 TEMPLATES[0]["OPTIONS"]["debug"] = DEBUG
+LOGGING["loggers"][""]["level"] = "CRITICAL"
 LOGGING["loggers"]["adserver"]["level"] = "CRITICAL"
+LOGGING["loggers"]["ethicalads_ext"]["level"] = "CRITICAL"
 
 # Skip the embedding app in testing
 if "ethicalads_ext.embedding" in INSTALLED_APPS:

--- a/config/urls.py
+++ b/config/urls.py
@@ -46,6 +46,11 @@ if settings.ADSERVER_ADMIN_URL:
     # If no ADSERVER_ADMIN_URL is specified, the Django admin is disabled
     urlpatterns += [path(f"{settings.ADSERVER_ADMIN_URL}/", admin.site.urls)]
 
+if "ethicalads_ext.support" in settings.INSTALLED_APPS:
+    urlpatterns += [
+        path(r"support/", include("ethicalads_ext.support.urls")),
+    ]
+
 urlpatterns += [
     path(r"accounts/", include("allauth.urls")),
     path(r"stripe/", include("djstripe.urls", namespace="djstripe")),


### PR DESCRIPTION
Adds an app with custom URLs under `/support/`. This is going to be used for some private webhooks (currently for processing some support and lead forms).