### PR TITLE
Automated PayPal payouts

### DIFF
--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -334,10 +334,11 @@ class PublisherFinishPayoutView(StaffUserMixin, DetailView):
         paypal_email = publisher.paypal_email
         amount = str(round(payout.amount, 2))  # PayPal wants the amount as a string
 
+        # https://developer.paypal.com/api/rest/requests/
         if settings.DEBUG:
-            paypal_api_root = "https://api.sandbox.paypal.com"
+            paypal_api_root = "https://api-m.sandbox.paypal.com"
         else:
-            paypal_api_root = "https://api.paypal.com"
+            paypal_api_root = "https://api-m.paypal.com"
 
         # https://developer.paypal.com/api/rest/authentication/
         oauth_url = f"{paypal_api_root}/v1/oauth2/token"

--- a/adserver/templates/adserver/staff/publisher-payout-finish.html
+++ b/adserver/templates/adserver/staff/publisher-payout-finish.html
@@ -58,6 +58,15 @@
             </div>
 
             <a href="{{ payout.publisher.payout_url }}" class="btn btn-sm btn-outline-secondary">{% trans "Or Send Manually" %}</a>
+          {% elif payout.method == "paypal" %}
+            <div class="form-group form-check">
+              <input type="checkbox" class="form-check-input" id="paypal-payout-confirm" name="paypal-payout-confirm">
+              <label class="form-check-label" for="paypal-payout-confirm">
+                <span>{% blocktrans with amount=payout.amount|floatformat:2|intcomma %}Send ${{ amount }} via PayPal ($0.25 fee){% endblocktrans %}</span>
+              </label>
+            </div>
+
+            <a href="{{ payout.publisher.payout_url }}" class="btn btn-sm btn-outline-secondary">{% trans "Or Send Manually" %}</a>
           {% else %}
             <a href="{{ payout.publisher.payout_url }}" class="btn btn-sm btn-outline-secondary">{% trans "Send Money" %}</a>
           {% endif %}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -454,6 +454,12 @@ else:
     stripe.api_key = None
 stripe.api_version = "2020-08-27"
 
+# PayPal
+# Used for automated PayPal payouts only
+# --------------------------------------------------------------------------
+PAYPAL_CLIENT_ID = env("PAYPAL_CLIENT_ID", default=None)
+PAYPAL_SECRET_KEY = env("PAYPAL_SECRET_KEY", default=None)
+
 
 # Slack
 # Sending slack notifications


### PR DESCRIPTION
I have nearly completed the implementation here and I discovered in testing that PayPal [charges a $0.25 fee](https://www.paypal.com/us/business/paypal-business-fees#maxfeecap) on every transaction! Pretty frustrating that going through the web interface is free but this isn’t.

## Testing

In testing, toggle live to sandbox, click on the application and you get both test API credentials as well as a full test PayPal login. You can verify the transactions by logging in with the test login.