### PR TITLE
Add public code for the audience estimator

### DIFF
--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -277,6 +277,15 @@
                 </a>
               </li>
 
+              {% if adserver_etl %}
+                <li class="nav-item">
+                  <a class="nav-link" href="{% url 'etl-staff-audience-estimator' %}">
+                    <span class="fa fa-bullhorn fa-fw mr-2 text-muted" aria-hidden="true"></span>
+                    <span>{% trans 'Audience Estimator' %}</span>
+                  </a>
+                </li>
+              {% endif %}
+
             </ul>
           {% endif %}
         </nav>

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -39,7 +39,6 @@ log = logging.getLogger(__name__)  # noqa
 
 # Put this here so we don't reload it on each call
 COUNTRY_DICT = dict(countries)
-COUNTRY_DICT["T1"] = "Tor"
 
 
 @dataclass

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -9,5 +9,6 @@ def settings_processor(request):
         "adserver_privacy_policy": settings.ADSERVER_PRIVACY_POLICY_URL,
         "adserver_publisher_policy": settings.ADSERVER_PUBLISHER_POLICY_URL,
         "adserver_version": settings.ADSERVER_VERSION,
+        "adserver_etl": "ethicalads_ext.etl" in settings.INSTALLED_APPS,
         "plausible_domain": settings.PLAUSIBLE_DOMAIN,
     }

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -512,6 +512,16 @@ METABASE_DASHBOARDS = {
 PLAUSIBLE_DOMAIN = env("PLAUSIBLE_DOMAIN", default="server.ethicalads.io")
 
 
+# Django countries
+# https://github.com/SmileyChris/django-countries/
+# --------------------------------------------------------------------------
+COUNTRIES_OVERRIDE = {
+    # Cloudflare uses this country code for Tor
+    # By adding it here, it will be displayed correctly when countries are shown
+    "T1": "Tor Network",
+}
+
+
 # Ad server specific settings
 # https://ethical-ad-server.readthedocs.io/en/latest/install/configuration.html
 # --------------------------------------------------------------------------

--- a/config/urls.py
+++ b/config/urls.py
@@ -55,6 +55,11 @@ if "ethicalads_ext.support" in settings.INSTALLED_APPS:
         path(r"support/", include("ethicalads_ext.support.urls")),
     ]
 
+if "ethicalads_ext.etl" in settings.INSTALLED_APPS:
+    urlpatterns += [
+        path(r"etl/", include("ethicalads_ext.etl.urls")),
+    ]
+
 urlpatterns += [
     path(r"accounts/", include("allauth.urls")),
     path(r"stripe/", include("djstripe.urls", namespace="djstripe")),


### PR DESCRIPTION
Since the audience estimator requires analytical parquet dumps, the code is in a private repo.