### PR TITLE
Exclude $ from copied amount in staff payout finish view

### DIFF
--- a/adserver/templates/adserver/staff/publisher-payout-finish.html
+++ b/adserver/templates/adserver/staff/publisher-payout-finish.html
@@ -45,7 +45,7 @@
 
     <dt>{% trans 'Amount' %}</dt>
     <dd>
-      <span id="payout-amount">${{ payout.amount|floatformat:2|intcomma }}</span>
+      $<span id="payout-amount">{{ payout.amount|floatformat:2|intcomma }}</span>
       <button type="button" class="btn btn-sm btn-outline-secondary ml-2 copy-btn" data-copy-target="payout-amount" title="{% trans 'Copy amount' %}">
         <span class="fa fa-copy" aria-hidden="true"></span>
       </button>

--- a/adserver/tests/test_staff_actions.py
+++ b/adserver/tests/test_staff_actions.py
@@ -406,7 +406,7 @@ class PublisherPayoutTests(TestCase):
         finish_response = self.client.get(finish_url)
         self.assertEqual(finish_response.status_code, 200)
         self.assertContains(finish_response, self.payout3.get_status_display())
-        self.assertContains(finish_response, "$99")
+        self.assertContains(finish_response, '$<span id="payout-amount">99.00</span>')
         # Verify individual copy buttons are present
         self.assertContains(finish_response, "copy-btn")
         self.assertContains(finish_response, 'data-copy-target="payout-amount"')


### PR DESCRIPTION
Move the dollar sign outside the span that the copy button reads from
so only the numeric amount is copied to the clipboard.