### PR TITLE
Add a crop/resize widget for uploading ads

### DIFF
--- a/adserver/forms.py
+++ b/adserver/forms.py
@@ -1093,7 +1093,6 @@ class AdvertisementForm(AdvertisementFormMixin, forms.ModelForm):
                     data_width=ad_type_image_width,
                     data_height=ad_type_image_height,
                 ),
-                HTML("<p data-bind='text: imageErrors()' class='text-danger'></p>"),
                 css_class="my-3",
             ),
             Fieldset(

--- a/adserver/templates/adserver/advertiser/advertisement-create.html
+++ b/adserver/templates/adserver/advertiser/advertisement-create.html
@@ -53,4 +53,6 @@
 
 </div>
 
+{% include "adserver/includes/widgets/advertisement-crop-resize-modal.html" %}
+
 {% endblock content_container %}

--- a/adserver/templates/adserver/advertiser/advertisement-update.html
+++ b/adserver/templates/adserver/advertiser/advertisement-update.html
@@ -41,4 +41,6 @@
 
 </div>
 
+{% include "adserver/includes/widgets/advertisement-crop-resize-modal.html" %}
+
 {% endblock content_container %}

--- a/adserver/templates/adserver/includes/widgets/advertisement-crop-resize-modal.html
+++ b/adserver/templates/adserver/includes/widgets/advertisement-crop-resize-modal.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+
+<!-- Modal -->
+<div class="modal fade" id="modal" tabindex="-1" aria-labelledby="modalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="modalLabel">{% trans 'Crop and resize image' %}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>{% trans 'Your image is not the right size for the ad format. You will need to crop and resize the image.' %}</p>
+        <p data-bind='text: imageErrors()' class='text-danger'></p>
+        <div class="mw-100">
+          <img class="mw-100" style="display: block" id="crop-resize-widget" />
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans 'Close' %}</button>
+        <button type="button" class="btn btn-primary" data-bind="click: cropAndResize">{% trans 'Crop and resize image' %}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/assets/src/scss/index.scss
+++ b/assets/src/scss/index.scss
@@ -7,6 +7,9 @@ $fa-font-path: "~font-awesome/fonts";
 // Import ad styles from the ad client
 @import "~ethical-ad-client/styles.scss";
 
+// $cropper-image-path: '../images';
+@import "~cropperjs/src/index.css";
+
 @import "theme.scss";
 @import "branding.scss";
 @import "utils.scss";

--- a/assets/src/views/advertisement-form.js
+++ b/assets/src/views/advertisement-form.js
@@ -1,4 +1,5 @@
 import * as jquery from 'jquery';
+import Cropper from 'cropperjs';
 const ko = require('knockout');
 
 
@@ -7,6 +8,11 @@ function AdvertisementFormViewModel(method) {
   const SENSIBLE_MAXIMUM_LENGTH = 1000;
 
   const viewmodel = this;
+  const image = document.querySelector("#id_image");
+  const expected_width = parseInt(image.getAttribute("data-width"));
+  const expected_height = parseInt(image.getAttribute("data-height"));
+  const uploadInput = document.getElementById("id_image");
+  let cropper = null;
 
   this.headline = ko.observable($("#id_headline").val());
   this.content = ko.observable($("#id_content").val());
@@ -35,22 +41,6 @@ function AdvertisementFormViewModel(method) {
     return length;
   };
 
-  this.imageErrors = function () {
-    let image = document.querySelector("#id_image");
-    let expected_width = parseInt(image.getAttribute("data-width"));
-    let expected_height = parseInt(image.getAttribute("data-height"));
-
-    if (expected_width && expected_height && this.image_width() && this.image_height() &&
-        (expected_width != this.image_width() || expected_height != this.image_height())
-    ) {
-      return 'Expected an image sized ' + expected_width + '*' + expected_height + 'px ' +
-             '(it is ' + this.image_width() + '*' + this.image_height() + 'px).';
-    }
-
-    return '';
-  };
-
-
   this.maxLength = function () {
     // The actual max length passed from the backend form
     let max_length = parseInt($("#id_maximum_text_length").attr("data-maximum-length"));
@@ -63,25 +53,95 @@ function AdvertisementFormViewModel(method) {
     return max_length;
   };
 
+  this.imageIsWrongSize = function () {
+    if (expected_width && expected_height && this.image_width() && this.image_height() &&
+        (expected_width != this.image_width() || expected_height != this.image_height())
+    ) {
+      return true;
+    }
+
+    return false;
+  };
+
+  this.imageErrors = function () {
+    if (this.imageIsWrongSize()) {
+      return 'Expected an image sized ' + expected_width + '*' + expected_height + 'px ' +
+             '(it is ' + this.image_width() + '*' + this.image_height() + 'px).';
+    }
+
+    return '';
+  };
+
+  this.cropAndResize = function () {
+    if (cropper) {
+      cropper.getCroppedCanvas({width: expected_width, height: expected_height}).toBlob((blob) => {
+        // modified time is required for some reason
+        let file = new File([blob], "cropped.png", {type:"image/png", lastModified: new Date().getTime()});
+        let container = new DataTransfer();
+        container.items.add(file);
+        uploadInput.files = container.files;
+
+        // Trigger the change event
+        uploadInput.dispatchEvent(new Event('change'));
+      });
+    }
+    $('#modal').modal('hide');
+
+    // Update URL which sends a measurement event
+    const url = new URL(window.location);
+    url.searchParams.set("crop", "end");
+    window.history.pushState({}, null, url);
+  };
+
   // Handle uploading images cleanly including cropping/resizing
   // and showing the preview
-  const upload = document.getElementById("id_image");
-  upload.addEventListener('change', e => {
+  uploadInput.addEventListener('change', e => {
     if (e.target.files.length) {
-      for (const file of upload.files) {
+      for (const file of uploadInput.files) {
         // Get the image width/height
         let imageSrc = URL.createObjectURL(file);
         let tempImage = new Image();
         tempImage.onload = function(ev) {
           viewmodel.image_width(ev.target.width);
           viewmodel.image_height(ev.target.height);
+          if (viewmodel.imageIsWrongSize()) {
+            const image = document.getElementById('crop-resize-widget');
+            const aspectRatio = expected_width / expected_height;
+            const containerRatio = 466 / expected_width;  // 466 is the modal width
+            image.src = imageSrc;
+
+            if (cropper) {
+              // Reset the cropper before creating a new one
+              cropper.destroy();
+            }
+
+            $('#modal').modal('show');
+
+            // https://github.com/fengyuanchen/cropperjs
+            cropper = new Cropper(image, {
+              // Height and Width are guaranteed to be >0 here
+              // since the image size was checked
+              aspectRatio: aspectRatio,
+              initialAspectRatio: aspectRatio,
+              viewMode: 2,
+              autoCropArea: 1,
+              rotatable: false,
+              minContainerWidth: expected_width * containerRatio,
+              minContainerHeight: expected_height * containerRatio,
+            });
+
+            // Update URL which sends a measurement event
+            const url = new URL(window.location);
+            url.searchParams.set("crop", "start");
+            window.history.pushState({}, null, url);
+          } else {
+            // Show the image in the ad preview(s)
+            document.querySelectorAll(".advertisement-preview img").forEach(element => {
+              element.src = imageSrc;
+            });
+          }
         };
         tempImage.src = imageSrc;
-
-        // Show the image in the ad preview(s)
-        document.querySelectorAll(".advertisement-preview img").forEach(element => {
-          element.src = imageSrc;
-        });
       }
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "ethical-ad-server",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ethical-ad-server",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "bootstrap": "^4.6.2",
+        "cropperjs": "^1.6.2",
         "font-awesome": "^4.7.0",
         "jquery": "^3.5.1",
         "knockout": "^3.5.1",
@@ -1437,6 +1438,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/cropperjs": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.2.tgz",
+      "integrity": "sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6602,6 +6608,11 @@
           }
         }
       }
+    },
+    "cropperjs": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.2.tgz",
+      "integrity": "sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA=="
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "npm" : ">=8.0.0 <9.0.0",
+    "npm": ">=8.0.0 <9.0.0",
     "node": ">=16.0.0 <17.0.0"
   },
   "scripts": {
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/readthedocs/ethical-ad-server#readme",
   "dependencies": {
     "bootstrap": "^4.6.2",
+    "cropperjs": "^1.6.2",
     "font-awesome": "^4.7.0",
     "jquery": "^3.5.1",
     "knockout": "^3.5.1",


### PR DESCRIPTION
Built on #886.

- Uploading a "wrong-sized" image triggers the crop tool
- Cropped image is saved to the form and uploaded as normal
- Uses [cropperjs](https://github.com/fengyuanchen/cropperjs).

## Screenshot
![Screenshot from 2024-06-27 12-55-39](https://github.com/readthedocs/ethical-ad-server/assets/185043/524f7edb-b7e4-4f8a-bea7-6ff114bf0556)
