### PR TITLE
Update requirements

### DIFF
--- a/requirements/analyzer.txt
+++ b/requirements/analyzer.txt
@@ -37,7 +37,7 @@ confection==0.1.5
     #   weasel
 courlan==1.3.2
     # via trafilatura
-cymem==2.0.8
+cymem==2.0.10
     # via
     #   preshed
     #   spacy
@@ -69,7 +69,7 @@ huggingface-hub==0.24.7
     #   transformers
 idna==3.10
     # via requests
-jellyfish==1.1.0
+jellyfish==1.1.2
     # via textacy
 jinja2==3.1.4
     # via
@@ -103,7 +103,7 @@ markupsafe==3.0.2
     # via jinja2
 mpmath==1.3.0
     # via sympy
-murmurhash==1.0.10
+murmurhash==1.0.11
     # via
     #   preshed
     #   spacy
@@ -223,7 +223,7 @@ sentence-transformers==2.2.2
     # via -r analyzer.in
 sentencepiece==0.2.0
     # via sentence-transformers
-six==1.16.0
+six==1.17.0
     # via
     #   langdetect
     #   python-dateutil
@@ -276,7 +276,7 @@ torch==2.5.1
     #   torchvision
 torchvision==0.20.1
     # via sentence-transformers
-tqdm==4.67.0
+tqdm==4.67.1
     # via
     #   huggingface-hub
     #   nltk
@@ -284,7 +284,7 @@ tqdm==4.67.0
     #   spacy
     #   textacy
     #   transformers
-trafilatura==1.12.2
+trafilatura==2.0.0
     # via -r analyzer.in
 transformers==4.25.1
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile base.in
 #
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.6
+aiohttp==3.11.9
     # via geoip2
 aiosignal==1.3.1
     # via aiohttp
@@ -50,7 +50,7 @@ crispy-bootstrap4==2024.10
     # via -r base.in
 dj-stripe==2.8.4
     # via -r base.in
-django==5.0.9
+django==5.0.10
     # via
     #   -r base.in
     #   crispy-bootstrap4
@@ -63,7 +63,7 @@ django==5.0.9
     #   django-slack
     #   djangorestframework
     #   jsonfield
-django-allauth==65.2.0
+django-allauth==65.3.0
     # via -r base.in
 django-cors-headers==4.6.0
     # via -r base.in
@@ -115,11 +115,11 @@ pillow==11.0.0
     # via -r base.in
 prompt-toolkit==3.0.48
     # via click-repl
-propcache==0.2.0
+propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
-pyjwt==2.10.0
+pyjwt==2.10.1
     # via -r base.in
 python-dateutil==2.9.0.post0
     # via celery
@@ -132,7 +132,7 @@ requests==2.32.3
     #   django-slack
     #   geoip2
     #   stripe
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sqlparse==0.5.2
     # via django
@@ -147,8 +147,12 @@ typing-extensions==4.12.2
     #   multidict
 tzdata==2024.2
     # via kombu
-ua-parser==0.18.0
-    # via user-agents
+ua-parser==1.0.0
+    # via
+    #   ua-parser-builtins
+    #   user-agents
+ua-parser-builtins==0.18.0
+    # via ua-parser
 urllib3==2.2.3
     # via requests
 user-agents==2.2.0
@@ -164,5 +168,5 @@ webencodings==0.5.1
     # via bleach
 whitenoise==6.8.2
     # via -r base.in
-yarl==1.17.2
+yarl==1.18.3
     # via aiohttp

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile development.in
 #
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.6
+aiohttp==3.11.9
     # via geoip2
 aiosignal==1.3.1
     # via aiohttp
@@ -24,7 +24,7 @@ asgiref==3.8.1
     #   django-allauth
     #   django-cors-headers
     #   django-countries
-asttokens==2.4.1
+asttokens==3.0.0
     # via stack-data
 async-timeout==5.0.1
     # via
@@ -68,7 +68,7 @@ click-repl==0.3.0
     # via celery
 colorama==0.4.6
     # via sphinx-autobuild
-coverage==7.6.7
+coverage==7.6.8
     # via
     #   -r development.in
     #   django-coverage-plugin
@@ -82,7 +82,7 @@ distlib==0.3.9
     # via virtualenv
 dj-stripe==2.8.4
     # via -r base.in
-django==5.0.9
+django==5.0.10
     # via
     #   -r base.in
     #   crispy-bootstrap4
@@ -96,7 +96,7 @@ django==5.0.9
     #   django-slack
     #   djangorestframework
     #   jsonfield
-django-allauth==65.2.0
+django-allauth==65.3.0
     # via -r base.in
 django-cors-headers==4.6.0
     # via -r base.in
@@ -124,7 +124,7 @@ django-simple-history==3.7.0
     # via -r base.in
 django-slack==5.19.0
     # via -r base.in
-django-upgrade==1.22.1
+django-upgrade==1.22.2
     # via -r development.in
 djangorestframework==3.15.2
     # via -r base.in
@@ -154,7 +154,7 @@ geoip2==4.8.1
     # via -r base.in
 h11==0.14.0
     # via uvicorn
-identify==2.6.2
+identify==2.6.3
     # via pre-commit
 idna==3.10
     # via
@@ -169,7 +169,7 @@ ip2proxy==3.4.2
     # via -r base.in
 ipdb==0.13.13
     # via -r development.in
-ipython==8.29.0
+ipython==8.30.0
     # via
     #   -r development.in
     #   ipdb
@@ -218,7 +218,7 @@ prompt-toolkit==3.0.48
     # via
     #   click-repl
     #   ipython
-propcache==0.2.0
+propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
@@ -232,9 +232,9 @@ pygments==2.18.0
     # via
     #   ipython
     #   sphinx
-pyjwt==2.10.0
+pyjwt==2.10.1
     # via -r base.in
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   -r development.in
     #   pytest-django
@@ -264,9 +264,8 @@ responses==0.25.3
     # via -r development.in
 ruff==0.5.2
     # via -r development.in
-six==1.16.0
+six==1.17.0
     # via
-    #   asttokens
     #   python-dateutil
     #   sphinxcontrib-httpdomain
     #   tox
@@ -318,7 +317,7 @@ stripe==4.2.0
     #   dj-stripe
 tokenize-rt==6.1.0
     # via django-upgrade
-tomli==2.1.0
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
@@ -340,8 +339,12 @@ typing-extensions==4.12.2
     #   uvicorn
 tzdata==2024.2
     # via kombu
-ua-parser==0.18.0
-    # via user-agents
+ua-parser==1.0.0
+    # via
+    #   ua-parser-builtins
+    #   user-agents
+ua-parser-builtins==0.18.0
+    # via ua-parser
 url-normalize==1.4.3
     # via requests-cache
 urllib3==2.2.3
@@ -359,11 +362,11 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.27.1
+virtualenv==20.28.0
     # via
     #   pre-commit
     #   tox
-watchfiles==0.24.0
+watchfiles==1.0.0
     # via sphinx-autobuild
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -373,5 +376,5 @@ websockets==14.1
     # via sphinx-autobuild
 whitenoise==6.8.2
     # via -r base.in
-yarl==1.17.2
+yarl==1.18.3
     # via aiohttp

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile production.in
 #
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.6
+aiohttp==3.11.9
     # via geoip2
 aiosignal==1.3.1
     # via aiohttp
@@ -58,11 +58,11 @@ click-repl==0.3.0
     # via celery
 crispy-bootstrap4==2024.10
     # via -r base.in
-cryptography==43.0.3
+cryptography==44.0.0
     # via azure-storage-blob
 dj-stripe==2.8.4
     # via -r base.in
-django==5.0.9
+django==5.0.10
     # via
     #   -r base.in
     #   crispy-bootstrap4
@@ -78,7 +78,7 @@ django==5.0.9
     #   django-storages
     #   djangorestframework
     #   jsonfield
-django-allauth==65.2.0
+django-allauth==65.3.0
     # via -r base.in
 django-anymail==12.0
     # via -r production.in
@@ -136,7 +136,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-newrelic==10.3.0
+newrelic==10.3.1
     # via -r production.in
 packaging==24.2
     # via gunicorn
@@ -144,7 +144,7 @@ pillow==11.0.0
     # via -r base.in
 prompt-toolkit==3.0.48
     # via click-repl
-propcache==0.2.0
+propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
@@ -152,7 +152,7 @@ psycopg2-binary==2.9.10
     # via -r production.in
 pycparser==2.22
     # via cffi
-pyjwt==2.10.0
+pyjwt==2.10.1
     # via -r base.in
 python-dateutil==2.9.0.post0
     # via celery
@@ -169,9 +169,9 @@ requests==2.32.3
     #   django-slack
     #   geoip2
     #   stripe
-sentry-sdk==2.18.0
+sentry-sdk==2.19.0
     # via -r production.in
-six==1.16.0
+six==1.17.0
     # via
     #   azure-core
     #   python-dateutil
@@ -190,8 +190,12 @@ typing-extensions==4.12.2
     #   multidict
 tzdata==2024.2
     # via kombu
-ua-parser==0.18.0
-    # via user-agents
+ua-parser==1.0.0
+    # via
+    #   ua-parser-builtins
+    #   user-agents
+ua-parser-builtins==0.18.0
+    # via ua-parser
 urllib3==2.2.3
     # via
     #   django-anymail
@@ -210,5 +214,5 @@ webencodings==0.5.1
     # via bleach
 whitenoise==6.8.2
     # via -r base.in
-yarl==1.17.2
+yarl==1.18.3
     # via aiohttp

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -20,13 +20,13 @@ pluggy==1.5.0
     # via tox
 py==1.11.0
     # via tox
-six==1.16.0
+six==1.17.0
     # via tox
 soupsieve==2.6
     # via beautifulsoup4
-tomli==2.1.0
+tomli==2.2.1
     # via tox
 tox==3.28.0
     # via -r testing.in
-virtualenv==20.27.1
+virtualenv==20.28.0
     # via tox


### PR DESCRIPTION
Doing this in favor of https://github.com/readthedocs/ethical-ad-server/pull/948 and https://github.com/readthedocs/ethical-ad-server/pull/951. The latter references absolute paths in the requirements files (not sure why).