### PR TITLE
Fix a celerybeat task configuration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -40,9 +40,9 @@ try:
 
     import ethicalads_ext  # noqa
 
-    ext = True
+    ADSERVER_EXT = True
 except ImportError:
-    ext = False
+    ADSERVER_EXT = False
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -533,9 +533,9 @@ ADSERVER_ANALYZER_BACKEND = env.list(
 )
 if ADSERVER_ANALYZER_BACKEND:
     INSTALLED_APPS.append("adserver.analyzer")
-if ADSERVER_ANALYZER_BACKEND and ext:
+if ADSERVER_ANALYZER_BACKEND and ADSERVER_EXT:
     INSTALLED_APPS.append("ethicalads_ext.embedding")
-if ext:
+if ADSERVER_EXT:
     INSTALLED_APPS.append("ethicalads_ext.support")
 
 # Whether Do Not Track is enabled for the ad server

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -195,8 +195,9 @@ if "adserver.analyzer" in INSTALLED_APPS:
         "task": "adserver.analyzer.tasks.daily_analyze_urls",
         "schedule": crontab(hour="4", minute="0"),
     }
+if "ethicalads_ext.embedding" in INSTALLED_APPS:
     CELERY_BEAT_SCHEDULE["every-day-analyze-advertiser-urls"] = {
-        "task": "adserver.analyzer.tasks.daily_analyze_advertiser_urls",
+        "task": "ethicalads_ext.embedding.tasks.daily_analyze_advertiser_urls",
         "schedule": crontab(hour="4", minute="30"),
     }
 


### PR DESCRIPTION
Frankly, I'm surprised the celerybeat configuration works in dev. I also renamed the variable `ext` -> `ADSERVER_EXT` in case we need to use it in derived settings files although I didn't do that here.


Fixes https://github.com/readthedocs/ethical-ad-server/issues/937