### PR TITLE
Improve placement priority performance

### DIFF
--- a/adserver/decisionengine/backends.py
+++ b/adserver/decisionengine/backends.py
@@ -14,7 +14,6 @@ from ..constants import COMMUNITY_CAMPAIGN
 from ..constants import HOUSE_CAMPAIGN
 from ..constants import PAID_CAMPAIGN
 from ..constants import PUBLISHER_HOUSE_CAMPAIGN
-from ..models import Advertisement
 from ..models import Flight
 from ..models import Region
 from ..models import Topic
@@ -270,7 +269,7 @@ class AdvertisingEnabledBackend(BaseAdDecisionBackend):
             ).filter(num_ads__gt=0)
 
         # Ensure we prefetch necessary data so it doesn't result in N queries for each flight
-        return flights.select_related("campaign", "campaign__advertiser")
+        return flights.select_related("campaign")
 
     def filter_flight(self, flight, regions=None, topics=None):
         """
@@ -374,15 +373,22 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
         * Prioritize the flight that needs the most impressions
         """
         flights = self.get_candidate_flights()
-        flights = flights.prefetch_related(
-            models.Prefetch(
-                "advertisements",
-                queryset=Advertisement.objects.filter(
-                    live=True, ad_types__slug__in=self.ad_types
-                ),
-                to_attr="matching_ads",
-            ),
-            "matching_ads__ad_types",
+        whens = [
+            models.When(
+                advertisements__ad_types__slug=placement["ad_type"],
+                advertisements__live=True,
+                then=models.Value(placement.get("priority", 1)),
+            )
+            for placement in self.placements
+        ]
+        flights = flights.annotate(
+            max_placement_priority=models.Max(
+                models.Case(
+                    *whens,
+                    default=models.Value(1),
+                    output_field=models.IntegerField(),
+                )
+            )
         )
 
         paid_flights = []
@@ -480,11 +486,7 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
                     )
 
                     # Boost the weight of this flight if it matches a high priority placement
-                    priority = 1
-                    for ad in flight.matching_ads:
-                        placement = self.get_placement(ad)
-                        if placement:
-                            priority = max(priority, placement.get("priority", 1))
+                    priority = getattr(flight, "max_placement_priority", 1)
 
                     weighted_clicks_needed_this_interval *= priority
 
@@ -583,18 +585,14 @@ class ProbabilisticFlightBackend(AdvertisingEnabledBackend):
         if self.ad_slug:
             # Ignore live and adtype checks when forcing a specific ad
             candidate_ads = flight.advertisements.filter(slug=self.ad_slug)
-            candidate_ads = candidate_ads.select_related("flight").prefetch_related(
-                "ad_types"
-            )
-        elif hasattr(flight, "matching_ads"):
-            candidate_ads = flight.matching_ads
         else:
             candidate_ads = flight.advertisements.filter(
                 live=True, ad_types__slug__in=self.ad_types
             )
-            candidate_ads = candidate_ads.select_related("flight").prefetch_related(
-                "ad_types"
-            )
+
+        candidate_ads = candidate_ads.select_related(
+            "flight", "flight__campaign", "flight__campaign__advertiser"
+        ).prefetch_related("ad_types")
 
         # Get similarity scores for candidate ads if embedding support is available
         # Reuse the publisher_embedding and domain_embedding fetched earlier to avoid duplicate queries

--- a/adserver/tests/test_decision_engine.py
+++ b/adserver/tests/test_decision_engine.py
@@ -518,20 +518,21 @@ class DecisionEngineTests(TestCase):
             flights = list(self.probabilistic_backend.get_candidate_flights())
             self.assertEqual(len(flights), 3)
 
-        with self.assertNumQueries(3):
-            # One for flights, one for ads, one for ad types (due to prefetch)
+        with self.assertNumQueries(1):
+            # This should just be the same query from `get_candidate_flights` above
             flight = self.probabilistic_backend.select_flight()
 
-        with self.assertNumQueries(0):
-            # No queries because we used the prefetched ads
+        with self.assertNumQueries(2):
+            # One query to get the specific ad for the chosen flight
+            # One to prefetch all the ad types
             ad = self.probabilistic_backend.select_ad_for_flight(flight)
             self.assertTrue(ad in self.possible_ads, ad)
 
         with self.assertNumQueries(3):
             # Three total queries to get an ad placement
-            # 1. Get all the candidate flights (and prefetch ads/adtypes)
-            # 2. Choose the specific ad for the chosen flight (0 queries)
-            # 3. get_placement (0 queries as it uses prefetch)
+            # 1. Get all the candidate flights
+            # 2. Choose the specific ad for the chosen flight
+            # 3. Prefetch the ad types for all the ads in the chosen flight
             ad, _ = self.probabilistic_backend.get_ad_and_placement()
             self.assertTrue(ad in self.possible_ads, ad)
 


### PR DESCRIPTION
Looking at the performance degradation in NR, the problem didn't seem to be a "query" problem in so far as NR didn't show elevated database times. Looking at the code, this led me to believe the degradation (~20ms avg) from the previous change was due to python deserializing too many objects from the database.

After discussion with the ol' AI (Gemini), this change should avoid deserializing a pretty large number of objects and be similar to what we had before. Previously, we were requesting every ad and its ad types for each ad from each candidate flight. Assuming 3 ad types per ad and ~30 flights and ~4 ads per flight, we're looking at ~350 more objects being deserialized from the DB. The query itself didn't appear more expensive, but turning that data into Django model objects was. That's at least the working theory.

I have verified that this change looks good from a query perspective and I reviewed every query in the critical path.

## References

- [Django Case/When](https://docs.djangoproject.com/en/5.2/ref/models/conditional-expressions/)
- These case/when's result in Postgres [CASE statements](https://www.postgresql.org/docs/current/functions-conditional.html#FUNCTIONS-CASE)