### PR TITLE
Advertiser report optimizations

### DIFF
--- a/adserver/mixins.py
+++ b/adserver/mixins.py
@@ -120,12 +120,16 @@ class AdvertisementValidateLinkMixin:
 class ReportQuerysetMixin:
     """Mixin for getting a queryset of advertiser report data."""
 
-    # Subclasses must define one of these
+    # Subclasses must define this OR `get_impression_model`
     impression_model = None
+
+    def get_impression_model(self, **kwargs):
+        return self.impression_model
 
     def get_queryset(self, **kwargs):
         """Get the queryset (from ``impression_model``) used to generate the report."""
-        queryset = self.impression_model.objects.all()
+        model = self.get_impression_model(**kwargs)
+        queryset = model.objects.all()
 
         if "start_date" in kwargs and kwargs["start_date"]:
             queryset = queryset.filter(date__gte=kwargs["start_date"])

--- a/adserver/reports.py
+++ b/adserver/reports.py
@@ -11,6 +11,7 @@ from .models import AdvertiserImpression
 from .models import GeoImpression
 from .models import KeywordImpression
 from .models import PlacementImpression
+from .models import PublisherImpression
 from .models import PublisherPaidImpression
 from .models import RegionImpression
 from .models import RegionTopicImpression
@@ -326,6 +327,15 @@ class PublisherReport(BaseReport):
             return value
 
         return super().get_index_display(index)
+
+
+class OptimizedPublisherReport(PublisherReport):
+    """A report using the optimized PublisherImpression index showing daily ad performance for a publisher."""
+
+    model = PublisherImpression
+    index = "date"
+    order = "-date"
+    select_related_fields = ("publisher",)
 
 
 class OptimizedPublisherPaidReport(PublisherReport):

--- a/adserver/templates/adserver/reports/includes/publisher-report-table.html
+++ b/adserver/templates/adserver/reports/includes/publisher-report-table.html
@@ -19,7 +19,6 @@
         <th class="text-right staff-only"><strong>{% trans 'Our&nbsp;Rev' %}</strong></th>
         <th class="text-right staff-only"><strong>{% trans 'Total&nbsp;Rev' %}</strong></th>
         <th class="text-right staff-only"><strong>{% blocktrans %}Total <abbr title="Effective cost per thousand impressions">eCPM</abbr>{% endblocktrans %}</strong></th>
-        <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="% of traffic with a paid ad">Fill Rate</abbr>{% endblocktrans %}</strong></th>
       {% endif %}
     </tr>
   </thead>
@@ -42,7 +41,6 @@
           <td class="text-right">${{ result.our_revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.ecpm|floatformat:2 }}</td>
-          <td class="text-right">{{ result.fill_rate|floatformat:1 }}%</td>
         {% endif %}
       </tr>
       {% endif %}
@@ -63,7 +61,6 @@
         <td class="text-right"><strong>${{ report.total.our_revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.ecpm|floatformat:2 }}</strong></td>
-        <td class="text-right"><strong>{{ report.total.fill_rate|floatformat:1 }}%</strong></td>
       {% endif %}
     </tr>
   </tbody>

--- a/adserver/templates/adserver/reports/includes/publisher-report-table.html
+++ b/adserver/templates/adserver/reports/includes/publisher-report-table.html
@@ -19,6 +19,7 @@
         <th class="text-right staff-only"><strong>{% trans 'Our&nbsp;Rev' %}</strong></th>
         <th class="text-right staff-only"><strong>{% trans 'Total&nbsp;Rev' %}</strong></th>
         <th class="text-right staff-only"><strong>{% blocktrans %}Total <abbr title="Effective cost per thousand impressions">eCPM</abbr>{% endblocktrans %}</strong></th>
+        <th class="text-right staff-only"><strong>{% blocktrans %}<abbr title="% of traffic with a paid ad">Fill Rate</abbr>{% endblocktrans %}</strong></th>
       {% endif %}
     </tr>
   </thead>
@@ -41,6 +42,7 @@
           <td class="text-right">${{ result.our_revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.revenue|floatformat:2|intcomma }}</td>
           <td class="text-right">${{ result.ecpm|floatformat:2 }}</td>
+          <td class="text-right">{{ result.fill_rate|floatformat:1 }}%</td>
         {% endif %}
       </tr>
       {% endif %}
@@ -61,6 +63,7 @@
         <td class="text-right"><strong>${{ report.total.our_revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.revenue|floatformat:2|intcomma }}</strong></td>
         <td class="text-right"><strong>${{ report.total.ecpm|floatformat:2 }}</strong></td>
+        <td class="text-right"><strong>{{ report.total.fill_rate|floatformat:1 }}%</strong></td>
       {% endif %}
     </tr>
   </tbody>

--- a/adserver/templates/adserver/reports/publisher.html
+++ b/adserver/templates/adserver/reports/publisher.html
@@ -26,9 +26,9 @@
 
 
 {% block toc %}
-    {# Note: the publisher dashboard only shows if there is no set campaign type (meaning all types) #}
-    {#       Otherwise the data will not match the tabular report below. #}
-    {% if metabase_publisher_dashboard and not campaign_type %}
+  {# Note: the publisher dashboard only shows if there is no set campaign type (meaning all types) #}
+  {#       Otherwise the data will not match the tabular report below. #}
+  {% if metabase_publisher_dashboard and not campaign_type %}
     <section class="mb-5">
       <div class="row mb-5">
         <div class="col min-vh-75">

--- a/adserver/templates/adserver/reports/publisher.html
+++ b/adserver/templates/adserver/reports/publisher.html
@@ -26,9 +26,7 @@
 
 
 {% block toc %}
-  {# Note: the publisher dashboard only shows if there is no set campaign type (meaning all types) #}
-  {#       Otherwise the data will not match the tabular report below. #}
-  {% if metabase_publisher_dashboard and not campaign_type %}
+  {% if metabase_publisher_dashboard %}
     <section class="mb-5">
       <div class="row mb-5">
         <div class="col min-vh-75">
@@ -48,7 +46,7 @@
     You can filter it to better understand what is going on with your traffic.
   </p>
   <em>
-  This report updates close to real-time.
+  This report updates every five minutes.
   </em>
 </section>
 {% endblock explainer %}

--- a/adserver/templates/adserver/reports/publisher.html
+++ b/adserver/templates/adserver/reports/publisher.html
@@ -26,7 +26,9 @@
 
 
 {% block toc %}
-  {% if metabase_publisher_dashboard %}
+    {# Note: the publisher dashboard only shows if there is no set campaign type (meaning all types) #}
+    {#       Otherwise the data will not match the tabular report below. #}
+    {% if metabase_publisher_dashboard and not campaign_type %}
     <section class="mb-5">
       <div class="row mb-5">
         <div class="col min-vh-75">
@@ -46,7 +48,7 @@
     You can filter it to better understand what is going on with your traffic.
   </p>
   <em>
-  This report updates every five minutes.
+    This report updates close to real-time.
   </em>
 </section>
 {% endblock explainer %}

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -549,6 +549,7 @@ class TestReportViews(TestReportsBase):
 
         # Update reporting
         daily_update_impressions()
+        daily_update_publishers()
 
         # Generate the report (used to check data)
         report = PublisherReport(AdImpression.objects.filter(publisher=self.publisher1))
@@ -568,18 +569,11 @@ class TestReportViews(TestReportsBase):
         response = self.client.get(url)
         self.assertContains(response, '<td class="text-right"><strong>5</strong></td>')
 
-        # Filter reports
-        response = self.client.get(url, {"campaign_type": "paid"})
-        self.assertContains(response, '<td class="text-right"><strong>2</strong></td>')
-        self.assertNotContains(
-            response, '<td class="text-right"><strong>3</strong></td>'
-        )
-
         # Verify the export URL is configured
         self.assertContains(response, "CSV Export")
 
         # Check staff fields not present since the permission wasn't configured
-        self.assertNotContains(response, "Fill Rate")
+        self.assertNotContains(response, "Our&nbsp;Rev")
 
         # Add the permission
         self.staff_user.user_permissions.add(
@@ -589,7 +583,7 @@ class TestReportViews(TestReportsBase):
             )
         )
         response = self.client.get(url)
-        self.assertContains(response, "Fill Rate")
+        self.assertContains(response, "Our&nbsp;Rev")
 
     def test_publisher_placement_report_contents(self):
         self.client.force_login(self.staff_user)

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -569,6 +569,13 @@ class TestReportViews(TestReportsBase):
         response = self.client.get(url)
         self.assertContains(response, '<td class="text-right"><strong>5</strong></td>')
 
+        # Filter reports
+        response = self.client.get(url, {"campaign_type": "paid"})
+        self.assertContains(response, '<td class="text-right"><strong>2</strong></td>')
+        self.assertNotContains(
+            response, '<td class="text-right"><strong>3</strong></td>'
+        )
+
         # Verify the export URL is configured
         self.assertContains(response, "CSV Export")
 

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -100,7 +100,6 @@ from .reports import AdvertiserPublisherReport
 from .reports import AdvertiserReport
 from .reports import OptimizedAdvertiserReport
 from .reports import OptimizedPublisherPaidReport
-from .reports import OptimizedPublisherReport
 from .reports import PublisherAdvertiserReport
 from .reports import PublisherGeoReport
 from .reports import PublisherKeywordReport
@@ -1660,8 +1659,8 @@ class PublisherReportView(PublisherAccessMixin, BaseReportView):
     export_view = "publisher_report_export"
     template_name = "adserver/reports/publisher.html"
     fieldnames = ["index", "views", "clicks", "ctr", "ecpm", "revenue", "revenue_share"]
-    report = OptimizedPublisherReport
-    impression_model = PublisherImpression
+    report = PublisherReport
+    impression_model = AdImpression
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -1671,6 +1670,7 @@ class PublisherReportView(PublisherAccessMixin, BaseReportView):
 
         queryset = self.get_queryset(
             publisher=publisher,
+            campaign_type=context["campaign_type"],
             start_date=context["start_date"],
             end_date=context["end_date"],
         )
@@ -1683,6 +1683,7 @@ class PublisherReportView(PublisherAccessMixin, BaseReportView):
             {
                 "publisher": publisher,
                 "report": report,
+                "campaign_types": CAMPAIGN_TYPES,
                 "export_url": self.get_export_url(publisher_slug=publisher.slug),
                 "metabase_publisher_dashboard": settings.METABASE_DASHBOARDS.get(
                     "PUBLISHER_FIGURES"

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -172,7 +172,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "halfhourly-publisher-index": {
         "task": "adserver.tasks.daily_update_publishers",
-        "schedule": crontab(minute="*/5"),
+        "schedule": crontab(minute="*/30"),
     },
     # Run publisher importers daily
     "every-day-sync-publisher-data": {

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -168,11 +168,11 @@ CELERY_BEAT_SCHEDULE = {
     # Very fast indexes that can be run more frequently
     "halfhourly-advertiser-index": {
         "task": "adserver.tasks.daily_update_advertisers",
-        "schedule": crontab(minute="*/30"),
+        "schedule": crontab(minute="*/5"),
     },
     "halfhourly-publisher-index": {
         "task": "adserver.tasks.daily_update_publishers",
-        "schedule": crontab(minute="*/30"),
+        "schedule": crontab(minute="*/5"),
     },
     # Run publisher importers daily
     "every-day-sync-publisher-data": {


### PR DESCRIPTION
- Use smaller tables with no unnecessary data for advertisers
- ~~Publisher table cannot get "fill rate" as that requires knowing if impressions are paid or not~~
- ~~Future work: if needed, add a way to filter publisher data by campaign type.~~