### PR TITLE
Pin prompt-toolkit>=3.0.43 to fix TypeError on Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ dependencies = [
     # Celery <5.5 has a stability issue the redis broker: https://github.com/celery/celery/issues/8030
     "celery[redis]==5.5.0rc1",
 
+    # Celery depends on prompt-toolkit via click-repl
+    # Versions <3.0.43 pass coroutines to asyncio.wait() which raises TypeError on Python 3.12+
+    "prompt-toolkit>=3.0.43",
+
     # Static files
     "whitenoise",
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 
 [[package]]
@@ -1010,6 +1010,7 @@ dependencies = [
     { name = "ip2proxy" },
     { name = "jsonfield" },
     { name = "pillow" },
+    { name = "prompt-toolkit" },
     { name = "pyjwt" },
     { name = "pytz" },
     { name = "stripe" },
@@ -1108,6 +1109,7 @@ requires-dist = [
     { name = "openai", marker = "extra == 'analyzer'", specifier = ">=1.84.0" },
     { name = "pgvector", marker = "extra == 'analyzer'" },
     { name = "pillow" },
+    { name = "prompt-toolkit", specifier = ">=3.0.43" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'production'" },
     { name = "pyjwt" },
     { name = "pytz" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,6 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
-
-[options]
-exclude-newer = "2026-06-18T00:00:00Z"
 
 [[package]]
 name = "adlfs"


### PR DESCRIPTION
## Summary
- Older versions of `prompt-toolkit` pass bare coroutines to `asyncio.wait()`, which raises `TypeError` on Python 3.12+ (coroutines were deprecated in 3.8, became an error in 3.12)
- `prompt-toolkit` is a transitive dependency via `celery` → `click-repl`
- Pins `prompt-toolkit>=3.0.43` which wraps coroutines with `ensure_future()` before passing to `asyncio.wait()`

## Error
```
File "prompt_toolkit/renderer.py", line 514, in wait_for_cpr_responses
    await wait(coroutines, return_when=FIRST_COMPLETED)
TypeError: Passing coroutines is forbidden, use tasks explicitly.
```

## Test plan
- [ ] Verify celery starts without the `TypeError` on Python 3.12