### PR TITLE
Remove keywords from string repr of Analyzer

### DIFF
--- a/adserver/analyzer/models.py
+++ b/adserver/analyzer/models.py
@@ -51,7 +51,7 @@ class BaseAnalyzedUrl(TimeStampedModel):
 
     def __str__(self):
         """Simple override."""
-        return f"{self.keywords} on {self.url}"
+        return self.url
 
     def save(self, *args, **kwargs):
         self.full_clean()


### PR DESCRIPTION
This just makes the admin a bit cleaner. The keywords are still displayed in list form.