### PR TITLE
Aggregation Optimizations

### DIFF
--- a/adserver/models.py
+++ b/adserver/models.py
@@ -2762,8 +2762,8 @@ class Offer(AdBase):
 
     def is_old(self):
         """Checks if this offer is "old" meaning not for a currently running ad."""
-        four_hours_ago = timezone.now() - datetime.timedelta(hours=4)
-        if four_hours_ago > self.date:
+        old_threshold = timezone.now() - datetime.timedelta(hours=2)
+        if old_threshold > self.date:
             return True
         return False
 

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -532,6 +532,17 @@ def generate_publisher_payout_data(
     )
 
 
+def offers_dump_exists(day):
+    if settings.ADSERVER_EXT and "ethicalads_ext.etl" in settings.INSTALLED_APPS:
+        from ethicalads_ext.etl.utils import offers_dump_exists
+
+        return offers_dump_exists(day)
+    else:
+        # This is a placeholder function to avoid breaking the code
+        # when the ethicalads_ext.etl module is not available.
+        return False
+
+
 # Compile these regular expressions at startup time for performance purposes
 BLOCKLISTED_UA_REGEXES = [
     re.compile(s) for s in settings.ADSERVER_BLOCKLISTED_USER_AGENTS

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -131,7 +131,7 @@ CELERY_BEAT_SCHEDULE = {
     # Run the previous days reports
     "every-day-generate-indexes-all-reports": {
         "task": "adserver.tasks.update_previous_day_reports",
-        "schedule": crontab(hour="2", minute="0"),
+        "schedule": crontab(hour="2", minute="30"),
     },
     "every-day-calculate-publisher-ctrs": {
         "task": "adserver.tasks.calculate_publisher_ctrs",
@@ -202,7 +202,7 @@ if "ethicalads_ext.embedding" in INSTALLED_APPS:
 if "ethicalads_ext.etl" in INSTALLED_APPS:
     CELERY_BEAT_SCHEDULE["every-day-etl-pipeline"] = {
         "task": "ethicalads_ext.etl.tasks.daily_etl_pipeline",
-        "schedule": crontab(hour="0", minute="30"),
+        "schedule": crontab(hour="2", minute="0"),
     }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,10 @@ commands =
 [testenv:lint]
 description = run through black to check coding standards
 deps = -r{toxinidir}/requirements/development.txt
+setenv =
+    PYTHONPATH={toxinidir}/ethicaladserver:{toxinidir}
+    DJANGO_SETTINGS_MODULE=config.settings.testing
+    DJANGO_SETTINGS_SKIP_LOCAL=True
 commands =
     # Linting and code style
     pre-commit run --all-files
@@ -60,6 +64,7 @@ commands =
 
 [testenv:docs]
 description = check and build documentation
+deps = -r{toxinidir}/requirements/development.txt
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -W --keep-going -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
@@ -68,6 +73,10 @@ commands =
 [testenv:coverage]
 description = shows the coverage report
 whitelist_externals = echo
+setenv =
+    PYTHONPATH={toxinidir}/ethicaladserver:{toxinidir}
+    DJANGO_SETTINGS_MODULE=config.settings.testing
+    DJANGO_SETTINGS_SKIP_LOCAL=True
 commands =
     # Run html first so we have a report of the failing coverage results
     coverage html


### PR DESCRIPTION
We have a few aggregations which run nightly to make querying the previous day's data faster. Some of these are quite expensive on the database and we're looking to move this processing out of the database. We already write the day's "Offers" to a parquet file and these aggregations can be run against that file more efficiently.

This PR starts by running only the Domain aggregation against that file and only if the day's offers are present.

While putting this together, I also noticed we're seeing very small discrepencies (~100 total impressions per day out of ~600k+) and this is due to ad views for an offer from one day occurring on the next day after the Offers have been dumped. This lowers the threshold of how long an offer can be viewed for from 4 hours -> 2 hours and makes the offer dump happen 2 hours after UTC midnight. These discrepancies should disappear.