### PR TITLE
Fix Mailchimp email list signup

### DIFF
--- a/adserver/templates/adserver/email/publisher-payout.html
+++ b/adserver/templates/adserver/email/publisher-payout.html
@@ -65,7 +65,7 @@ but for now I think we can't avoid it because of linking to content on our marke
   If you want to keep up to date with the latest features and updates from EthicalAds,
   we recommend reading our <a href="https://www.ethicalads.io/blog/">blog</a> or <a href="https://twitter.com/ethicaladsio">Twitter</a>.
   If you prefer getting updates in your inbox,
-  you can subscribe to our <a href="https://ethicalads.us17.list-manage.com/subscribe/post?u=ca5e74de3ea2867d373058271&id=5746f18bb8">mailing list</a> as well.
+  you can subscribe to our <a href="https://mailchi.mp/ethicalads/mail-list-signup">mailing list</a> as well.
 </p>
 
 <p>


### PR DESCRIPTION
We got a report that the previous URL wasn't working. It did work at one time.