### PR TITLE
Filter get_niche_weights by flights

### DIFF
--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -407,15 +407,12 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
                     # We have to do this here,
                     # so we can filter by the weight in the filter_flight call below
                     # TODO: Handle filtering by multiple flights in the future
-                    if not self.niche_weights:
-                        from ethicalads_ext.embedding.utils import (  # noqa
-                            get_niche_weights,
-                        )
+                    from ethicalads_ext.embedding.utils import (  # noqa
+                        get_niche_weights,
+                    )
 
-                        self.niche_weights = get_niche_weights(
-                            self.url, flights=[flight]
-                        )
-                        log.info("Niche targeting weights: %s", self.niche_weights)
+                    self.niche_weights = get_niche_weights(self.url, flights=[flight])
+                    log.info("Niche targeting weights: %s", self.niche_weights)
 
                 # Handle excluding flights based on targeting
                 if not self.filter_flight(flight):

--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -402,21 +402,20 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
                 flight for flight in flights if flight.niche_targeting
             ]
 
-            if flights_with_niche_targeting:
-                # Apply niche targeting only when any flight has it.
-                # This is to track whether we should do expensive distance queries.
-                if (
-                    flights_with_niche_targeting
-                    and "ethicalads_ext.embedding" in settings.INSTALLED_APPS
-                ):
-                    # We have to do this here,
-                    # so we can filter by the weight in the filter_flight call below
-                    from ethicalads_ext.embedding.utils import get_niche_weights  # noqa
+            # Apply niche targeting only when any flight has it.
+            # This is to track whether we should do expensive distance queries.
+            if (
+                flights_with_niche_targeting
+                and "ethicalads_ext.embedding" in settings.INSTALLED_APPS
+            ):
+                # We have to do this here,
+                # so we can filter by the weight in the filter_flight call below
+                from ethicalads_ext.embedding.utils import get_niche_weights  # noqa
 
-                    self.niche_weights = get_niche_weights(
-                        self.url, flights=flights_with_niche_targeting
-                    )
-                    log.info("Niche targeting weights: %s", self.niche_weights)
+                self.niche_weights = get_niche_weights(
+                    self.url, flights=flights_with_niche_targeting
+                )
+                log.info("Niche targeting weights: %s", self.niche_weights)
 
             for flight in possible_flights:
                 # Handle excluding flights based on targeting

--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -404,13 +404,16 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
                     flight.niche_targeting
                     and "ethicalads_ext.embedding" in settings.INSTALLED_APPS
                 ):
+                    # We have to do this here,
+                    # so we can filter by the weight in the filter_flight call below
+                    # TODO: Handle filtering by multiple flights in the future
                     if not self.niche_weights:
                         from ethicalads_ext.embedding.utils import (  # noqa
                             get_niche_weights,
                         )
 
                         self.niche_weights = get_niche_weights(
-                            self.url,
+                            self.url, flights=[flight]
                         )
                         log.info("Niche targeting weights: %s", self.niche_weights)
 

--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -413,7 +413,7 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
                 from ethicalads_ext.embedding.utils import get_niche_weights  # noqa
 
                 self.niche_weights = get_niche_weights(
-                    self.url, flights=flights_with_niche_targeting
+                    url=self.url, flights=flights_with_niche_targeting
                 )
                 log.info("Niche targeting weights: %s", self.niche_weights)
 

--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -399,7 +399,7 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
             self.niche_weights = None
 
             flights_with_niche_targeting = [
-                flight for flight in flights if flight.niche_targeting
+                flight for flight in possible_flights if flight.niche_targeting
             ]
 
             # Apply niche targeting only when any flight has it.

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1001,7 +1001,7 @@ class Flight(TimeStampedModel, IndestructibleModel):
         Return the niche targeting parameter for this flight.
 
         0.0 means no niche targeting,
-        and then the lower the number the more niche the targeting.
+        and then the lower the number (between 0.01 and 0.99) the more niche the targeting.
         """
         if not self.targeting_parameters:
             return 0.0

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1224,14 +1224,18 @@ class Flight(TimeStampedModel, IndestructibleModel):
         return True
 
     def show_to_niche_targeting(self, weights):
-        """Filter flights based on distance of niche targeting."""
-        if self.niche_targeting:
-            if self.campaign.advertiser in weights:
-                goal_weight = self.niche_targeting
-                return weights[self.campaign.advertiser] < goal_weight
-            return False
+        """
+        Filter flights based on distance of niche targeting.
 
-        return True
+        Only filters if the flight has a niche targeting goal set.
+        """
+        if not self.niche_targeting:
+            return True
+
+        if self.campaign.advertiser in weights:
+            goal_weight = self.niche_targeting
+            return weights[self.campaign.advertiser] < goal_weight
+        return False
 
     def sold_days(self):
         # The flight is considered to end at the end of the day on the `end_date`

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1000,7 +1000,8 @@ class Flight(TimeStampedModel, IndestructibleModel):
         """
         Return the niche targeting parameter for this flight.
 
-        Testing out return types here as well..
+        0.0 means no niche targeting,
+        and then the lower the number the more niche the targeting.
         """
         if not self.targeting_parameters:
             return 0.0


### PR DESCRIPTION
This should reduce the set of things we have to filter over,
and hopefully save memory.

This won't scale cleanly to multiple flights with niche_targeting,
and will require a refactor,
but should safe a bunch of processing on the query for now on unrelated Advertisers.
