### PR TITLE
Allauth added the forgot password link - remove ours

### DIFF
--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -25,5 +25,4 @@
   <input type="hidden" name="next" value="{{ next }}" />
 </form>
 
-<p class="mt-2"><small><a href="{% url 'account_reset_password' %}">{% trans 'Forgot password?' %}</a></small></p>
 {% endblock content %}


### PR DESCRIPTION
Allauth put the forgot PW link into password help text. This PR removes our forgot PW link which is a duplicate.

## Duplicate forgot PW links

![image](https://github.com/user-attachments/assets/e26df619-aa7d-48a7-ba21-af71c0d05626)
