### PR TITLE
Re-introduce flight priority again

### DIFF
--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -14,6 +14,7 @@ from ..constants import COMMUNITY_CAMPAIGN
 from ..constants import HOUSE_CAMPAIGN
 from ..constants import PAID_CAMPAIGN
 from ..constants import PUBLISHER_HOUSE_CAMPAIGN
+from ..models import Advertisement
 from ..models import Flight
 from ..models import Region
 from ..models import Topic
@@ -269,7 +270,7 @@ class AdvertisingEnabledBackend(BaseAdDecisionBackend):
             ).filter(num_ads__gt=0)
 
         # Ensure we prefetch necessary data so it doesn't result in N queries for each flight
-        return flights.select_related("campaign")
+        return flights.select_related()
 
     def filter_flight(self, flight, regions=None, topics=None):
         """
@@ -373,6 +374,16 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
         * Prioritize the flight that needs the most impressions
         """
         flights = self.get_candidate_flights()
+        flights = flights.prefetch_related(
+            models.Prefetch(
+                "advertisements",
+                queryset=Advertisement.objects.filter(
+                    live=True, ad_types__slug__in=self.ad_types
+                ),
+                to_attr="matching_ads",
+            ),
+            "matching_ads__ad_types",
+        )
 
         paid_flights = []
         affiliate_flights = []
@@ -467,6 +478,15 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
                             self.publisher,
                         )
                     )
+
+                    # Boost the weight of this flight if it matches a high priority placement
+                    priority = 1
+                    for ad in flight.matching_ads:
+                        placement = self.get_placement(ad)
+                        if placement:
+                            priority = max(priority, placement.get("priority", 1))
+
+                    weighted_clicks_needed_this_interval *= priority
 
                     flight_range.append(
                         [
@@ -563,14 +583,18 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
         if self.ad_slug:
             # Ignore live and adtype checks when forcing a specific ad
             candidate_ads = flight.advertisements.filter(slug=self.ad_slug)
+            candidate_ads = candidate_ads.select_related("flight").prefetch_related(
+                "ad_types"
+            )
+        elif hasattr(flight, "matching_ads"):
+            candidate_ads = flight.matching_ads
         else:
             candidate_ads = flight.advertisements.filter(
                 live=True, ad_types__slug__in=self.ad_types
             )
-
-        candidate_ads = candidate_ads.select_related("flight").prefetch_related(
-            "ad_types"
-        )
+            candidate_ads = candidate_ads.select_related("flight").prefetch_related(
+                "ad_types"
+            )
 
         # Get similarity scores for candidate ads if embedding support is available
         # Reuse the publisher_embedding and domain_embedding fetched earlier to avoid duplicate queries

--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -270,7 +270,7 @@ class AdvertisingEnabledBackend(BaseAdDecisionBackend):
             ).filter(num_ads__gt=0)
 
         # Ensure we prefetch necessary data so it doesn't result in N queries for each flight
-        return flights.select_related()
+        return flights.select_related("campaign", "campaign__advertiser")
 
     def filter_flight(self, flight, regions=None, topics=None):
         """

--- a/adserver/tests/data/bulk_ad_upload.csv
+++ b/adserver/tests/data/bulk_ad_upload.csv
@@ -1,3 +1,3 @@
 Name,Live,Link URL,Image URL,Headline,Content,Call to Action
-Ad1,true,http://example.com/ad1,https://ethicalads.blob.core.windows.net/media/images/2022/11/ethicalads-housead.png,Ad headline,"Ad content",Ad CTA
-Ad2,true,http://example.com/ad2,https://ethicalads.blob.core.windows.net/media/images/2022/11/ethicalads-housead.png,Ad headline2,"Ad content2",Ad CTA2
+Ad1,true,http://example.com/ad1,https://media.ethicalads.io/images/2022/11/ethicalads-housead.png,Ad headline,"Ad content",Ad CTA
+Ad2,true,http://example.com/ad2,https://media.ethicalads.io/images/2022/11/ethicalads-housead.png,Ad headline2,"Ad content2",Ad CTA2

--- a/adserver/tests/data/bulk_ad_upload_invalid.csv
+++ b/adserver/tests/data/bulk_ad_upload_invalid.csv
@@ -1,2 +1,2 @@
 Name,Live,Link URL,Image URL,Headline,Content,Call to Action
-Invalid Ad1,true,http://example.com/ad1,https://ethicalads.blob.core.windows.net/media/images/2022/11/ethicalads-housead.png,Ad headline,"Ad content that is so long that it will raise an error since it's too long and there's a maximum",Ad CTA
+Invalid Ad1,true,http://example.com/ad1,https://media.ethicalads.io/images/2022/11/ethicalads-housead.png,Ad headline,"Ad content that is so long that it will raise an error since it's too long and there's a maximum",Ad CTA

--- a/adserver/tests/test_decision_engine.py
+++ b/adserver/tests/test_decision_engine.py
@@ -518,21 +518,20 @@ class DecisionEngineTests(TestCase):
             flights = list(self.probabilistic_backend.get_candidate_flights())
             self.assertEqual(len(flights), 3)
 
-        with self.assertNumQueries(1):
-            # This should just be the same query from `get_candidate_flights` above
+        with self.assertNumQueries(3):
+            # One for flights, one for ads, one for ad types (due to prefetch)
             flight = self.probabilistic_backend.select_flight()
 
-        with self.assertNumQueries(2):
-            # One query to get the specific ad for the chosen flight
-            # One to prefetch all the ad types
+        with self.assertNumQueries(0):
+            # No queries because we used the prefetched ads
             ad = self.probabilistic_backend.select_ad_for_flight(flight)
             self.assertTrue(ad in self.possible_ads, ad)
 
         with self.assertNumQueries(3):
             # Three total queries to get an ad placement
-            # 1. Get all the candidate flights
-            # 2. Choose the specific ad for the chosen flight
-            # 3. Prefetch the ad types for all the ads in the chosen flight
+            # 1. Get all the candidate flights (and prefetch ads/adtypes)
+            # 2. Choose the specific ad for the chosen flight (0 queries)
+            # 3. get_placement (0 queries as it uses prefetch)
             ad, _ = self.probabilistic_backend.get_ad_and_placement()
             self.assertTrue(ad in self.possible_ads, ad)
 
@@ -619,6 +618,85 @@ class DecisionEngineTests(TestCase):
                     randint.return_value = total + 1
                     ad, _ = self.probabilistic_backend.get_ad_and_placement()
                     self.assertEqual(ad, None)
+
+    def test_flight_matching_priority(self):
+        # Remove existing flights
+        for flight in Flight.objects.all():
+            flight.live = False
+            flight.save()
+
+        # Priority 1
+        ad_type_a = get(AdType, has_image=False, slug="a")
+        # Priority 10
+        ad_type_b = get(AdType, has_image=False, slug="b")
+
+        placements = [
+            {"div_id": "a", "ad_type": "a", "priority": 1},
+            {"div_id": "b", "ad_type": "b", "priority": 10},
+        ]
+
+        # Flight 1: Matches placement A (priority 1)
+        flight1 = get(
+            Flight,
+            live=True,
+            campaign=self.campaign,
+            sold_clicks=1000,
+            start_date=get_ad_day().date(),
+            end_date=get_ad_day().date() + datetime.timedelta(days=30),
+            pacing_interval=24 * 60 * 60,
+        )
+        ad1 = get(
+            Advertisement,
+            slug="ad1",
+            live=True,
+            flight=flight1,
+        )
+        ad1.ad_types.add(ad_type_a)
+
+        # Flight 2: Matches placement B (priority 10)
+        flight2 = get(
+            Flight,
+            live=True,
+            campaign=self.campaign,
+            sold_clicks=1000,
+            start_date=get_ad_day().date(),
+            end_date=get_ad_day().date() + datetime.timedelta(days=30),
+            pacing_interval=24 * 60 * 60,
+        )
+        ad2 = get(
+            Advertisement,
+            slug="ad2",
+            live=True,
+            flight=flight2,
+        )
+        ad2.ad_types.add(ad_type_b)
+
+        backend = ProbabilisticFlightBackend(
+            request=self.request, placements=placements, publisher=self.publisher
+        )
+
+        flight1_count = 0
+        flight2_count = 0
+        iterations = 1000
+
+        # Ensure base weights are equal
+        self.assertEqual(
+            flight1.weighted_clicks_needed_this_interval(self.publisher),
+            flight2.weighted_clicks_needed_this_interval(self.publisher),
+        )
+
+        for _ in range(iterations):
+            selected = backend.select_flight()
+            if selected == flight1:
+                flight1_count += 1
+            elif selected == flight2:
+                flight2_count += 1
+
+        # Avoid div by 0 and handle potential 0 counts
+        ratio = flight2_count / (flight1_count + 1)
+
+        # Used to be ~1, now should be ~10
+        self.assertGreater(ratio, 5.0)
 
     def test_publisher_campaign_type_restrictions(self):
         self.campaign.campaign_type = PAID_CAMPAIGN


### PR DESCRIPTION
Branched from #1204 just to ensure green tests.

Re-introduces changes reverted in #1164. I believe the performance degradation we saw there is fixed. I reviewed the queries generated and while the flight selection query is a bit different, I believe this should have good performance combined with the LRU caches for embeddings. I was able to remove one extra query.