### PR TITLE
Fix custom.css

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,7 +135,7 @@ html_static_path = ["_static"]
 # html_sidebars = {}
 
 html_css_files = [
-    "_static/css/custom.css",
+    "css/custom.css",
 ]
 
 html_js_files = []


### PR DESCRIPTION
This was causing a double _static:

```
      <link rel="stylesheet" type="text/css" href="_static/_static/css/custom.css" />

```