### PR TITLE
Notify on large daily publisher traffic spikes

### DIFF
--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -1270,6 +1270,107 @@ def notify_of_completed_flights():
                 message.send()
 
 
+def check_publisher_metrics_change(
+    publisher,
+    metric,
+    current_start,
+    current_end,
+    previous_start,
+    previous_end,
+    difference_threshold,
+    min_views,
+    current_period_name,
+    previous_period_name,
+    check_increase_only=False,
+    min_views_in_current_only=False,
+):
+    """
+    Check if a publisher's metrics have changed significantly between two periods
+    and send a Slack notification if they have.
+
+    :param publisher: The Publisher instance to check
+    :param metric: The metric to compare (e.g. "views", "revenue")
+    :param current_start: Start date for the current period
+    :param current_end: End date for the current period
+    :param previous_start: Start date for the previous period
+    :param previous_end: End date for the previous period
+    :param difference_threshold: Notify of differences larger than this (e.g., 0.25 = 25%)
+    :param min_views: Don't notify unless there's at least this many views
+    :param current_period_name: Human-readable name for current period (e.g., "last week")
+    :param previous_period_name: Human-readable name for previous period
+    :param check_increase_only: If True, only notify on increases, not decreases
+    :param min_views_in_current_only: If True, only check the current period against min_views
+    """
+    # Generate a report for the current period
+    queryset = AdImpression.objects.filter(
+        date__gte=current_start,
+        publisher=publisher,
+        advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
+    )
+    if current_end:
+        queryset = queryset.filter(date__lte=current_end)
+    current_report = PublisherReport(queryset)
+    current_report.generate()
+
+    # Generate the previous period for comparison
+    queryset = AdImpression.objects.filter(
+        date__gte=previous_start,
+        publisher=publisher,
+        advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
+    )
+    if previous_end:
+        queryset = queryset.filter(date__lte=previous_end)
+    previous_report = PublisherReport(queryset)
+    previous_report.generate()
+
+    current_value = current_report.total[metric]
+    previous_value = previous_report.total[metric]
+
+    current_views = current_report.total["views"]
+    previous_views = previous_report.total["views"]
+    total_views = current_views + previous_views
+
+    if current_value > 0 and previous_value > 0:
+        if check_increase_only:
+            metric_diff = (current_value / previous_value) - 1
+        else:
+            metric_diff = abs((current_value / previous_value) - 1)
+
+        perc_diff = calculate_percent_diff(current_value, previous_value)
+
+        has_min_views = (
+            current_views >= min_views
+            if min_views_in_current_only
+            else total_views >= min_views
+        )
+
+        if metric_diff > difference_threshold and has_min_views:
+            log.info(
+                "Publisher %s: %s was %s %s and %s %s.",
+                publisher,
+                metric,
+                current_value,
+                current_period_name,
+                previous_value,
+                previous_period_name,
+            )
+
+            # Send notification to Slack about this publisher
+            slack_message(
+                "adserver/slack/publisher-metric.slack",
+                {
+                    "publisher": publisher,
+                    "metric": metric,
+                    "current_value": current_value,
+                    "previous_value": previous_value,
+                    "percent_diff": perc_diff,
+                    "report_url": generate_absolute_url(publisher.get_absolute_url()),
+                    "current_period_name": current_period_name,
+                    "previous_period_name": previous_period_name,
+                },
+            )
+
+
 @app.task()
 def notify_of_publisher_changes(difference_threshold=0.25, min_views=10_000):
     """
@@ -1282,57 +1383,46 @@ def notify_of_publisher_changes(difference_threshold=0.25, min_views=10_000):
     two_weeks_ago = a_week_ago - datetime.timedelta(days=7)
 
     for publisher in Publisher.objects.filter(allow_paid_campaigns=True):
-        # Generate a report for the last week
-        queryset = AdImpression.objects.filter(
-            date__gte=a_week_ago,
+        check_publisher_metrics_change(
             publisher=publisher,
-            advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
+            metric="revenue",
+            current_start=a_week_ago,
+            current_end=None,
+            previous_start=two_weeks_ago,
+            previous_end=a_week_ago,
+            difference_threshold=difference_threshold,
+            min_views=min_views,
+            current_period_name="last week",
+            previous_period_name="the previous week",
         )
-        last_week_report = PublisherReport(queryset)
-        last_week_report.generate()
 
-        # Generate the previous week for comparison
-        queryset = AdImpression.objects.filter(
-            date__gte=two_weeks_ago,
-            date__lte=a_week_ago,
+
+@app.task()
+def notify_of_daily_traffic_spikes(difference_threshold=2.0, min_views=1_000):
+    """
+    Send a notification when a publisher's day-over-day traffic spikes.
+
+    :param difference_threshold: Notify of increases larger than this (2.0 = 200%)
+    :param min_views: Don't notify unless there's at least this many views in the current day
+    """
+    yesterday = get_ad_day() - datetime.timedelta(days=1)
+    day_before_yesterday = yesterday - datetime.timedelta(days=1)
+
+    for publisher in Publisher.objects.filter(allow_paid_campaigns=True):
+        check_publisher_metrics_change(
             publisher=publisher,
-            advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
+            metric="views",
+            current_start=yesterday,
+            current_end=yesterday,
+            previous_start=day_before_yesterday,
+            previous_end=day_before_yesterday,
+            difference_threshold=difference_threshold,
+            min_views=min_views,
+            current_period_name="yesterday",
+            previous_period_name="the previous day",
+            check_increase_only=True,
+            min_views_in_current_only=True,
         )
-        previous_week_report = PublisherReport(queryset)
-        previous_week_report.generate()
-
-        for metric in ("revenue",):
-            total_views = (
-                last_week_report.total["views"] + previous_week_report.total["views"]
-            )
-            last_week_value = last_week_report.total[metric]
-            previous_week_value = previous_week_report.total[metric]
-            if last_week_value > 0 and previous_week_value > 0:
-                metric_diff = abs((last_week_value / previous_week_value) - 1)
-                perc_diff = calculate_percent_diff(last_week_value, previous_week_value)
-                if metric_diff > difference_threshold and total_views >= min_views:
-                    log.info(
-                        "Publisher %s: %s was %s last week and %s the previous week.",
-                        publisher,
-                        metric,
-                        last_week_value,
-                        previous_week_value,
-                    )
-
-                    # Send notification to Slack about this publisher
-                    slack_message(
-                        "adserver/slack/publisher-metric.slack",
-                        {
-                            "publisher": publisher,
-                            "metric": metric,
-                            "last_week_value": last_week_value,
-                            "previous_week_value": previous_week_value,
-                            "percent_diff": perc_diff,
-                            "report_url": generate_absolute_url(
-                                publisher.get_absolute_url()
-                            ),
-                        },
-                    )
 
 
 @app.task()

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -1339,11 +1339,11 @@ def check_publisher_metrics_change(
 
 
 @app.task()
-def notify_of_publisher_changes(difference_threshold=0.25, min_views=10_000):
+def notify_of_publisher_changes(difference_threshold=0.33, min_views=10_000):
     """
     Send a notification when a publisher's main metrics change week to week.
 
-    :param difference_threshold: Notify of differences larger than this (0.25 = 25%)
+    :param difference_threshold: Notify of differences larger than this (0.33 = 33%)
     :param min_views: Don't notify unless there's at least this many views (between both weeks)
     """
     a_week_ago = get_ad_day() - datetime.timedelta(days=7)

--- a/adserver/tasks.py
+++ b/adserver/tasks.py
@@ -1271,7 +1271,7 @@ def notify_of_completed_flights():
 
 
 def check_publisher_metrics_change(
-    publisher,
+    publishers,
     metric,
     current_start,
     current_end,
@@ -1279,96 +1279,63 @@ def check_publisher_metrics_change(
     previous_end,
     difference_threshold,
     min_views,
-    current_period_name,
-    previous_period_name,
     check_increase_only=False,
-    min_views_in_current_only=False,
 ):
     """
-    Check if a publisher's metrics have changed significantly between two periods
-    and send a Slack notification if they have.
+    Check if a group of publishers' metrics have changed significantly between two periods.
 
-    :param publisher: The Publisher instance to check
+    Yields a tuple of (publisher, current_value, previous_value, perc_diff) for
+    each publisher that meets the threshold criteria.
+
+    :param publishers: A QuerySet or list of Publisher instances to check
     :param metric: The metric to compare (e.g. "views", "revenue")
     :param current_start: Start date for the current period
     :param current_end: End date for the current period
     :param previous_start: Start date for the previous period
     :param previous_end: End date for the previous period
     :param difference_threshold: Notify of differences larger than this (e.g., 0.25 = 25%)
-    :param min_views: Don't notify unless there's at least this many views
-    :param current_period_name: Human-readable name for current period (e.g., "last week")
-    :param previous_period_name: Human-readable name for previous period
+    :param min_views: Don't notify unless there's at least this many total views
     :param check_increase_only: If True, only notify on increases, not decreases
-    :param min_views_in_current_only: If True, only check the current period against min_views
     """
-    # Generate a report for the current period
-    queryset = AdImpression.objects.filter(
-        date__gte=current_start,
-        publisher=publisher,
-        advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
-    )
-    if current_end:
-        queryset = queryset.filter(date__lte=current_end)
-    current_report = PublisherReport(queryset)
-    current_report.generate()
-
-    # Generate the previous period for comparison
-    queryset = AdImpression.objects.filter(
-        date__gte=previous_start,
-        publisher=publisher,
-        advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
-    )
-    if previous_end:
-        queryset = queryset.filter(date__lte=previous_end)
-    previous_report = PublisherReport(queryset)
-    previous_report.generate()
-
-    current_value = current_report.total[metric]
-    previous_value = previous_report.total[metric]
-
-    current_views = current_report.total["views"]
-    previous_views = previous_report.total["views"]
-    total_views = current_views + previous_views
-
-    if current_value > 0 and previous_value > 0:
-        if check_increase_only:
-            metric_diff = (current_value / previous_value) - 1
-        else:
-            metric_diff = abs((current_value / previous_value) - 1)
-
-        perc_diff = calculate_percent_diff(current_value, previous_value)
-
-        has_min_views = (
-            current_views >= min_views
-            if min_views_in_current_only
-            else total_views >= min_views
+    for publisher in publishers:
+        # Generate a report for the current period
+        queryset = AdImpression.objects.filter(
+            date__gte=current_start,
+            publisher=publisher,
+            advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
         )
+        if current_end:
+            queryset = queryset.filter(date__lte=current_end)
+        current_report = PublisherReport(queryset)
+        current_report.generate()
 
-        if metric_diff > difference_threshold and has_min_views:
-            log.info(
-                "Publisher %s: %s was %s %s and %s %s.",
-                publisher,
-                metric,
-                current_value,
-                current_period_name,
-                previous_value,
-                previous_period_name,
-            )
+        # Generate the previous period for comparison
+        queryset = AdImpression.objects.filter(
+            date__gte=previous_start,
+            publisher=publisher,
+            advertisement__flight__campaign__campaign_type=PAID_CAMPAIGN,
+        )
+        if previous_end:
+            queryset = queryset.filter(date__lte=previous_end)
+        previous_report = PublisherReport(queryset)
+        previous_report.generate()
 
-            # Send notification to Slack about this publisher
-            slack_message(
-                "adserver/slack/publisher-metric.slack",
-                {
-                    "publisher": publisher,
-                    "metric": metric,
-                    "current_value": current_value,
-                    "previous_value": previous_value,
-                    "percent_diff": perc_diff,
-                    "report_url": generate_absolute_url(publisher.get_absolute_url()),
-                    "current_period_name": current_period_name,
-                    "previous_period_name": previous_period_name,
-                },
-            )
+        current_value = current_report.total[metric]
+        previous_value = previous_report.total[metric]
+
+        current_views = current_report.total["views"]
+        previous_views = previous_report.total["views"]
+        total_views = current_views + previous_views
+
+        if current_value > 0 and previous_value > 0:
+            if check_increase_only:
+                metric_diff = (current_value / previous_value) - 1
+            else:
+                metric_diff = abs((current_value / previous_value) - 1)
+
+            if metric_diff > difference_threshold and total_views >= min_views:
+                perc_diff = calculate_percent_diff(current_value, previous_value)
+                yield publisher, current_value, previous_value, perc_diff
 
 
 @app.task()
@@ -1382,18 +1349,46 @@ def notify_of_publisher_changes(difference_threshold=0.25, min_views=10_000):
     a_week_ago = get_ad_day() - datetime.timedelta(days=7)
     two_weeks_ago = a_week_ago - datetime.timedelta(days=7)
 
-    for publisher in Publisher.objects.filter(allow_paid_campaigns=True):
-        check_publisher_metrics_change(
-            publisher=publisher,
-            metric="revenue",
-            current_start=a_week_ago,
-            current_end=None,
-            previous_start=two_weeks_ago,
-            previous_end=a_week_ago,
-            difference_threshold=difference_threshold,
-            min_views=min_views,
-            current_period_name="last week",
-            previous_period_name="the previous week",
+    publishers = Publisher.objects.filter(allow_paid_campaigns=True)
+
+    for (
+        publisher,
+        current_value,
+        previous_value,
+        perc_diff,
+    ) in check_publisher_metrics_change(
+        publishers=publishers,
+        metric="revenue",
+        current_start=a_week_ago,
+        current_end=None,
+        previous_start=two_weeks_ago,
+        previous_end=a_week_ago,
+        difference_threshold=difference_threshold,
+        min_views=min_views,
+    ):
+        log.info(
+            "Publisher %s: %s was %s %s and %s %s.",
+            publisher,
+            "revenue",
+            current_value,
+            "last week",
+            previous_value,
+            "the previous week",
+        )
+
+        # Send notification to Slack about this publisher
+        slack_message(
+            "adserver/slack/publisher-metric.slack",
+            {
+                "publisher": publisher,
+                "metric": "revenue",
+                "current_value": current_value,
+                "previous_value": previous_value,
+                "percent_diff": perc_diff,
+                "report_url": generate_absolute_url(publisher.get_absolute_url()),
+                "current_period_name": "last week",
+                "previous_period_name": "the previous week",
+            },
         )
 
 
@@ -1408,20 +1403,47 @@ def notify_of_daily_traffic_spikes(difference_threshold=2.0, min_views=1_000):
     yesterday = get_ad_day() - datetime.timedelta(days=1)
     day_before_yesterday = yesterday - datetime.timedelta(days=1)
 
-    for publisher in Publisher.objects.filter(allow_paid_campaigns=True):
-        check_publisher_metrics_change(
-            publisher=publisher,
-            metric="views",
-            current_start=yesterday,
-            current_end=yesterday,
-            previous_start=day_before_yesterday,
-            previous_end=day_before_yesterday,
-            difference_threshold=difference_threshold,
-            min_views=min_views,
-            current_period_name="yesterday",
-            previous_period_name="the previous day",
-            check_increase_only=True,
-            min_views_in_current_only=True,
+    publishers = Publisher.objects.filter(allow_paid_campaigns=True)
+
+    for (
+        publisher,
+        current_value,
+        previous_value,
+        perc_diff,
+    ) in check_publisher_metrics_change(
+        publishers=publishers,
+        metric="views",
+        current_start=yesterday,
+        current_end=yesterday,
+        previous_start=day_before_yesterday,
+        previous_end=day_before_yesterday,
+        difference_threshold=difference_threshold,
+        min_views=min_views,
+        check_increase_only=True,
+    ):
+        log.info(
+            "Publisher %s: %s was %s %s and %s %s.",
+            publisher,
+            "views",
+            current_value,
+            "yesterday",
+            previous_value,
+            "the previous day",
+        )
+
+        # Send notification to Slack about this publisher
+        slack_message(
+            "adserver/slack/publisher-metric.slack",
+            {
+                "publisher": publisher,
+                "metric": "views",
+                "current_value": current_value,
+                "previous_value": previous_value,
+                "percent_diff": perc_diff,
+                "report_url": generate_absolute_url(publisher.get_absolute_url()),
+                "current_period_name": "yesterday",
+                "previous_period_name": "the previous day",
+            },
         )
 
 

--- a/adserver/templates/adserver/slack/publisher-metric.slack
+++ b/adserver/templates/adserver/slack/publisher-metric.slack
@@ -1,6 +1,5 @@
 {% extends django_slack %}
 
-
 {% block text %}
-Publisher {{ publisher }}: "{{ metric }}" was {{ last_week_value|floatformat:-2 }} last week and {{ previous_week_value|floatformat:-2 }} the previous week ({% if percent_diff > 0 %}+{% endif %}{{ percent_diff|floatformat:2 }}%): {{ report_url }}
+Publisher {{ publisher }}: "{{ metric }}" was {{ current_value|floatformat:-2 }} {{ current_period_name|default:"last week" }} and {{ previous_value|floatformat:-2 }} {{ previous_period_name|default:"the previous week" }} ({% if percent_diff > 0 %}+{% endif %}{{ percent_diff|floatformat:2 }}%): {{ report_url }}
 {% endblock %}

--- a/adserver/tests/test_tasks.py
+++ b/adserver/tests/test_tasks.py
@@ -35,6 +35,7 @@ from ..tasks import daily_update_uplift
 from ..tasks import disable_inactive_publishers
 from ..tasks import notify_of_autorenewing_flights
 from ..tasks import notify_of_completed_flights
+from ..tasks import notify_of_daily_traffic_spikes
 from ..tasks import notify_of_first_flight_launched
 from ..tasks import notify_of_publisher_changes
 from ..tasks import remove_old_client_ids
@@ -420,6 +421,65 @@ class TasksTest(BaseAdModelsTestCase):
 
         # No messages because it's below the minimum views
         notify_of_publisher_changes(min_views=1000)
+        messages = backend.retrieve_messages()
+        self.assertEqual(len(messages), 0)
+
+    def test_notify_of_daily_traffic_spikes(self):
+        # Publisher changes only apply to paid campaigns
+        self.publisher.allow_paid_campaigns = True
+        self.publisher.save()
+
+        backend = get_backend()
+        backend.reset_messages()
+
+        notify_of_daily_traffic_spikes()
+        messages = backend.retrieve_messages()
+
+        # Shouldn't be any traffic spikes yet
+        self.assertEqual(len(messages), 0)
+
+        yesterday = get_ad_day() - datetime.timedelta(days=1)
+        day_before = yesterday - datetime.timedelta(days=1)
+
+        # Add 1000 views to yesterday
+        for _ in range(100):
+            get(
+                Offer,
+                advertisement=self.ad1,
+                publisher=self.publisher,
+                date=yesterday,
+                viewed=True,
+            )
+
+        # Add 10 views to the day before
+        for _ in range(1):
+            get(
+                Offer,
+                advertisement=self.ad1,
+                publisher=self.publisher,
+                date=day_before,
+                viewed=True,
+            )
+
+        daily_update_impressions(yesterday)
+        daily_update_impressions(day_before)
+
+        backend.reset_messages()
+        # Use smaller min_views for test speed, difference threshold of 2.0 (200% increase)
+        notify_of_daily_traffic_spikes(min_views=100)
+
+        messages = backend.retrieve_messages()
+        self.assertEqual(len(messages), 1, messages)
+        self.assertTrue(
+            '"views" was 100 yesterday and 1 the previous day (+9900.00%)'
+            in messages[0]["text"],
+            messages[0]["text"],
+        )
+
+        backend.reset_messages()
+
+        # No messages because it's below the minimum views
+        notify_of_daily_traffic_spikes(min_views=1000)
         messages = backend.retrieve_messages()
         self.assertEqual(len(messages), 0)
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -236,6 +236,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "adserver.tasks.notify_of_first_flight_launched",
         "schedule": crontab(hour="1", minute="30"),
     },
+    "every-day-notify-publisher-traffic-spikes": {
+        "task": "adserver.tasks.notify_of_daily_traffic_spikes",
+        "schedule": crontab(hour="3", minute="15"),
+    },
     "every-week-notify-publisher-changes": {
         "task": "adserver.tasks.notify_of_publisher_changes",
         # Runs on Wednesday


### PR DESCRIPTION
- 200% increases on a publisher over a single day (posts to slack)
- Keep the weekly notification