### PR TITLE
Advertiser domain report

### DIFF
--- a/adserver/reports.py
+++ b/adserver/reports.py
@@ -8,6 +8,7 @@ import operator
 from .constants import PAID_CAMPAIGN
 from .models import AdImpression
 from .models import AdvertiserImpression
+from .models import DomainImpression
 from .models import GeoImpression
 from .models import KeywordImpression
 from .models import PlacementImpression
@@ -85,6 +86,9 @@ class BaseReport:
     def get_index_display(self, index):
         """Used to add display logic the index field."""
         return index
+
+    def get_index_header(self):
+        return "Day (UTC)"
 
     def generate(self):
         raise NotImplementedError("Subclasses implement this method")
@@ -186,6 +190,18 @@ class AdvertiserPublisherReport(AdvertiserReport):
     index = "publisher"
     order = "-views"
     select_related_fields = ("advertisement", "advertisement__flight", "publisher")
+
+
+class AdvertiserDomainReport(AdvertiserReport):
+    """Report to breakdown advertiser performance by domain where the ad appears."""
+
+    model = DomainImpression
+    index = "domain"
+    order = "-views"
+    select_related_fields = ("advertisement", "advertisement__flight")
+
+    def get_index_header(self):
+        return self.index.title()
 
 
 class PublisherReport(BaseReport):

--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -127,6 +127,16 @@
               </li>
 
               <li class="nav-item">
+                <a
+                  class="nav-link"
+                  href="{% url 'advertiser_domain_report' advertiser.slug %}"
+                >
+                  <span class="fa fa-laptop fa-fw ml-4 text-muted" aria-hidden="true"></span>
+                  <span>{% trans 'Domains' %}</span>
+                </a>
+              </li>
+
+              <li class="nav-item">
                 <a class="nav-link" href="{% url 'advertiser_users' advertiser.slug %}">
                   <span class="fa fa-users fa-fw mr-2 text-muted" aria-hidden="true"></span>
                   <span>{% trans 'Authorized users' %}</span>

--- a/adserver/templates/adserver/reports/advertiser-domain.html
+++ b/adserver/templates/adserver/reports/advertiser-domain.html
@@ -1,0 +1,46 @@
+{% extends "adserver/reports/advertiser.html" %}
+{% load humanize %}
+{% load i18n %}
+
+
+{% block title %}{% trans 'Advertiser Domain Report' %} - {{ advertiser }}{% endblock %}
+
+
+{% block heading %}
+{% blocktrans %}Advertiser Domain Report for {{ advertiser }}{% endblocktrans %}
+{% endblock heading %}
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item active">{% trans 'Advertiser Domain Report' %}</li>
+{% endblock breadcrumbs %}
+
+
+{% block additional_filters %}
+{{ block.super }}
+
+<div class="col-xl-3 col-md-6 col-12 mb-3">
+  <label class="col-form-label" for="id_flight">{% trans 'Flight' %}</label>
+  <select class="form-control" name="flight" id="id_flight">
+    <option value="">{% trans 'All flights' %}</option>
+    {% for flight in flights %}
+      <option value="{{ flight.slug }}"{% if flight.slug == request.GET.flight %} selected{% endif %}>{{ flight.name }}</option>
+    {% endfor %}
+  </select>
+</div>
+
+{% endblock additional_filters %}
+
+
+{% block explainer %}
+<section class="mb-5">
+  <h3>{% trans 'About this report' %}</h3>
+  <p>{% trans 'This report shows the top domains where your ads are shown.' %}</p>
+  <em>
+    {% blocktrans %}This report shows the <strong>top {{ limit }} domains</strong> and updates daily. All previous days data is complete.{% endblocktrans %}
+  </em>
+</section>
+{% endblock explainer %}
+
+
+{% block report %}{% endblock report %}

--- a/adserver/templates/adserver/reports/includes/advertiser-report-table.html
+++ b/adserver/templates/adserver/reports/includes/advertiser-report-table.html
@@ -4,7 +4,7 @@
 <table class="table table-hover report">
   <thead>
     <tr>
-      <th><strong>{% trans 'Day (UTC)' %}</strong></th>
+      <th><strong>{{ report.get_index_header }}</strong></th>
       <th class="text-right"><strong>{% trans 'Views' %}</strong></th>
       <th class="text-right"><strong>{% trans 'Clicks' %}</strong></th>
       <th class="text-right"><strong>{% trans 'Cost' %}</strong></th>

--- a/adserver/urls.py
+++ b/adserver/urls.py
@@ -15,6 +15,7 @@ from .views import AdvertisementUpdateView
 from .views import AdvertiserAuthorizedUsersInviteView
 from .views import AdvertiserAuthorizedUsersRemoveView
 from .views import AdvertiserAuthorizedUsersView
+from .views import AdvertiserDomainReportView
 from .views import AdvertiserFlightReportView
 from .views import AdvertiserGeoReportView
 from .views import AdvertiserKeywordReportView
@@ -193,6 +194,11 @@ urlpatterns = [
         r"advertiser/<slug:advertiser_slug>/report/topics/",
         AdvertiserTopicReportView.as_view(),
         name="advertiser_topic_report",
+    ),
+    path(
+        r"advertiser/<slug:advertiser_slug>/report/domains/",
+        AdvertiserDomainReportView.as_view(),
+        name="advertiser_domain_report",
     ),
     path(
         r"advertiser/<slug:advertiser_slug>/flights/",

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -93,6 +93,7 @@ from .models import Advertisement
 from .models import Advertiser
 from .models import AdvertiserImpression
 from .models import Campaign
+from .models import DomainImpression
 from .models import Flight
 from .models import GeoImpression
 from .models import KeywordImpression
@@ -107,6 +108,7 @@ from .models import RegionImpression
 from .models import RegionTopicImpression
 from .models import Topic
 from .models import UpliftImpression
+from .reports import AdvertiserDomainReport
 from .reports import AdvertiserPublisherReport
 from .reports import AdvertiserReport
 from .reports import OptimizedAdvertiserReport
@@ -1633,6 +1635,61 @@ class AdvertiserTopicReportView(AdvertiserAccessMixin, BaseReportView):
                 "metabase_advertiser_topics": settings.METABASE_QUESTIONS.get(
                     "ADVERTISER_TOPIC_PERFORMANCE"
                 ),
+            }
+        )
+
+        return context
+
+
+class AdvertiserDomainReportView(AdvertiserAccessMixin, BaseReportView):
+    LIMIT = 50
+    DATA_COLLECTION_START_DATE = datetime(
+        year=2024, month=12, day=1, tzinfo=timezone.get_current_timezone()
+    )
+
+    impression_model = DomainImpression
+    template_name = "adserver/reports/advertiser-domain.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        advertiser_slug = kwargs.get("advertiser_slug", "")
+        advertiser = get_object_or_404(Advertiser, slug=advertiser_slug)
+
+        flight_slug = self.request.GET.get("flight", "")
+        flight = Flight.objects.filter(
+            campaign__advertiser=advertiser, slug=flight_slug
+        ).first()
+
+        if context["start_date"] < self.DATA_COLLECTION_START_DATE:
+            messages.info(
+                self.request,
+                _(
+                    "Data for the domain report started being collected in %s. Data for this date range may be incomplete."
+                )
+                % (self.DATA_COLLECTION_START_DATE.strftime("%B %Y")),
+            )
+
+        queryset = self.get_queryset(
+            advertiser=advertiser,
+            flight=flight,
+            start_date=context["start_date"],
+            end_date=context["end_date"],
+        )
+
+        report = AdvertiserDomainReport(
+            queryset,
+            max_results=self.LIMIT,
+        )
+        report.generate()
+
+        context.update(
+            {
+                "advertiser": advertiser,
+                "report": report,
+                "flights": Flight.objects.filter(
+                    campaign__advertiser=advertiser
+                ).order_by("-start_date"),
             }
         )
 


### PR DESCRIPTION
Adds an advertiser domain report where they can see the top domains for their ads. 

- Adds a note/alert if the timeframe is earlier than when data began being collected.
- We don't currently mention that some ads do not report their domain (eg. native ones) so this won't add up to the total in all cases. How should we mention that?

## Screenshot
![image](https://github.com/user-attachments/assets/c8e63044-3191-42ee-9eb2-881dc403efe0)
