### PR TITLE
Bugfix last analyzed date on analyzer

### DIFF
--- a/adserver/analyzer/tasks.py
+++ b/adserver/analyzer/tasks.py
@@ -33,6 +33,7 @@ def analyze_url(url, publisher_slug, force=False):
     - Creates or updates an entry in AnalyzedUrls table
     - Discovers keywords and topics for a URL
     """
+    skip_renanalyze_days_threshold = 30
     normalized_url = normalize_url(url)
 
     publisher = Publisher.objects.filter(slug=publisher_slug).first()
@@ -50,7 +51,8 @@ def analyze_url(url, publisher_slug, force=False):
         existing_record
         and not force
         and existing_record.last_analyzed_date
-        > (timezone.now() - datetime.timedelta(days=7))
+        and existing_record.last_analyzed_date
+        > (timezone.now() - datetime.timedelta(days=skip_renanalyze_days_threshold))
     ):
         log.warning("URL recently analyzed. Skipping.")
         return

--- a/adserver/analyzer/tasks.py
+++ b/adserver/analyzer/tasks.py
@@ -33,7 +33,6 @@ def analyze_url(url, publisher_slug, force=False):
     - Creates or updates an entry in AnalyzedUrls table
     - Discovers keywords and topics for a URL
     """
-    skip_renanalyze_days_threshold = 30
     normalized_url = normalize_url(url)
 
     publisher = Publisher.objects.filter(slug=publisher_slug).first()
@@ -52,7 +51,7 @@ def analyze_url(url, publisher_slug, force=False):
         and not force
         and existing_record.last_analyzed_date
         and existing_record.last_analyzed_date
-        > (timezone.now() - datetime.timedelta(days=skip_renanalyze_days_threshold))
+        > (timezone.now() - datetime.timedelta(days=ANALYZER_REANALYZE_DATE_THRESHOLD))
     ):
         log.warning("URL recently analyzed. Skipping.")
         return


### PR DESCRIPTION
We have some URLs in our DB that haven't been analyzed. These can be created by `daily_visited_urls_aggregation`. This causes the `analyze_url` task to fail when it is called on one of those which it currently never is automatically.

I'm going to have a separate PR to start analyzing those.