### PR TITLE
Fix a number of warnings

### DIFF
--- a/adserver/management/commands/archive_offers.py
+++ b/adserver/management/commands/archive_offers.py
@@ -15,7 +15,7 @@ import tempfile
 from pathlib import Path
 
 from django.conf import settings
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import storages
 from django.core.management import CommandError
 from django.core.management.base import BaseCommand
 from django.db import connections
@@ -135,7 +135,7 @@ class Command(BaseCommand):
 
     def copy_offer_dump(self, archive_filepath):
         """Copy offer CSV files to settings.BACKUPS_STORAGE."""
-        if not hasattr(settings, "BACKUPS_STORAGE"):
+        if "backups" not in settings.STORAGES:
             self.stdout.write(
                 self.style.WARNING(
                     _(
@@ -145,7 +145,7 @@ class Command(BaseCommand):
             )
             return
 
-        storage = get_storage_class(settings.BACKUPS_STORAGE)()
+        storage = storages.create_storage(storages.backends["backups"])
 
         storage_path = self.storage_output_dir + archive_filepath.name
         self.stdout.write(_("Copying offers (%s) to backups...") % archive_filepath)
@@ -164,7 +164,7 @@ class Command(BaseCommand):
 
     def delete_offers(self, day):
         """Deletes offers from the database (requires them to be copied to settings.BACKUPS_STORAGE)."""
-        if not hasattr(settings, "BACKUPS_STORAGE"):
+        if "backups" not in settings.STORAGES:
             self.stdout.write(
                 self.style.WARNING(
                     _("Skipping deleting archived offers (backups weren't copied)...")

--- a/adserver/models.py
+++ b/adserver/models.py
@@ -1814,7 +1814,7 @@ class Advertisement(TimeStampedModel, IndestructibleModel):
 
         # Fix up names/slugs of ads that have been copied before
         # Remove dates and (" Copy") from the end of the name/slug
-        new_name = re.sub(" \d{4}-\d{2}-\d{2}$", "", new_name)
+        new_name = re.sub(r" \d{4}-\d{2}-\d{2}$", "", new_name)
         while new_name.endswith(" Copy"):
             new_name = new_name[:-5]
 

--- a/adserver/tests/test_advertiser_dashboard.py
+++ b/adserver/tests/test_advertiser_dashboard.py
@@ -866,7 +866,7 @@ class TestAdvertiserDashboardViews(TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertContains(resp, "Preview and save your ads")
 
-            soup = bs4.BeautifulSoup(resp.content)
+            soup = bs4.BeautifulSoup(resp.content, features="html.parser")
             elem = soup.find("input", attrs={"name": "signed_advertisements"})
             self.assertIsNotNone(elem)
 

--- a/adserver/tests/test_management_commands.py
+++ b/adserver/tests/test_management_commands.py
@@ -134,7 +134,17 @@ class TestArchiveOffers(TestCase):
         output = self.out.getvalue()
         self.assertTrue("Skipping deleting archived offers" in output)
 
-    @override_settings(BACKUPS_STORAGE="django.core.files.storage.FileSystemStorage")
+    @override_settings(STORAGES={
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "whitenoise.storage.CompressedStaticFilesStorage",
+        },
+        "backups": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        }
+    })
     @patch("django.db.connections")
     def test_archive_offers_storage(self, conn_mock):
         management.call_command(

--- a/adserver/tests/test_reports.py
+++ b/adserver/tests/test_reports.py
@@ -7,6 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import reverse
+from django.utils import timezone
 from django_dynamic_fixture import get
 
 from ..constants import CLICKS
@@ -630,7 +631,7 @@ class TestReportViews(TestReportsBase):
         get(Offer, publisher=self.publisher1, div_id="ad_23453464", viewed=True)
 
         # Update reporting
-        daily_update_placements(day=datetime.datetime.utcnow().isoformat())
+        daily_update_placements(day=timezone.now().isoformat())
 
         # All reports
         response = self.client.get(url)
@@ -1110,7 +1111,7 @@ class TestReportViews(TestReportsBase):
         # 2 filters lead to a date-based view
         response = self.client.get(url, {"topic": "frontend-web", "region": "us-ca"})
         self.assertContains(
-            response, "<td>%s" % datetime.datetime.utcnow().strftime("%b")
+            response, "<td>%s" % timezone.now().strftime("%b")
         )
         self.assertNotContains(response, "<td>us-ca:frontend-web")
 

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -13,7 +13,6 @@ from datetime import timezone as dttimezone
 from urllib.parse import urlparse
 
 import IP2Proxy
-from celery.utils.iso8601 import parse_iso8601
 from django.conf import settings
 from django.contrib.gis.geoip2 import GeoIP2
 from django.contrib.gis.geoip2 import GeoIP2Exception
@@ -67,12 +66,12 @@ def get_day(day=None):
     Always return two datetimes with timezone.
     If `day` is `None`, use today.
     If `day` is a datetime or date object, use that day but remove any time data.
-    Otherwise, attempt to convert from iso8601.
+    Otherwise, attempt to convert from iso8601 with `datetime.fromisoformat`.
     """
     start_date = get_ad_day()
     if day:
         if not isinstance(day, (datetime, date)):
-            day = parse_iso8601(day)
+            day = datetime.fromisoformat(day)
         start_date = day.replace(hour=0, minute=0, second=0, microsecond=0)
         if is_naive(start_date):
             start_date = start_date.replace(tzinfo=dttimezone.utc)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -388,9 +388,10 @@ CRISPY_TEMPLATE_PACK = "bootstrap4"
 # https://docs.allauth.org/en/latest/mfa/configuration.html
 # --------------------------------------------------------------------------
 ACCOUNT_ADAPTER = "adserver.auth.adapters.AdServerAccountAdapter"
-ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 ACCOUNT_MAX_EMAIL_ADDRESSES = 1
+# https://docs.allauth.org/en/dev/account/advanced.html#custom-user-models
+ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
 ACCOUNT_LOGIN_METHODS = {"email"}
 # Allow this many codes before or after to be valid.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -389,10 +389,9 @@ CRISPY_TEMPLATE_PACK = "bootstrap4"
 # --------------------------------------------------------------------------
 ACCOUNT_ADAPTER = "adserver.auth.adapters.AdServerAccountAdapter"
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
-ACCOUNT_EMAIL_REQUIRED = True
-ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 ACCOUNT_MAX_EMAIL_ADDRESSES = 1
+ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
 ACCOUNT_LOGIN_METHODS = {"email"}
 # Allow this many codes before or after to be valid.
 # MFA_TOTP_PERIOD (30s) of clock drift in either direction allowed.

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -111,6 +111,7 @@ AZURE_ACCOUNT_NAME = env("AZURE_ACCOUNT_NAME", default="")
 AZURE_ACCOUNT_KEY = env("AZURE_ACCOUNT_KEY", default="")
 AZURE_CONTAINER = env("AZURE_CONTAINER", default="")
 BACKUPS_STORAGE = env("BACKUPS_STORAGE", default="config.storage.AzureBackupsStorage")
+STORAGES["backups"] = {"BACKEND": BACKUPS_STORAGE}
 
 
 # Celery settings for asynchronous tasks


### PR DESCRIPTION
- Warnings from allauth (eg. `settings.ACCOUNT_EMAIL_REQUIRED is deprecated, use: settings.ACCOUNT_SIGNUP_FIELDS = ['email*', 'password1*', 'password2*']`)
- Changes with Django's storages API which will become errors in Django 5.1
- Rely on the builtin `fromisoformat`