### PR TITLE
Publisher payouts performance fix

### DIFF
--- a/adserver/tests/test_publisher_dashboard.py
+++ b/adserver/tests/test_publisher_dashboard.py
@@ -269,6 +269,9 @@ class TestPublisherDashboardViews(TestCase):
         self.ad1.incr(VIEWS, self.publisher1)
         self.ad1.incr(CLICKS, self.publisher1)
 
+        # Run the daily aggregation task
+        daily_update_publishers()
+
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Balance for this month")

--- a/adserver/tests/test_staff_actions.py
+++ b/adserver/tests/test_staff_actions.py
@@ -20,6 +20,7 @@ from ..models import PublisherPayout
 from ..staff.forms import CreateAdvertiserForm
 from ..staff.forms import CreatePublisherForm
 from ..tasks import daily_update_impressions
+from ..tasks import daily_update_publishers
 
 User = get_user_model()
 
@@ -250,6 +251,7 @@ class PublisherPayoutTests(TestCase):
 
         # Index data into proper table
         daily_update_impressions(day=last_month)
+        daily_update_publishers(day=last_month)
 
     def test_list_view(self):
         url = reverse("staff-publisher-payouts")

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -430,8 +430,9 @@ def generate_publisher_payout_data(
     """
     # pylint: disable=cyclic-import
     # pylint: disable=import-outside-toplevel
-    from .reports import PublisherReport
+    from .reports import OptimizedPublisherPaidReport
 
+    # Today in UTC - time is not important as PublisherPaidImpressions only store date, not datetime
     today = timezone.now()
     end_date = today.replace(day=1) - timedelta(days=1)
     last_payout = publisher.payouts.filter(status=PAID).last()
@@ -456,12 +457,11 @@ def generate_publisher_payout_data(
     due_report_url = None
 
     if include_current_report:
-        current_queryset = publisher.adimpression_set.filter(
+        current_queryset = publisher.publisher_paid_impressions.filter(
             date__gte=today.replace(day=1),
             date__lte=today,
-            advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
         )
-        current_report = PublisherReport(current_queryset)
+        current_report = OptimizedPublisherPaidReport(current_queryset)
         current_report.generate()
 
         current_report_url = (
@@ -480,12 +480,11 @@ def generate_publisher_payout_data(
     if include_due_report and start_date < today.replace(
         day=1, hour=0, minute=0, second=0, microsecond=0
     ):
-        due_queryset = publisher.adimpression_set.filter(
+        due_queryset = publisher.publisher_paid_impressions.filter(
             date__gte=start_date,
             date__lte=end_date,
-            advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
         )
-        due_report = PublisherReport(due_queryset)
+        due_report = OptimizedPublisherPaidReport(due_queryset)
         due_report.generate()
 
         due_report_url = (


### PR DESCRIPTION
This improves the performance of getting what a publisher is owed for this month to date and for other periods (eg. publisher getting a payout after a few months). This will also improve the performance of the staff payout list view.

It uses the optimized aggregation we have for publisher paid impressions. As a result, it can be up to 5 minutes out of date but that's probably fine for almost all purposes.

A publisher who is getting their first payout after a long time reported this due to a dashboard 502. For that case, getting what they're owed in their first payout next month but the time period for calculating their payout is almost 2 years.