### PR TITLE
Update Python requirements - Feb 2025

### DIFF
--- a/requirements/analyzer.txt
+++ b/requirements/analyzer.txt
@@ -6,15 +6,15 @@
 #
 adlfs==2024.12.0
     # via -r analyzer.in
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.13
     # via adlfs
 aiosignal==1.3.2
     # via aiohttp
 async-timeout==5.0.1
     # via aiohttp
-attrs==24.3.0
+attrs==25.1.0
     # via aiohttp
 azure-core==1.32.0
     # via
@@ -23,17 +23,17 @@ azure-core==1.32.0
     #   azure-storage-blob
 azure-datalake-store==0.0.53
     # via adlfs
-azure-identity==1.19.0
+azure-identity==1.20.0
     # via adlfs
 azure-storage-blob==12.24.1
     # via adlfs
-babel==2.16.0
+babel==2.17.0
     # via courlan
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via -r analyzer.in
 blis==0.7.11
     # via thinc
-cachetools==5.5.1
+cachetools==5.5.2
     # via textacy
 catalogue==2.0.10
     # via
@@ -41,7 +41,7 @@ catalogue==2.0.10
     #   srsly
     #   textacy
     #   thinc
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   requests
     #   trafilatura
@@ -64,7 +64,7 @@ confection==0.1.5
     #   weasel
 courlan==1.3.2
     # via trafilatura
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -77,7 +77,7 @@ cymem==2.0.11
     #   thinc
 cytoolz==1.0.1
     # via textacy
-dateparser==1.2.0
+dateparser==1.2.1
     # via htmldate
 duckdb==1.1.3
     # via -r analyzer.in
@@ -88,14 +88,13 @@ filelock==3.17.0
     #   huggingface-hub
     #   torch
     #   transformers
-    #   triton
 floret==0.10.5
     # via textacy
 frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.12.0
+fsspec==2025.2.0
     # via
     #   adlfs
     #   huggingface-hub
@@ -124,7 +123,7 @@ joblib==1.4.2
     #   nltk
     #   scikit-learn
     #   textacy
-justext==3.0.1
+justext==3.0.2
     # via trafilatura
 langcodes==3.5.0
     # via spacy
@@ -132,7 +131,7 @@ langdetect==1.0.9
     # via -r analyzer.in
 language-data==1.3.0
     # via langcodes
-lxml[html-clean,html_clean]==5.3.0
+lxml[html-clean,html_clean]==5.3.1
     # via
     #   -r analyzer.in
     #   htmldate
@@ -207,6 +206,8 @@ nvidia-cusparse-cu12==12.3.1.170
     # via
     #   nvidia-cusolver-cu12
     #   torch
+nvidia-cusparselt-cu12==0.6.2
+    # via torch
 nvidia-nccl-cu12==2.21.5
     # via torch
 nvidia-nvjitlink-cu12==12.4.127
@@ -237,7 +238,7 @@ preshed==3.0.9
     # via
     #   spacy
     #   thinc
-propcache==0.2.1
+propcache==0.3.0
     # via
     #   aiohttp
     #   yarl
@@ -259,7 +260,7 @@ python-dateutil==2.9.0.post0
     # via
     #   dateparser
     #   htmldate
-pytz==2024.2
+pytz==2025.1
     # via dateparser
 pyyaml==6.0.2
     # via
@@ -284,7 +285,7 @@ scikit-learn==1.6.1
     # via
     #   sentence-transformers
     #   textacy
-scipy==1.15.1
+scipy==1.15.2
     # via
     #   scikit-learn
     #   sentence-transformers
@@ -340,12 +341,12 @@ tokenizers==0.13.3
     # via transformers
 toolz==1.0.0
     # via cytoolz
-torch==2.5.1
+torch==2.6.0
     # via
     #   sentence-transformers
     #   spacy-transformers
     #   torchvision
-torchvision==0.20.1
+torchvision==0.21.0
     # via sentence-transformers
 tqdm==4.67.1
     # via
@@ -361,7 +362,7 @@ transformers==4.25.1
     # via
     #   sentence-transformers
     #   spacy-transformers
-triton==3.1.0
+triton==3.2.0
     # via torch
 typer==0.7.0
     # via
@@ -373,12 +374,13 @@ typing-extensions==4.12.2
     #   azure-core
     #   azure-identity
     #   azure-storage-blob
+    #   beautifulsoup4
     #   cloudpathlib
     #   huggingface-hub
     #   multidict
     #   pydantic
     #   torch
-tzlocal==5.2
+tzlocal==5.3
     # via dateparser
 urllib3==2.3.0
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile base.in
 #
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.13
     # via geoip2
 aiosignal==1.3.2
     # via aiohttp
@@ -22,7 +22,7 @@ async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
-attrs==24.3.0
+attrs==25.1.0
     # via aiohttp
 billiard==4.2.1
     # via celery
@@ -30,7 +30,7 @@ bleach==6.2.0
     # via -r base.in
 celery[redis]==5.5.0rc1
     # via -r base.in
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
@@ -50,7 +50,7 @@ crispy-bootstrap4==2024.10
     # via -r base.in
 dj-stripe==2.8.4
     # via -r base.in
-django==5.0.11
+django==5.0.12
     # via
     #   -r base.in
     #   crispy-bootstrap4
@@ -63,9 +63,9 @@ django==5.0.11
     #   django-slack
     #   djangorestframework
     #   jsonfield
-django-allauth==65.3.1
+django-allauth==65.4.1
     # via -r base.in
-django-cors-headers==4.6.0
+django-cors-headers==4.7.0
     # via -r base.in
 django-countries==7.6.1
     # via -r base.in
@@ -75,13 +75,13 @@ django-crispy-forms==2.3
     #   crispy-bootstrap4
 django-enforce-host==1.1.0
     # via -r base.in
-django-environ==0.11.2
+django-environ==0.12.0
     # via -r base.in
 django-extensions==3.2.3
     # via -r base.in
 django-ratelimit==3.0.1
     # via -r base.in
-django-simple-history==3.7.0
+django-simple-history==3.8.0
     # via -r base.in
 django-slack==5.19.0
     # via -r base.in
@@ -93,19 +93,19 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-geoip2==4.8.1
+geoip2==5.0.1
     # via -r base.in
 idna==3.10
     # via
     #   requests
     #   yarl
-ip2proxy==3.4.2
+ip2proxy==3.5.1
     # via -r base.in
 jsonfield==3.1.0
     # via -r base.in
 kombu==5.4.2
     # via celery
-maxminddb==2.6.2
+maxminddb==2.6.3
     # via geoip2
 multidict==6.1.0
     # via
@@ -113,9 +113,9 @@ multidict==6.1.0
     #   yarl
 pillow==11.1.0
     # via -r base.in
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via click-repl
-propcache==0.2.1
+propcache==0.3.0
     # via
     #   aiohttp
     #   yarl
@@ -123,7 +123,7 @@ pyjwt==2.10.1
     # via -r base.in
 python-dateutil==2.9.0.post0
     # via celery
-pytz==2024.2
+pytz==2025.1
     # via -r base.in
 redis==5.2.1
     # via celery
@@ -145,9 +145,9 @@ typing-extensions==4.12.2
     #   asgiref
     #   django-countries
     #   multidict
-tzdata==2024.2
+tzdata==2025.1
     # via kombu
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via user-agents
 ua-parser-builtins==0.18.0.post1
     # via ua-parser
@@ -166,7 +166,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-whitenoise==6.8.2
+whitenoise==6.9.0
     # via -r base.in
 yarl==1.18.3
     # via aiohttp

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile development.in
 #
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.13
     # via geoip2
 aiosignal==1.3.2
     # via aiohttp
@@ -14,7 +14,7 @@ alabaster==0.7.16
     # via sphinx
 amqp==5.3.1
     # via kombu
-anyio==4.7.0
+anyio==4.8.0
     # via
     #   starlette
     #   watchfiles
@@ -30,24 +30,24 @@ async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   aiohttp
     #   cattrs
     #   requests-cache
-babel==2.16.0
+babel==2.17.0
     # via sphinx
-beautifulsoup4==4.12.3
-    # via -r testing.in
+beautifulsoup4==4.13.3
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/testing.in
 billiard==4.2.1
     # via celery
 bleach==6.2.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 cattrs==24.1.2
     # via requests-cache
 celery[redis]==5.5.0rc1
-    # via -r base.in
-certifi==2024.12.14
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+certifi==2025.1.31
     # via requests
 cfgv==3.4.0
     # via pre-commit
@@ -68,23 +68,23 @@ click-repl==0.3.0
     # via celery
 colorama==0.4.6
     # via sphinx-autobuild
-coverage==7.6.10
+coverage==7.6.12
     # via
     #   -r development.in
     #   django-coverage-plugin
 crispy-bootstrap4==2024.10
-    # via -r base.in
-decorator==5.1.1
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+decorator==5.2.1
     # via
     #   ipdb
     #   ipython
 distlib==0.3.9
     # via virtualenv
 dj-stripe==2.8.4
-    # via -r base.in
-django==5.0.11
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+django==5.0.12
     # via
-    #   -r base.in
+    #   -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
     #   crispy-bootstrap4
     #   dj-stripe
     #   django-allauth
@@ -96,40 +96,40 @@ django==5.0.11
     #   django-slack
     #   djangorestframework
     #   jsonfield
-django-allauth==65.3.1
-    # via -r base.in
-django-cors-headers==4.6.0
-    # via -r base.in
+django-allauth==65.4.1
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+django-cors-headers==4.7.0
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-countries==7.6.1
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-coverage-plugin==3.1.0
     # via -r development.in
 django-crispy-forms==2.3
     # via
-    #   -r base.in
+    #   -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
     #   crispy-bootstrap4
 django-debug-toolbar==3.8.1
     # via -r development.in
 django-dynamic-fixture==4.0.1
     # via -r development.in
 django-enforce-host==1.1.0
-    # via -r base.in
-django-environ==0.11.2
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+django-environ==0.12.0
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-extensions==3.2.3
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-ratelimit==3.0.1
-    # via -r base.in
-django-simple-history==3.7.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+django-simple-history==3.8.0
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-slack==5.19.0
-    # via -r base.in
-django-upgrade==1.22.2
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+django-upgrade==1.23.1
     # via -r development.in
 djangorestframework==3.15.2
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 djangorestframework-jsonp==1.0.2
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 docutils==0.19
     # via
     #   sphinx
@@ -140,9 +140,9 @@ exceptiongroup==1.2.2
     #   cattrs
     #   ipython
     #   pytest
-executing==2.1.0
+executing==2.2.0
     # via stack-data
-filelock==3.16.1
+filelock==3.17.0
     # via
     #   tox
     #   virtualenv
@@ -150,11 +150,11 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-geoip2==4.8.1
-    # via -r base.in
+geoip2==5.0.1
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 h11==0.14.0
     # via uvicorn
-identify==2.6.4
+identify==2.6.8
     # via pre-commit
 idna==3.10
     # via
@@ -165,11 +165,11 @@ imagesize==1.4.1
     # via sphinx
 iniconfig==2.0.0
     # via pytest
-ip2proxy==3.4.2
-    # via -r base.in
+ip2proxy==3.5.1
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 ipdb==0.13.13
     # via -r development.in
-ipython==8.31.0
+ipython==8.32.0
     # via
     #   -r development.in
     #   ipdb
@@ -178,14 +178,14 @@ jedi==0.19.2
 jinja2==3.1.5
     # via sphinx
 jsonfield==3.1.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 kombu==5.4.2
     # via celery
 markupsafe==3.0.2
     # via jinja2
 matplotlib-inline==0.1.7
     # via ipython
-maxminddb==2.6.2
+maxminddb==2.6.3
     # via geoip2
 multidict==6.1.0
     # via
@@ -203,7 +203,7 @@ parso==0.8.4
 pexpect==4.9.0
     # via ipython
 pillow==11.1.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 platformdirs==4.3.6
     # via
     #   requests-cache
@@ -212,13 +212,13 @@ pluggy==1.5.0
     # via
     #   pytest
     #   tox
-pre-commit==4.0.1
+pre-commit==4.1.0
     # via -r development.in
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   click-repl
     #   ipython
-propcache==0.2.1
+propcache==0.3.0
     # via
     #   aiohttp
     #   yarl
@@ -228,22 +228,22 @@ pure-eval==0.2.3
     # via stack-data
 py==1.11.0
     # via tox
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   ipython
     #   sphinx
 pyjwt==2.10.1
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 pytest==8.3.4
     # via
     #   -r development.in
     #   pytest-django
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via -r development.in
 python-dateutil==2.9.0.post0
     # via celery
-pytz==2024.2
-    # via -r base.in
+pytz==2025.1
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 pyyaml==6.0.2
     # via
     #   pre-commit
@@ -260,7 +260,7 @@ requests==2.32.3
     #   stripe
 requests-cache==1.2.1
     # via -r development.in
-responses==0.25.3
+responses==0.25.6
     # via -r development.in
 ruff==0.5.2
     # via -r development.in
@@ -309,11 +309,11 @@ sqlparse==0.5.3
     #   django-debug-toolbar
 stack-data==0.6.3
     # via ipython
-starlette==0.45.1
+starlette==0.46.0
     # via sphinx-autobuild
 stripe==4.2.0
     # via
-    #   -r base.in
+    #   -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
     #   dj-stripe
 tokenize-rt==6.1.0
     # via django-upgrade
@@ -323,7 +323,7 @@ tomli==2.2.1
     #   pytest
     #   tox
 tox==3.28.0
-    # via -r testing.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/testing.in
 traitlets==5.14.3
     # via
     #   ipython
@@ -332,14 +332,15 @@ typing-extensions==4.12.2
     # via
     #   anyio
     #   asgiref
+    #   beautifulsoup4
     #   cattrs
     #   django-countries
     #   ipython
     #   multidict
     #   uvicorn
-tzdata==2024.2
+tzdata==2025.1
     # via kombu
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via user-agents
 ua-parser-builtins==0.18.0.post1
     # via ua-parser
@@ -352,9 +353,9 @@ urllib3==2.3.0
     #   requests-cache
     #   responses
 user-agents==2.2.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 uuid-utils==0.10.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 uvicorn==0.34.0
     # via sphinx-autobuild
 vine==5.1.0
@@ -362,19 +363,19 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.28.0
+virtualenv==20.29.2
     # via
     #   pre-commit
     #   tox
-watchfiles==1.0.3
+watchfiles==1.0.4
     # via sphinx-autobuild
 wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-websockets==14.1
+websockets==15.0
     # via sphinx-autobuild
-whitenoise==6.8.2
-    # via -r base.in
+whitenoise==6.9.0
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 yarl==1.18.3
     # via aiohttp

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile production.in
 #
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.13
     # via geoip2
 aiosignal==1.3.2
     # via aiohttp
@@ -22,21 +22,21 @@ async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
-attrs==24.3.0
+attrs==25.1.0
     # via aiohttp
 azure-core==1.32.0
     # via
     #   azure-storage-blob
     #   django-storages
-azure-storage-blob==12.24.0
+azure-storage-blob==12.24.1
     # via django-storages
 billiard==4.2.1
     # via celery
 bleach==6.2.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 celery[redis]==5.5.0rc1
-    # via -r base.in
-certifi==2024.12.14
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+certifi==2025.1.31
     # via
     #   requests
     #   sentry-sdk
@@ -57,14 +57,14 @@ click-plugins==1.1.1
 click-repl==0.3.0
     # via celery
 crispy-bootstrap4==2024.10
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 cryptography==44.0.1
     # via azure-storage-blob
 dj-stripe==2.8.4
-    # via -r base.in
-django==5.0.11
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+django==5.0.12
     # via
-    #   -r base.in
+    #   -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
     #   crispy-bootstrap4
     #   dj-stripe
     #   django-allauth
@@ -78,73 +78,73 @@ django==5.0.11
     #   django-storages
     #   djangorestframework
     #   jsonfield
-django-allauth==65.3.1
-    # via -r base.in
+django-allauth==65.4.1
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-anymail==12.0
     # via -r production.in
-django-cors-headers==4.6.0
-    # via -r base.in
+django-cors-headers==4.7.0
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-countries==7.6.1
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-crispy-forms==2.3
     # via
-    #   -r base.in
+    #   -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
     #   crispy-bootstrap4
 django-enforce-host==1.1.0
-    # via -r base.in
-django-environ==0.11.2
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+django-environ==0.12.0
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-extensions==3.2.3
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-ratelimit==3.0.1
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-redis==5.4.0
     # via -r production.in
-django-simple-history==3.7.0
-    # via -r base.in
+django-simple-history==3.8.0
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 django-slack==5.19.0
-    # via -r base.in
-django-storages[azure]==1.14.4
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+django-storages[azure]==1.14.5
     # via -r production.in
 djangorestframework==3.15.2
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 djangorestframework-jsonp==1.0.2
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-geoip2==4.8.1
-    # via -r base.in
+geoip2==5.0.1
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 gunicorn==23.0.0
     # via -r production.in
 idna==3.10
     # via
     #   requests
     #   yarl
-ip2proxy==3.4.2
-    # via -r base.in
+ip2proxy==3.5.1
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 isodate==0.7.2
     # via azure-storage-blob
 jsonfield==3.1.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 kombu==5.4.2
     # via celery
-maxminddb==2.6.2
+maxminddb==2.6.3
     # via geoip2
 multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-newrelic==10.4.0
+newrelic==10.6.0
     # via -r production.in
 packaging==24.2
     # via gunicorn
 pillow==11.1.0
-    # via -r base.in
-prompt-toolkit==3.0.48
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
+prompt-toolkit==3.0.50
     # via click-repl
-propcache==0.2.1
+propcache==0.3.0
     # via
     #   aiohttp
     #   yarl
@@ -153,11 +153,11 @@ psycopg2-binary==2.9.10
 pycparser==2.22
     # via cffi
 pyjwt==2.10.1
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 python-dateutil==2.9.0.post0
     # via celery
-pytz==2024.2
-    # via -r base.in
+pytz==2025.1
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 redis==5.2.1
     # via
     #   celery
@@ -169,7 +169,7 @@ requests==2.32.3
     #   django-slack
     #   geoip2
     #   stripe
-sentry-sdk==2.19.2
+sentry-sdk==2.22.0
     # via -r production.in
 six==1.17.0
     # via
@@ -179,7 +179,7 @@ sqlparse==0.5.3
     # via django
 stripe==4.2.0
     # via
-    #   -r base.in
+    #   -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
     #   dj-stripe
 typing-extensions==4.12.2
     # via
@@ -188,9 +188,9 @@ typing-extensions==4.12.2
     #   azure-storage-blob
     #   django-countries
     #   multidict
-tzdata==2024.2
+tzdata==2025.1
     # via kombu
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via user-agents
 ua-parser-builtins==0.18.0.post1
     # via ua-parser
@@ -200,9 +200,9 @@ urllib3==2.3.0
     #   requests
     #   sentry-sdk
 user-agents==2.2.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 uuid-utils==0.10.0
-    # via -r base.in
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 vine==5.1.0
     # via
     #   amqp
@@ -212,7 +212,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-whitenoise==6.8.2
-    # via -r base.in
+whitenoise==6.9.0
+    # via -r /home/david/ReadTheDocs/ethical-ad-server/requirements/base.in
 yarl==1.18.3
     # via aiohttp

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile testing.in
 #
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via -r testing.in
 distlib==0.3.9
     # via virtualenv
-filelock==3.16.1
+filelock==3.17.0
     # via
     #   tox
     #   virtualenv
@@ -28,5 +28,7 @@ tomli==2.2.1
     # via tox
 tox==3.28.0
     # via -r testing.in
-virtualenv==20.28.0
+typing-extensions==4.12.2
+    # via beautifulsoup4
+virtualenv==20.29.2
     # via tox


### PR DESCRIPTION
Replaces https://github.com/readthedocs/ethical-ad-server/pull/984.
Replaces #992

This has been tested including with the analyzer models.