### PR TITLE
MFA TOTP tolerance

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -385,6 +385,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap4"
 # https://docs.allauth.org
 # https://docs.allauth.org/en/latest/account/advanced.html#custom-user-models
 # https://docs.allauth.org/en/latest/mfa/introduction.html
+# https://docs.allauth.org/en/latest/mfa/configuration.html
 # --------------------------------------------------------------------------
 ACCOUNT_ADAPTER = "adserver.auth.adapters.AdServerAccountAdapter"
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
@@ -393,6 +394,9 @@ ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 ACCOUNT_MAX_EMAIL_ADDRESSES = 1
 ACCOUNT_LOGIN_METHODS = {"email"}
+# Allow this many codes before or after to be valid.
+# MFA_TOTP_PERIOD (30s) of clock drift in either direction allowed.
+MFA_TOTP_TOLERANCE = 1
 
 
 # Celery settings for asynchronous tasks


### PR DESCRIPTION
I've seen the issue a few times where the lag between the TOTP code being inputted by the PW manager and being submitted crosses the `TOTP_PERIOD` threshold causing the code to be invalid. This will add ~30s of wiggle room here.

https://docs.allauth.org/en/latest/mfa/configuration.html