### PR TITLE
Automate stripe publisher payouts

### DIFF
--- a/adserver/templates/adserver/staff/publisher-payout-finish.html
+++ b/adserver/templates/adserver/staff/publisher-payout-finish.html
@@ -15,46 +15,65 @@
 {% block content_container %}
 <h1>{% block heading %}{% trans 'Finish Payout' %}{% endblock heading %}</h1>
 
-<dl>
-  <dt>{% trans 'Publisher' %}</dt>
-  <dd>{{ payout.publisher }}</dd>
+<div>
 
-  <dt>{% trans 'Method' %}</dt>
-  <dd>
-  {{ payout.publisher.get_payout_method_display }}:
-  </dd>
+<form method="post">
 
-  {% if payout.publisher.paypal_email %}
-  <dt>{% trans 'User' %}</dt>
-  <dd>
-  {{ payout.publisher.paypal_email }}
-  </dd>
-  {% endif %}
+  <dl>
+    <dt>{% trans 'Publisher' %}</dt>
+    <dd>{{ payout.publisher }}</dd>
 
-  <dt>{% trans 'Status' %}</dt>
-  <dd>{{ payout.get_status_display }}</dd>
+    <dt>{% trans 'Method' %}</dt>
+    <dd>
+    {{ payout.publisher.get_payout_method_display }}:
+    </dd>
 
-  <dt>{% trans 'Amount' %}</dt>
-  <dd>${{ payout.amount|floatformat:2|intcomma }}</dd>
+    {% if payout.publisher.paypal_email %}
+    <dt>{% trans 'User' %}</dt>
+    <dd>
+    {{ payout.publisher.paypal_email }}
+    </dd>
+    {% endif %}
 
-  <dt>{% trans 'Subject' %}</dt>
-  <dd>{% trans "EthicalAds Payout" %} - {{ payout.publisher.name }}</dd>
+    <dt>{% trans 'Status' %}</dt>
+    <dd>{{ payout.get_status_display }}</dd>
 
-  <dt>{% trans 'Action' %}</dt>
-  <dd>
-  {% if payout.status == 'emailed' and payout.publisher.payout_url %}
-  <a href="{{ payout.publisher.payout_url }}" class="button">{% trans "Send Money" %}</a>
-  {% endif %}
-  </dd>
+    <dt>{% trans 'Amount' %}</dt>
+    <dd>${{ payout.amount|floatformat:2|intcomma }}</dd>
 
-</dl>
+    <dt>{% trans 'Subject' %}</dt>
+    <dd>{% trans "EthicalAds Payout" %} - {{ payout.publisher.name }}</dd>
 
-<div id="content" class="colM delete-confirmation">
-  <form method="post">
-    {% csrf_token %}
-    <input type="submit" value="{% trans "Finish payout" %}" class="btn btn-primary">
-    <p class="small">{% trans "This will mark the payout as paid" %}</p>
-  </form>
+    <dt>{% trans 'Action' %}</dt>
+    <dd>
+      <div class="ml-2 mb-5">
+
+        {% if payout.status == 'emailed' and payout.publisher.payout_url %}
+          {% if payout.method == "stripe" %}
+            <div class="form-group form-check">
+              <input type="checkbox" class="form-check-input" id="stripe-payout-confirm" name="stripe-payout-confirm">
+              <label class="form-check-label" for="stripe-payout-confirm">
+                <span>{% blocktrans with amount=payout.amount|floatformat:2|intcomma %}Send ${{ amount }} via Stripe Connect{% endblocktrans %}</span>
+              </label>
+            </div>
+
+            <a href="{{ payout.publisher.payout_url }}" class="btn btn-sm btn-outline-secondary">{% trans "Or Send Manually" %}</a>
+          {% else %}
+            <a href="{{ payout.publisher.payout_url }}" class="btn btn-sm btn-outline-secondary">{% trans "Send Money" %}</a>
+          {% endif %}
+        {% endif %}
+
+      </div>
+    </dd>
+
+  </dl>
+
+  {% csrf_token %}
+  <input type="submit" value="{% trans "Finish payout" %}" class="btn btn-primary">
+  <p class="small">{% trans "This will mark the payout as paid" %}</p>
+
+</form>
+
 </div>
 
 {% endblock content_container %}

--- a/adserver/templates/adserver/staff/publisher-payout-list.html
+++ b/adserver/templates/adserver/staff/publisher-payout-list.html
@@ -67,7 +67,11 @@
       <tbody>
         {% for publisher, payout_data in payouts.items %}
           <tr>
-            <td><a href="{{ payout_data.due_report_url }}">{{ publisher.name }}</a></td>
+            <td>
+              {% if payout_data.due_report_url %}<a href="{{ payout_data.due_report_url }}">{% endif %}
+                <span>{{ publisher.name }}</span>
+              {% if payout_data.due_report_url %}</a>{% endif %}
+            </td>
             <td>{{ payout_data.start_date|date }}</td>
             <td>{{ payout_data.first }}</td>
             <td>${{ payout_data.total }}</td>

--- a/adserver/tests/test_staff_actions.py
+++ b/adserver/tests/test_staff_actions.py
@@ -269,7 +269,7 @@ class PublisherPayoutTests(TestCase):
         list_response = self.client.get(url)
         self.assertEqual(list_response.status_code, 200)
         self.assertContains(list_response, "<td>$70.00</td>")
-        self.assertContains(list_response, f"{self.publisher1.name}</a></td>")
+        self.assertContains(list_response, f"<span>{self.publisher1.name}</span>")
 
     def test_list_view_filters(self):
         url = reverse("staff-publisher-payouts")
@@ -279,34 +279,34 @@ class PublisherPayoutTests(TestCase):
         list_response = self.client.get(url + "?paid=True")
         self.assertEqual(list_response.status_code, 200)
         self.assertNotContains(list_response, "<td>$70.00</td>")
-        self.assertNotContains(list_response, f"{self.publisher1.name}</a></td>")
+        self.assertNotContains(list_response, f"<span>{self.publisher1.name}</span>")
 
         list_response = self.client.get(url + "?paid=False")
         self.assertEqual(list_response.status_code, 200)
         self.assertContains(list_response, "<td>$70.00</td>")
-        self.assertContains(list_response, f"{self.publisher1.name}</a></td>")
+        self.assertContains(list_response, f"<span>{self.publisher1.name}</span>")
 
         # Filter first
         list_response = self.client.get(url + "?first=True")
         self.assertEqual(list_response.status_code, 200)
         self.assertContains(list_response, "<td>$70.00</td>")
-        self.assertContains(list_response, f"{self.publisher1.name}</a></td>")
+        self.assertContains(list_response, f"<span>{self.publisher1.name}</span>")
 
         list_response = self.client.get(url + "?first=False")
         self.assertEqual(list_response.status_code, 200)
         self.assertNotContains(list_response, "<td>$70.00</td>")
-        self.assertNotContains(list_response, f"{self.publisher1.name}</a></td>")
+        self.assertNotContains(list_response, f"<span>{self.publisher1.name}</span>")
 
         # Filter publisher
         list_response = self.client.get(url + "?publisher=foo")
         self.assertEqual(list_response.status_code, 200)
         self.assertNotContains(list_response, "<td>$70.00</td>")
-        self.assertNotContains(list_response, f"{self.publisher1.name}</a></td>")
+        self.assertNotContains(list_response, f"<span>{self.publisher1.name}</span>")
 
         list_response = self.client.get(url + "?publisher=test")
         self.assertEqual(list_response.status_code, 200)
         self.assertContains(list_response, "<td>$70.00</td>")
-        self.assertContains(list_response, f"{self.publisher1.name}</a></td>")
+        self.assertContains(list_response, f"<span>{self.publisher1.name}</span>")
 
     @override_settings(
         # Use the memory email backend instead of front for testing


### PR DESCRIPTION
- Makes this just a checkbox per publisher
- Writes the transfer ID into the payout note
- Still allows handling manually if something goes wrong