### PR TITLE
Add roles for advertisers and publishers

### DIFF
--- a/adserver/auth/admin.py
+++ b/adserver/auth/admin.py
@@ -6,6 +6,22 @@ from django.utils.translation import gettext_lazy as _
 from simple_history.admin import SimpleHistoryAdmin
 
 from .models import User
+from .models import UserAdvertiserMember
+from .models import UserPublisherMember
+
+
+class UserAdvertiserInline(admin.TabularInline):
+    """For inlining the user-advertiser relationship."""
+
+    model = UserAdvertiserMember
+    raw_id_fields = ("advertiser",)
+
+
+class UserPublisherInline(admin.TabularInline):
+    """For inlining the user-publisher relationship."""
+
+    model = UserPublisherMember
+    raw_id_fields = ("publisher",)
 
 
 @admin.register(User)
@@ -19,8 +35,6 @@ class UserAdmin(SimpleHistoryAdmin):
             _("Ad server details"),
             {
                 "fields": (
-                    "advertisers",
-                    "publishers",
                     "flight_notifications",
                     "notify_on_completed_flights",  # DEPRECATED
                 )
@@ -43,6 +57,7 @@ class UserAdmin(SimpleHistoryAdmin):
             {"fields": ("last_login", "updated_date", "created_date")},
         ),
     )
+    inlines = (UserAdvertiserInline, UserPublisherInline)
     list_display = (
         "email",
         "name",

--- a/adserver/auth/migrations/0009_user_advertiser_publisher_roles.py
+++ b/adserver/auth/migrations/0009_user_advertiser_publisher_roles.py
@@ -1,0 +1,70 @@
+"""
+This migration was autocreated but has been customized.
+
+See: https://docs.djangoproject.com/en/5.0/howto/writing-migrations/#changing-a-manytomanyfield-to-use-a-through-model
+"""
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('adserver', '0098_rotation_aggregation'),
+        ('adserver_auth', '0008_data_flight_notifications'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name='UserAdvertiserMember',
+                    fields=[
+                        ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                        # We add this in a separate operation below
+                        # ('role', models.CharField(choices=[('Admin', 'Admin'), ('Manager', 'Manager'), ('Reporter', 'Reporter')], default='Admin', max_length=100)),
+                        ('advertiser', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='adserver.advertiser')),
+                        ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                    ],
+                    options={
+                        'db_table': 'adserver_auth_user_advertisers',
+                    },
+                ),
+                migrations.AlterField(
+                    model_name='user',
+                    name='advertisers',
+                    field=models.ManyToManyField(blank=True, through='adserver_auth.UserAdvertiserMember', to='adserver.advertiser'),
+                ),
+                migrations.CreateModel(
+                    name='UserPublisherMember',
+                    fields=[
+                        ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                        # We add this in a separate operation below
+                        # ('role', models.CharField(choices=[('Admin', 'Admin'), ('Manager', 'Manager'), ('Reporter', 'Reporter')], default='Admin', max_length=100)),
+                        ('publisher', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='adserver.publisher')),
+                        ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                    ],
+                    options={
+                        'db_table': 'adserver_auth_user_publishers',
+                    },
+                ),
+                migrations.AlterField(
+                    model_name='user',
+                    name='publishers',
+                    field=models.ManyToManyField(blank=True, through='adserver_auth.UserPublisherMember', to='adserver.publisher'),
+                ),
+            ],
+        ),
+        migrations.AddField(
+            model_name="useradvertisermember",
+            name="role",
+            field=models.CharField(choices=[('Admin', 'Admin'), ('Manager', 'Manager'), ('Reporter', 'Reporter')], default='Admin', max_length=100),
+        ),
+        migrations.AddField(
+            model_name="userpublishermember",
+            name="role",
+            field=models.CharField(choices=[('Admin', 'Admin'), ('Manager', 'Manager'), ('Reporter', 'Reporter')], default='Admin', max_length=100),
+        ),
+    ]

--- a/adserver/auth/models.py
+++ b/adserver/auth/models.py
@@ -79,8 +79,12 @@ class User(AbstractBaseUser, PermissionsMixin):
     created_date = models.DateTimeField(_("create date"), auto_now_add=True)
 
     # A user may have access to zero or more advertisers or publishers
-    advertisers = models.ManyToManyField(Advertiser, blank=True)
-    publishers = models.ManyToManyField(Publisher, blank=True)
+    advertisers = models.ManyToManyField(
+        Advertiser, blank=True, through="UserAdvertiserMember"
+    )
+    publishers = models.ManyToManyField(
+        Publisher, blank=True, through="UserPublisherMember"
+    )
 
     # Notifications
     flight_notifications = models.BooleanField(
@@ -146,3 +150,51 @@ class User(AbstractBaseUser, PermissionsMixin):
             [self.email],
         )
         return True
+
+
+class UserAdvertiserMember(models.Model):
+    """User-Advertiser 'through' model."""
+
+    ROLE_ADMIN = "Admin"
+    ROLE_MANAGER = "Manager"
+    ROLE_REPORTER = "Reporter"
+    ROLES = (ROLE_ADMIN, ROLE_MANAGER, ROLE_REPORTER)
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    advertiser = models.ForeignKey(Advertiser, on_delete=models.CASCADE)
+    role = models.CharField(
+        max_length=100,
+        choices=(
+            (ROLE_ADMIN, _(ROLE_ADMIN)),
+            (ROLE_MANAGER, _(ROLE_MANAGER)),
+            (ROLE_REPORTER, _(ROLE_REPORTER)),
+        ),
+        default=ROLE_ADMIN,
+    )
+
+    class Meta:
+        db_table = "adserver_auth_user_advertisers"
+
+
+class UserPublisherMember(models.Model):
+    """User-Publisher 'through' model."""
+
+    ROLE_ADMIN = "Admin"
+    ROLE_MANAGER = "Manager"
+    ROLE_REPORTER = "Reporter"
+    ROLES = (ROLE_ADMIN, ROLE_MANAGER, ROLE_REPORTER)
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    publisher = models.ForeignKey(Publisher, on_delete=models.CASCADE)
+    role = models.CharField(
+        max_length=100,
+        choices=(
+            (ROLE_ADMIN, _(ROLE_ADMIN)),
+            (ROLE_MANAGER, _(ROLE_MANAGER)),
+            (ROLE_REPORTER, _(ROLE_REPORTER)),
+        ),
+        default=ROLE_ADMIN,
+    )
+
+    class Meta:
+        db_table = "adserver_auth_user_publishers"

--- a/adserver/forms.py
+++ b/adserver/forms.py
@@ -29,6 +29,7 @@ from django.utils.text import slugify
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
+from .auth.models import UserAdvertiserMember
 from .models import Advertisement
 from .models import Campaign
 from .models import Flight
@@ -1322,6 +1323,14 @@ class InviteUserForm(forms.ModelForm):
     without a duplicate being created.
     """
 
+    role = forms.ChoiceField(
+        required=True,
+        # This form works for both publishers and advertisers
+        # Currently, the roles are the same for both
+        # If that ever changes, this will need an update
+        choices=((r, r) for r in UserAdvertiserMember.ROLES),
+    )
+
     def __init__(self, *args, **kwargs):
         """Add the form helper and customize the look of the form."""
         super().__init__(*args, **kwargs)
@@ -1331,6 +1340,7 @@ class InviteUserForm(forms.ModelForm):
                 "",
                 Field("name"),
                 Field("email", placeholder="user@yourdomain.com"),
+                Field("role"),
                 css_class="my-3",
             ),
             Submit("submit", "Send invite"),

--- a/adserver/mixins.py
+++ b/adserver/mixins.py
@@ -9,10 +9,11 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.paginator import Paginator
 from django.db import connection
 from django.db import models
-from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
+from .auth.models import UserAdvertiserMember
+from .auth.models import UserPublisherMember
 from .constants import ALL_CAMPAIGN_TYPES
 from .constants import CAMPAIGN_TYPES
 from .models import Advertiser
@@ -34,38 +35,78 @@ class AdvertiserAccessMixin:
     """Mixin for checking advertiser access that works with the ``UserPassesTestMixin``."""
 
     advertiser_slug_parameter = "advertiser_slug"
+    allowed_roles = (
+        UserAdvertiserMember.ROLE_ADMIN,
+        UserAdvertiserMember.ROLE_MANAGER,
+        UserAdvertiserMember.ROLE_REPORTER,
+    )
 
     def test_func(self):
         """The user must have access on the advertiser or be staff."""
         if self.request.user.is_anonymous:
             return False
 
-        advertiser = get_object_or_404(
-            Advertiser, slug=self.kwargs[self.advertiser_slug_parameter]
-        )
         return (
             self.request.user.is_staff
-            or advertiser in self.request.user.advertisers.all()
+            or self.request.user.useradvertisermember_set.filter(
+                advertiser__slug=self.kwargs[self.advertiser_slug_parameter],
+                role__in=self.allowed_roles,
+            ).exists()
         )
+
+
+class AdvertiserAdminAccessMixin(AdvertiserAccessMixin):
+    """Mixin for checking advertiser ADMIN role that works with the ``UserPassesTestMixin``."""
+
+    allowed_roles = (UserAdvertiserMember.ROLE_ADMIN,)
+
+
+class AdvertiserManagerAccessMixin(AdvertiserAccessMixin):
+    """Mixin for checking advertiser Manager or Admin role that works with the ``UserPassesTestMixin``."""
+
+    allowed_roles = (
+        UserAdvertiserMember.ROLE_ADMIN,
+        UserAdvertiserMember.ROLE_MANAGER,
+    )
 
 
 class PublisherAccessMixin:
     """Mixin for checking publisher access that works with the ``UserPassesTestMixin``."""
 
     publisher_slug_parameter = "publisher_slug"
+    allowed_roles = (
+        UserPublisherMember.ROLE_ADMIN,
+        UserPublisherMember.ROLE_MANAGER,
+        UserPublisherMember.ROLE_REPORTER,
+    )
 
     def test_func(self):
         """The user must have access on the publisher or be staff."""
         if self.request.user.is_anonymous:
             return False
 
-        publisher = get_object_or_404(
-            Publisher, slug=self.kwargs[self.publisher_slug_parameter]
-        )
         return (
             self.request.user.is_staff
-            or publisher in self.request.user.publishers.all()
+            or self.request.user.userpublishermember_set.filter(
+                publisher__slug=self.kwargs[self.publisher_slug_parameter],
+                role__in=self.allowed_roles,
+            ).exists()
         )
+
+
+class PublisherAdminAccessMixin(PublisherAccessMixin):
+    """Mixin for checking publisher ADMIN role that works with the ``UserPassesTestMixin``."""
+
+    allowed_roles = (UserPublisherMember.ROLE_ADMIN,)
+
+
+class PublisherManagerAccessMixin(PublisherAccessMixin):
+    """Mixin for checking publisher Manager or Admin role that works with the ``UserPassesTestMixin``."""
+
+    allowed_roles = (
+        UserPublisherMember.ROLE_ADMIN,
+        UserPublisherMember.ROLE_MANAGER,
+    )
 
 
 class AdvertisementValidateLinkMixin:

--- a/adserver/templates/adserver/advertiser/advertisement-detail.html
+++ b/adserver/templates/adserver/advertiser/advertisement-detail.html
@@ -2,6 +2,10 @@
 {% load i18n %}
 {% load static %}
 {% load humanize %}
+{% load ad_extras %}
+
+
+{% advertiser_role request.user advertiser as user_advertiser_role %}
 
 
 {% block title %}{% trans 'Advertisement: ' %}{{ advertisement.name }}{% endblock %}
@@ -61,9 +65,11 @@
 </div>
 
 <div class="row mt-5">
+  {% if request.user.is_staff or user_advertiser_role  == "Admin" or user_advertiser_role  == "Manager" %}
   <div class="col">
     <a href="{% url 'advertisement_update' advertiser.slug advertisement.flight.slug advertisement.slug %}" class="btn btn-outline-primary" role="button" aria-pressed="true">{% trans 'Edit advertisement' %}</a>
   </div>
+  {% endif %}
 </div>
 
 {% endblock content_container %}

--- a/adserver/templates/adserver/advertiser/flight-detail.html
+++ b/adserver/templates/adserver/advertiser/flight-detail.html
@@ -2,6 +2,10 @@
 {% load i18n %}
 {% load static %}
 {% load humanize %}
+{% load ad_extras %}
+
+
+{% advertiser_role request.user advertiser as user_advertiser_role %}
 
 
 {% block title %}{{ flight.name }}{% endblock %}
@@ -30,10 +34,12 @@
       <span class="fa fa-bar-chart mr-1" aria-hidden="true"></span>
       <span>{% trans 'See full report' %}</span>
     </a>
+    {% if request.user.is_staff or user_advertiser_role  == "Admin" or user_advertiser_role  == "Manager" %}
     <a title="{% if flight.auto_renew %}{% trans 'Your flight will renew when complete.' %}{% else %}{% trans 'Flights that automatically renew receive an additional 10% discount' %}{% endif %}" data-toggle="tooltip" data-placement="left" href="{% url 'flight_auto_renew' advertiser.slug flight.slug %}" class="btn btn-sm  btn-outline-info" role="button" aria-pressed="true">
       <span class="fa fa-refresh mr-1" aria-hidden="true"></span>
       <span>{% if flight.auto_renew %}{% trans 'Renewing' %}{% else %}{% trans 'Automatically renew' %}{% endif %}</span>
     </a>
+    {% endif %}
     {% if "adserver.change_flight" in perms %}
     <a href="{% url 'flight_update' advertiser.slug flight.slug %}" class="btn btn-sm btn-outline-info" role="button" aria-pressed="true">
       <span class="fa fa-lock mr-1" aria-hidden="true"></span>
@@ -54,6 +60,7 @@
     <h5 class="col-md-8">{% trans 'Live ads' %}</h5>
 
     <aside class="col-md-4 text-right">
+      {% if request.user.is_staff or user_advertiser_role  == "Admin" or user_advertiser_role  == "Manager" %}
       <a href="{% url 'advertisement_create' advertiser.slug flight.slug %}" class="btn btn-sm btn-outline-primary mb-3" role="button" aria-pressed="true">
         <span class="fa fa-plus mr-1" aria-hidden="true"></span>
         <span>{% trans 'Create advertisement' %}</span>
@@ -63,6 +70,7 @@
         <span>{% trans 'Copy existing ads' %}</span>
       </a>
     </aside>
+    {% endif %}
   </div>
 
   {% if live_ads %}
@@ -73,7 +81,13 @@
     </div>
   {% else %}
     {% url 'advertisement_create' advertiser.slug flight.slug as create_ad_url %}
-    <p class="text-center">{% blocktrans %}There are no live ads in this flight yet but you can <a href="{{ create_ad_url }}">create one</a>.{% endblocktrans %}</p>
+    <p class="text-center">
+      {% if user_advertiser_role  == "Reporter" %}
+      <span>{% blocktrans %}There are no live ads in this flight yet.{% endblocktrans %}</span>
+      {% else %}
+      <span>{% blocktrans %}There are no live ads in this flight yet but you can <a href="{{ create_ad_url }}">create one</a>.{% endblocktrans %}</span>
+      {% endif %}
+    </p>
   {% endif %}
 
 

--- a/adserver/templates/adserver/advertiser/flight-list.html
+++ b/adserver/templates/adserver/advertiser/flight-list.html
@@ -2,6 +2,10 @@
 {% load i18n %}
 {% load static %}
 {% load humanize %}
+{% load ad_extras %}
+
+
+{% advertiser_role request.user advertiser as user_advertiser_role %}
 
 
 {% block title %}{% trans 'Manage Advertising' %}{% endblock %}
@@ -25,10 +29,12 @@
       <span>{% trans 'Create flight' %}</span>
     </a>
   {% endif %}
+  {% if request.user.is_staff or user_advertiser_role  == "Admin" or user_advertiser_role  == "Manager" %}
   <a href="{% url 'flight_request' advertiser.slug %}" class="btn btn-sm btn-outline-info mb-3" role="button" aria-pressed="true">
     <span class="fa fa-plus mr-1" aria-hidden="true"></span>
     <span>{% trans 'Request a new flight' %}</span>
   </a>
+  {% endif %}
 </aside>
 
 

--- a/adserver/templates/adserver/advertiser/users.html
+++ b/adserver/templates/adserver/advertiser/users.html
@@ -1,6 +1,10 @@
 {% extends "adserver/advertiser/overview.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+{% load ad_extras %}
+
+
+{% advertiser_role request.user advertiser as user_advertiser_role %}
 
 
 {% block title %}{% trans 'Authorized Users' %} - {{ advertiser }}{% endblock %}
@@ -15,33 +19,47 @@
 {% block content_container %}
   <section>
     <h1>{% blocktrans %}Authorized users for {{ advertiser }}{% endblocktrans %}</h1>
-    <p class="mb-5">{% trans 'These are users who have access to manage ads and view reports.' %}</p>
+    <p class="mb-3">{% trans 'These are users who have access to manage ads and view reports. The role levels are:' %}</p>
+    <dl class="mb-5">
+      <dt>{% trans 'Admin' %}</dt>
+      <dd>{% trans 'Can invite new users to collaborate as well as all permissions below.' %}</dd>
+      <dt>{% trans 'Manager' %}</dt>
+      <dd>{% trans 'Can manage advertisements and request new flights as well as all permissions below.' %}</dd>
+      <dt>{% trans 'Reporter' %}</dt>
+      <dd>{% trans 'Can only view reports but not change any ads or flights.' %}</dd>
+    </dl>
 
     <aside class="mb-3 text-right">
+      {% if request.user.is_staff or user_advertiser_role  == "Admin" %}
       <a href="{% url 'advertiser_users_invite' advertiser.slug %}" class="btn btn-sm btn-outline-primary" role="button" aria-pressed="true">
         <span class="fa fa-plus mr-1" aria-hidden="true"></span>
         <span>{% trans 'Invite user' %}</span>
       </a>
+      {% endif %}
     </aside>
 
-    {% if users %}
+    {% if members %}
       <div class="table-responsive">
         <table class="table table-hover">
           <thead>
             <tr>
               <th><strong>{% trans 'Name' %}</strong></th>
               <th><strong>{% trans 'Email' %}</strong></th>
+              <th><strong>{% trans 'Role' %}</strong></th>
               <th><strong>{% trans 'Options' %}</strong></th>
             </tr>
           </thead>
           <tbody>
-            {% for user in users %}
+            {% for member in members %}
               <tr>
-                <td>{{ user.name }}</td>
-                <td>{{ user.email }}</td>
+                <td>{{ member.user.name }}</td>
+                <td>{{ member.user.email }}</td>
+                <td>{{ member.role }}</td>
                 <td>
-                  {% if request.user.id != user.id %}
-                    <a href="{% url 'advertiser_users_remove' advertiser.slug user.id %}" title="{% trans 'You will have a chance to confirm' %}">{% trans 'remove' %}</a>
+                  {% if request.user.is_staff or user_advertiser_role  == "Admin" %}
+                  {% if request.user.id != member.user.id %}
+                    <a href="{% url 'advertiser_users_remove' advertiser.slug member.user.id %}" title="{% trans 'You will have a chance to confirm' %}">{% trans 'remove' %}</a>
+                  {% endif %}
                   {% endif %}
                 </td>
               </tr>

--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% load ad_extras %}
 
 
 {% block body_classes %}adserver-dashboard{% endblock body_classes %}
@@ -143,6 +144,7 @@
 
             </ul>
           {% elif publisher %}
+            {% publisher_role request.user publisher as user_publisher_role %}
             <h6 class="text-muted">{{ publisher }}</h6>
 
             <ul class="nav flex-column mb-5">
@@ -216,12 +218,14 @@
                 </a>
               </li>
 
+              {% if request.user.is_staff or user_publisher_role  == "Admin" %}
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'publisher_settings' publisher.slug %}">
                   <span class="fa fa-cog fa-fw mr-2 text-muted" aria-hidden="true"></span>
                   <span>{% trans 'Settings' %}</span>
                 </a>
               </li>
+              {% endif %}
 
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'publisher_users' publisher.slug %}">

--- a/adserver/templates/adserver/dashboard.html
+++ b/adserver/templates/adserver/dashboard.html
@@ -1,6 +1,7 @@
 {% extends 'adserver/base.html' %}
 {% load i18n %}
 
+
 {% block title %}{% trans 'Dashboard' %}{% endblock title %}
 
 

--- a/adserver/templates/adserver/publisher/fallback-ads-detail.html
+++ b/adserver/templates/adserver/publisher/fallback-ads-detail.html
@@ -2,6 +2,10 @@
 {% load i18n %}
 {% load static %}
 {% load humanize %}
+{% load ad_extras %}
+
+
+{% publisher_role request.user publisher as user_publisher_role %}
 
 
 {% block title %}{% trans 'Fallback ad: ' %}{{ advertisement.name }}{% endblock %}
@@ -58,9 +62,11 @@
 </div>
 
 <div class="row mt-5">
+  {% if request.user.is_staff or user_publisher_role  == "Admin" or user_publisher_role == "Manager" %}
   <div class="col">
     <a href="{% url 'publisher_fallback_ads_update' publisher.slug advertisement.slug %}" class="btn btn-outline-primary" role="button" aria-pressed="true">{% trans 'Edit fallback ad' %}</a>
   </div>
+  {% endif %}
 </div>
 
 {% endblock content_container %}

--- a/adserver/templates/adserver/publisher/fallback-ads-list.html
+++ b/adserver/templates/adserver/publisher/fallback-ads-list.html
@@ -1,6 +1,10 @@
 {% extends "adserver/publisher/overview.html" %}
 {% load humanize %}
 {% load i18n %}
+{% load ad_extras %}
+
+
+{% publisher_role request.user publisher as user_publisher_role %}
 
 
 {% block title %}{% trans 'Fallback ads' %} - {{ publisher }}{% endblock %}
@@ -25,10 +29,12 @@
     <h5 class="col-md-8">{% trans 'Advertisements' %}</h5>
 
     <aside class="col-md-4 text-right">
+      {% if request.user.is_staff or user_publisher_role  == "Admin" or user_publisher_role == "Manager" %}
       <a href="{{ create_ad_url }}" class="btn btn-sm btn-outline-primary mb-3" role="button" aria-pressed="true">
         <span class="fa fa-plus mr-1" aria-hidden="true"></span>
         <span>{% trans 'Create fallback ad' %}</span>
       </a>
+      {% endif %}
     </aside>
   </div>
 
@@ -67,7 +73,13 @@
       </table>
     </div>
   {% else %}
-    <p class="text-center">{% blocktrans %}There are no fallback ads yet but you can <a href="{{ create_ad_url }}">create one</a>.{% endblocktrans %}</p>
+    <p class="text-center">
+      {% if user_publisher_role  == "Reporter" %}
+      <span>{% blocktrans %}There are no fallback ads yet.{% endblocktrans %}</span>
+      {% else %}
+      <span>{% blocktrans %}There are no fallback ads yet but you can <a href="{{ create_ad_url }}">create one</a>.{% endblocktrans %}</span>
+      {% endif %}
+    </p>
   {% endif %}
 </section>
 

--- a/adserver/templates/adserver/publisher/users.html
+++ b/adserver/templates/adserver/publisher/users.html
@@ -1,6 +1,10 @@
 {% extends "adserver/publisher/overview.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+{% load ad_extras %}
+
+
+{% publisher_role request.user publisher as user_publisher_role %}
 
 
 {% block title %}{% trans 'Authorized Users' %} - {{ publisher }}{% endblock %}
@@ -15,33 +19,47 @@
 {% block content_container %}
   <section>
     <h1>{% blocktrans %}Authorized users for {{ publisher }}{% endblocktrans %}</h1>
-    <p class="mb-5">{% trans 'These are users who have access to manage ads and view reports.' %}</p>
+    <p class="mb-3">{% trans 'These are users who have access to manage ads and view reports. The role levels are:' %}</p>
+    <dl class="mb-5">
+      <dt>{% trans 'Admin' %}</dt>
+      <dd>{% trans 'Can invite new users to collaborate, update settings, as well as all permissions below.' %}</dd>
+      <dt>{% trans 'Manager' %}</dt>
+      <dd>{% trans 'Can manage fallback ads as well as all permissions below.' %}</dd>
+      <dt>{% trans 'Reporter' %}</dt>
+      <dd>{% trans 'Can only view reports but not change anything.' %}</dd>
+    </dl>
 
     <aside class="mb-3 text-right">
+      {% if request.user.is_staff or user_publisher_role  == "Admin" %}
       <a href="{% url 'publisher_users_invite' publisher.slug %}" class="btn btn-sm btn-outline-primary" role="button" aria-pressed="true">
         <span class="fa fa-plus mr-1" aria-hidden="true"></span>
         <span>{% trans 'Invite user' %}</span>
       </a>
+      {% endif %}
     </aside>
 
-    {% if users %}
+    {% if members %}
       <div class="table-responsive">
         <table class="table table-hover">
           <thead>
             <tr>
               <th><strong>{% trans 'Name' %}</strong></th>
               <th><strong>{% trans 'Email' %}</strong></th>
+              <th><strong>{% trans 'Role' %}</strong></th>
               <th><strong>{% trans 'Options' %}</strong></th>
             </tr>
           </thead>
           <tbody>
-            {% for user in users %}
+            {% for member in members %}
               <tr>
-                <td>{{ user.name }}</td>
-                <td>{{ user.email }}</td>
+                <td>{{ member.user.name }}</td>
+                <td>{{ member.user.email }}</td>
+                <td>{{ member.role }}</td>
                 <td>
-                  {% if request.user.id != user.id %}
-                    <a href="{% url 'publisher_users_remove' publisher.slug user.id %}" title="{% trans 'You will have a chance to confirm' %}">{% trans 'remove' %}</a>
+                  {% if request.user.is_staff or user_publisher_role  == "Admin" %}
+                  {% if request.user.id != member.user.id %}
+                    <a href="{% url 'publisher_users_remove' publisher.slug member.user.id %}" title="{% trans 'You will have a chance to confirm' %}">{% trans 'remove' %}</a>
+                  {% endif %}
                   {% endif %}
                 </td>
               </tr>

--- a/adserver/templatetags/ad_extras.py
+++ b/adserver/templatetags/ad_extras.py
@@ -14,3 +14,55 @@ def advertisement_preview(ad, ad_type=None):
         ad_type = ad.ad_types.first()
 
     return mark_safe(ad.render_ad(ad_type, preview=True))
+
+
+@register.simple_tag
+def advertiser_role(user, advertiser):
+    """
+    Returns the users role in this advertiser or None if the user has no permissions.
+
+    Staff status is not taken into account. Caches the result on the user so future calls
+    don't involve a DB lookup.
+    """
+    if not hasattr(user, "_advertiser_roles"):
+        user._advertiser_roles = {}
+
+    if advertiser.pk in user._advertiser_roles:
+        return user._advertiser_roles[advertiser.pk]
+
+    membership = user.useradvertisermember_set.filter(
+        advertiser=advertiser,
+    ).first()
+
+    role = None
+    if membership:
+        role = membership.role
+
+    user._advertiser_roles[advertiser.pk] = role
+    return role
+
+
+@register.simple_tag
+def publisher_role(user, publisher):
+    """
+    Returns the users role in this publisher or None if the user has no permissions.
+
+    Staff status is not taken into account. Caches the result on the user so future calls
+    don't involve a DB lookup.
+    """
+    if not hasattr(user, "_publisher_roles"):
+        user._publisher_roles = {}
+
+    if publisher.pk in user._publisher_roles:
+        return user._publisher_roles[publisher.pk]
+
+    membership = user.userpublishermember_set.filter(
+        publisher=publisher,
+    ).first()
+
+    role = None
+    if membership:
+        role = membership.role
+
+    user._publisher_roles[publisher.pk] = role
+    return role

--- a/adserver/tests/test_publisher_dashboard.py
+++ b/adserver/tests/test_publisher_dashboard.py
@@ -19,6 +19,7 @@ from ..models import Flight
 from ..models import Publisher
 from ..models import PublisherPayout
 from ..tasks import daily_update_publishers
+from ..auth.models import UserPublisherMember
 
 
 class TestPublisherDashboardViews(TestCase):
@@ -152,7 +153,18 @@ class TestPublisherDashboardViews(TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertTrue(resp["location"].startswith("/accounts/login/"))
 
-        self.client.force_login(self.staff_user)
+        member = UserPublisherMember.objects.create(
+            user=self.user,
+            publisher=self.publisher1,
+            role="Manager",
+        )
+        self.client.force_login(self.user)
+
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 403)
+
+        member.role = "Admin"
+        member.save()
 
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
@@ -391,15 +403,20 @@ class TestPublisherDashboardViews(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response["location"].startswith("/accounts/login/"))
 
-        self.user.publishers.add(self.publisher1)
+        member = UserPublisherMember.objects.create(
+            user=self.user,
+            publisher=self.publisher1,
+            role="Manager",
+        )
         self.client.force_login(self.user)
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.user.name)
         self.assertContains(response, self.user.email)
+        self.assertNotContains(response, "Invite user")
 
-        self.user.publishers.remove(self.publisher1)
+        member.delete()
 
         self.client.force_login(self.staff_user)
         response = self.client.get(url)
@@ -453,8 +470,19 @@ class TestPublisherDashboardViews(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response["location"].startswith("/accounts/login/"))
 
-        self.user.publishers.add(self.publisher1)
+        member = UserPublisherMember.objects.create(
+            user=self.user,
+            publisher=self.publisher1,
+            role="Manager",
+        )
+
         self.client.force_login(self.user)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        member.role = "Admin"
+        member.save()
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -462,7 +490,7 @@ class TestPublisherDashboardViews(TestCase):
 
         response = self.client.post(
             url,
-            data={"name": "Another User", "email": "another@example.com"},
+            data={"name": "Another User", "email": "another@example.com", "role": "Reporter"},
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
@@ -486,7 +514,7 @@ class TestPublisherDashboardViews(TestCase):
 
         response = self.client.post(
             url,
-            data={"name": name, "email": email},
+            data={"name": name, "email": email, "role": "Reporter"},
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
@@ -496,7 +524,7 @@ class TestPublisherDashboardViews(TestCase):
         # Invite the same user again to check that the user isn't created again
         response = self.client.post(
             url,
-            data={"name": "Yet Another User", "email": email},
+            data={"name": "Yet Another User", "email": email, "role": "Reporter"},
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
@@ -572,11 +600,23 @@ class TestPublisherFallbackAdsViews(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 403)
 
-        self.user.publishers.add(self.publisher)
+        member = UserPublisherMember.objects.create(
+            user=self.user,
+            publisher=self.publisher,
+            role="Manager",
+        )
 
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Test Ad 1")
+        self.assertContains(resp, "Create fallback ad")
+
+        member.role = "Reporter"
+        member.save()
+
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Create fallback ad")
 
     def test_fallback_ads_detail(self):
         url = reverse(
@@ -594,11 +634,23 @@ class TestPublisherFallbackAdsViews(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 403)
 
-        self.user.publishers.add(self.publisher)
+        member = UserPublisherMember.objects.create(
+            user=self.user,
+            publisher=self.publisher,
+            role="Manager",
+        )
 
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Test Ad 1")
+        self.assertContains(resp, "Edit fallback ad")
+
+        member.role = "Reporter"
+        member.save()
+
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Edit fallback ad")
 
     def test_fallback_ads_update(self):
         url = reverse(
@@ -616,7 +668,18 @@ class TestPublisherFallbackAdsViews(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 403)
 
-        self.user.publishers.add(self.publisher)
+        member = UserPublisherMember.objects.create(
+            user=self.user,
+            publisher=self.publisher,
+            role="Reporter",
+        )
+
+        # Reporters can't edit
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 403)
+
+        member.role = "Manager"
+        member.save()
 
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
@@ -653,7 +716,18 @@ class TestPublisherFallbackAdsViews(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 403)
 
-        self.user.publishers.add(self.publisher)
+        member = UserPublisherMember.objects.create(
+            user=self.user,
+            publisher=self.publisher,
+            role="Reporter",
+        )
+
+        # Reporter can't create
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 403)
+
+        member.role = "Manager"
+        member.save()
 
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
- Add 3 permission levels for advertisers and publishers
- The migration will default everybody to the highest permission
- Role permissions are checked in the UI and in the backend
- Admin users can change publisher settings, and invite users.
- Managers can edit things
- Reporters can't change anything.

## Screenshot
![Screenshot from 2024-11-14 16-18-07](https://github.com/user-attachments/assets/cc915782-1e8c-4d45-b4ce-f986ce5b6887)
