### PR TITLE
Dependency update Nov 2024

### DIFF
--- a/requirements/analyzer.in
+++ b/requirements/analyzer.in
@@ -28,7 +28,7 @@ lxml[html_clean]
 pgvector
 
 # This installs PyTorch which is ~250MB
-spacy-transformers
+spacy-transformers<1.2.0,>=1.1.8
 
 # For the ST backend
 sentence-transformers

--- a/requirements/analyzer.txt
+++ b/requirements/analyzer.txt
@@ -35,7 +35,7 @@ confection==0.1.5
     # via
     #   thinc
     #   weasel
-courlan==1.3.1
+courlan==1.3.2
     # via trafilatura
 cymem==2.0.8
     # via
@@ -60,7 +60,7 @@ fsspec==2024.10.0
     # via
     #   huggingface-hub
     #   torch
-htmldate==1.9.1
+htmldate==1.9.2
     # via trafilatura
 huggingface-hub==0.24.7
     # via
@@ -82,11 +82,11 @@ joblib==1.4.2
     #   textacy
 justext==3.0.1
     # via trafilatura
-langcodes==3.4.1
+langcodes==3.5.0
     # via spacy
 langdetect==1.0.9
     # via -r analyzer.in
-language-data==1.2.0
+language-data==1.3.0
     # via langcodes
 lxml[html-clean,html_clean]==5.3.0
     # via
@@ -95,7 +95,7 @@ lxml[html-clean,html_clean]==5.3.0
     #   justext
     #   lxml-html-clean
     #   trafilatura
-lxml-html-clean==0.3.1
+lxml-html-clean==0.4.1
     # via lxml
 marisa-trie==1.2.1
     # via language-data
@@ -125,7 +125,6 @@ numpy==1.26.4
     #   scipy
     #   sentence-transformers
     #   spacy
-    #   spacy-transformers
     #   textacy
     #   thinc
     #   torchvision
@@ -162,7 +161,7 @@ nvidia-nvjitlink-cu12==12.4.127
     #   torch
 nvidia-nvtx-cu12==12.4.127
     # via torch
-packaging==24.1
+packaging==24.2
     # via
     #   huggingface-hub
     #   spacy
@@ -173,7 +172,7 @@ pathlib-abc==0.1.1
     # via pathy
 pathy==0.11.0
     # via spacy
-pgvector==0.3.5
+pgvector==0.3.6
     # via -r analyzer.in
 pillow==11.0.0
     # via torchvision
@@ -181,13 +180,13 @@ preshed==3.0.9
     # via
     #   spacy
     #   thinc
-pydantic==1.10.18
+pydantic==1.10.19
     # via
     #   confection
     #   spacy
     #   thinc
     #   weasel
-pyphen==0.16.0
+pyphen==0.17.0
     # via textacy
 python-dateutil==2.9.0.post0
     # via
@@ -199,7 +198,7 @@ pyyaml==6.0.2
     # via
     #   huggingface-hub
     #   transformers
-regex==2024.9.11
+regex==2024.11.6
     # via
     #   dateparser
     #   nltk
@@ -247,7 +246,7 @@ spacy-legacy==3.0.12
     # via spacy
 spacy-loggers==1.0.5
     # via spacy
-spacy-transformers==1.2.1
+spacy-transformers==1.1.9
     # via -r analyzer.in
 srsly==2.4.8
     # via
@@ -270,14 +269,14 @@ tokenizers==0.13.3
     # via transformers
 toolz==1.0.0
     # via cytoolz
-torch==2.5.0
+torch==2.5.1
     # via
     #   sentence-transformers
     #   spacy-transformers
     #   torchvision
-torchvision==0.20.0
+torchvision==0.20.1
     # via sentence-transformers
-tqdm==4.66.5
+tqdm==4.67.0
     # via
     #   huggingface-hub
     #   nltk
@@ -287,7 +286,7 @@ tqdm==4.66.5
     #   transformers
 trafilatura==1.12.2
     # via -r analyzer.in
-transformers==4.26.1
+transformers==4.25.1
     # via
     #   sentence-transformers
     #   spacy-transformers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,11 +6,11 @@
 #
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.11
+aiohttp==3.11.6
     # via geoip2
 aiosignal==1.3.1
     # via aiohttp
-amqp==5.2.0
+amqp==5.3.1
     # via kombu
 asgiref==3.8.1
     # via
@@ -18,7 +18,7 @@ asgiref==3.8.1
     #   django-allauth
     #   django-cors-headers
     #   django-countries
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
@@ -26,7 +26,7 @@ attrs==24.2.0
     # via aiohttp
 billiard==4.2.1
     # via celery
-bleach==6.1.0
+bleach==6.2.0
     # via -r base.in
 celery[redis]==5.5.0rc1
     # via -r base.in
@@ -63,9 +63,9 @@ django==5.0.9
     #   django-slack
     #   djangorestframework
     #   jsonfield
-django-allauth==65.1.0
+django-allauth==65.2.0
     # via -r base.in
-django-cors-headers==4.5.0
+django-cors-headers==4.6.0
     # via -r base.in
 django-countries==7.6.1
     # via -r base.in
@@ -93,7 +93,7 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-geoip2==4.8.0
+geoip2==4.8.1
     # via -r base.in
 idna==3.10
     # via
@@ -116,8 +116,10 @@ pillow==11.0.0
 prompt-toolkit==3.0.48
     # via click-repl
 propcache==0.2.0
-    # via yarl
-pyjwt==2.9.0
+    # via
+    #   aiohttp
+    #   yarl
+pyjwt==2.10.0
     # via -r base.in
 python-dateutil==2.9.0.post0
     # via celery
@@ -131,10 +133,8 @@ requests==2.32.3
     #   geoip2
     #   stripe
 six==1.16.0
-    # via
-    #   bleach
-    #   python-dateutil
-sqlparse==0.5.1
+    # via python-dateutil
+sqlparse==0.5.2
     # via django
 stripe==4.2.0
     # via
@@ -162,10 +162,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-whitenoise==6.7.0
+whitenoise==6.8.2
     # via -r base.in
-yarl==1.16.0
+yarl==1.17.2
     # via aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,13 +6,13 @@
 #
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.11
+aiohttp==3.11.6
     # via geoip2
 aiosignal==1.3.1
     # via aiohttp
 alabaster==0.7.16
     # via sphinx
-amqp==5.2.0
+amqp==5.3.1
     # via kombu
 anyio==4.6.2.post1
     # via
@@ -26,7 +26,7 @@ asgiref==3.8.1
     #   django-countries
 asttokens==2.4.1
     # via stack-data
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
@@ -41,7 +41,7 @@ beautifulsoup4==4.12.3
     # via -r testing.in
 billiard==4.2.1
     # via celery
-bleach==6.1.0
+bleach==6.2.0
     # via -r base.in
 cattrs==24.1.2
     # via requests-cache
@@ -68,7 +68,7 @@ click-repl==0.3.0
     # via celery
 colorama==0.4.6
     # via sphinx-autobuild
-coverage==7.6.4
+coverage==7.6.7
     # via
     #   -r development.in
     #   django-coverage-plugin
@@ -96,9 +96,9 @@ django==5.0.9
     #   django-slack
     #   djangorestframework
     #   jsonfield
-django-allauth==65.1.0
+django-allauth==65.2.0
     # via -r base.in
-django-cors-headers==4.5.0
+django-cors-headers==4.6.0
     # via -r base.in
 django-countries==7.6.1
     # via -r base.in
@@ -150,11 +150,11 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-geoip2==4.8.0
+geoip2==4.8.1
     # via -r base.in
 h11==0.14.0
     # via uvicorn
-identify==2.6.1
+identify==2.6.2
     # via pre-commit
 idna==3.10
     # via
@@ -173,7 +173,7 @@ ipython==8.29.0
     # via
     #   -r development.in
     #   ipdb
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 jinja2==3.1.4
     # via sphinx
@@ -193,7 +193,7 @@ multidict==6.1.0
     #   yarl
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   pytest
     #   sphinx
@@ -219,7 +219,9 @@ prompt-toolkit==3.0.48
     #   click-repl
     #   ipython
 propcache==0.2.0
-    # via yarl
+    # via
+    #   aiohttp
+    #   yarl
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -230,7 +232,7 @@ pygments==2.18.0
     # via
     #   ipython
     #   sphinx
-pyjwt==2.9.0
+pyjwt==2.10.0
     # via -r base.in
 pytest==8.3.3
     # via
@@ -265,7 +267,6 @@ ruff==0.5.2
 six==1.16.0
     # via
     #   asttokens
-    #   bleach
     #   python-dateutil
     #   sphinxcontrib-httpdomain
     #   tox
@@ -285,7 +286,7 @@ sphinx==6.2.1
     #   sphinxcontrib-jquery
 sphinx-autobuild==2024.10.3
     # via -r development.in
-sphinx-rtd-theme==3.0.1
+sphinx-rtd-theme==3.0.2
     # via -r development.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -303,13 +304,13 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.1
+sqlparse==0.5.2
     # via
     #   django
     #   django-debug-toolbar
 stack-data==0.6.3
     # via ipython
-starlette==0.41.0
+starlette==0.41.3
     # via sphinx-autobuild
 stripe==4.2.0
     # via
@@ -317,7 +318,7 @@ stripe==4.2.0
     #   dj-stripe
 tokenize-rt==6.1.0
     # via django-upgrade
-tomli==2.0.2
+tomli==2.1.0
     # via
     #   ipdb
     #   pytest
@@ -351,14 +352,14 @@ urllib3==2.2.3
     #   responses
 user-agents==2.2.0
     # via -r base.in
-uvicorn==0.32.0
+uvicorn==0.32.1
     # via sphinx-autobuild
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.27.0
+virtualenv==20.27.1
     # via
     #   pre-commit
     #   tox
@@ -368,12 +369,9 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-websockets==13.1
+websockets==14.1
     # via sphinx-autobuild
-whitenoise==6.7.0
+whitenoise==6.8.2
     # via -r base.in
-yarl==1.16.0
+yarl==1.17.2
     # via aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,11 +6,11 @@
 #
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.11
+aiohttp==3.11.6
     # via geoip2
 aiosignal==1.3.1
     # via aiohttp
-amqp==5.2.0
+amqp==5.3.1
     # via kombu
 asgiref==3.8.1
     # via
@@ -18,21 +18,21 @@ asgiref==3.8.1
     #   django-allauth
     #   django-cors-headers
     #   django-countries
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
 attrs==24.2.0
     # via aiohttp
-azure-core==1.31.0
+azure-core==1.32.0
     # via
     #   azure-storage-blob
     #   django-storages
-azure-storage-blob==12.23.1
+azure-storage-blob==12.24.0
     # via django-storages
 billiard==4.2.1
     # via celery
-bleach==6.1.0
+bleach==6.2.0
     # via -r base.in
 celery[redis]==5.5.0rc1
     # via -r base.in
@@ -78,11 +78,11 @@ django==5.0.9
     #   django-storages
     #   djangorestframework
     #   jsonfield
-django-allauth==65.1.0
+django-allauth==65.2.0
     # via -r base.in
 django-anymail==12.0
     # via -r production.in
-django-cors-headers==4.5.0
+django-cors-headers==4.6.0
     # via -r base.in
 django-countries==7.6.1
     # via -r base.in
@@ -114,7 +114,7 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-geoip2==4.8.0
+geoip2==4.8.1
     # via -r base.in
 gunicorn==23.0.0
     # via -r production.in
@@ -136,21 +136,23 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-newrelic==10.2.0
+newrelic==10.3.0
     # via -r production.in
-packaging==24.1
+packaging==24.2
     # via gunicorn
 pillow==11.0.0
     # via -r base.in
 prompt-toolkit==3.0.48
     # via click-repl
 propcache==0.2.0
-    # via yarl
+    # via
+    #   aiohttp
+    #   yarl
 psycopg2-binary==2.9.10
     # via -r production.in
 pycparser==2.22
     # via cffi
-pyjwt==2.9.0
+pyjwt==2.10.0
     # via -r base.in
 python-dateutil==2.9.0.post0
     # via celery
@@ -167,14 +169,13 @@ requests==2.32.3
     #   django-slack
     #   geoip2
     #   stripe
-sentry-sdk==2.17.0
+sentry-sdk==2.18.0
     # via -r production.in
 six==1.16.0
     # via
     #   azure-core
-    #   bleach
     #   python-dateutil
-sqlparse==0.5.1
+sqlparse==0.5.2
     # via django
 stripe==4.2.0
     # via
@@ -207,10 +208,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-whitenoise==6.7.0
+whitenoise==6.8.2
     # via -r base.in
-yarl==1.16.0
+yarl==1.17.2
     # via aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -12,7 +12,7 @@ filelock==3.16.1
     # via
     #   tox
     #   virtualenv
-packaging==24.1
+packaging==24.2
     # via tox
 platformdirs==4.3.6
     # via virtualenv
@@ -24,9 +24,9 @@ six==1.16.0
     # via tox
 soupsieve==2.6
     # via beautifulsoup4
-tomli==2.0.2
+tomli==2.1.0
     # via tox
 tox==3.28.0
     # via -r testing.in
-virtualenv==20.27.0
+virtualenv==20.27.1
     # via tox


### PR DESCRIPTION
- Includes pinning for spacy-transformers which was causing issues

Replaces https://github.com/readthedocs/ethical-ad-server/pull/942