### PR TITLE
Fix staff payout paid filter to check status, not existence

### DIFF
--- a/adserver/staff/views.py
+++ b/adserver/staff/views.py
@@ -140,10 +140,9 @@ class PublisherPayoutView(StaffUserMixin, TemplateView):
             if not report and not current_payout:
                 continue
 
-            if (paid == "True" and current_payout is None) or (
-                paid == "False" and current_payout is not None
-            ):
-                # Filter by ``paid``, allowing for 3 states (''=all, False=not first, True=first)
+            is_paid = current_payout is not None and current_payout.status == PAID
+            if (paid == "True" and not is_paid) or (paid == "False" and is_paid):
+                # Filter by ``paid``, allowing for 3 states (''=all, False=not paid, True=paid)
                 continue
 
             if (first == "True" and data["first"] is False) or (

--- a/adserver/tests/test_staff_actions.py
+++ b/adserver/tests/test_staff_actions.py
@@ -334,6 +334,30 @@ class PublisherPayoutTests(TestCase):
         self.assertContains(list_response, "<td>$70.00</td>")
         self.assertContains(list_response, f"<span>{self.publisher1.name}</span>")
 
+    def test_list_view_paid_filter_with_emailed_payout(self):
+        """An emailed-but-not-paid payout should count as unpaid, not paid."""
+        url = reverse("staff-publisher-payouts")
+        self.client.force_login(self.staff_user)
+
+        # Simulate the staff having sent the payout email for this cycle.
+        get(
+            PublisherPayout,
+            status="emailed",
+            publisher=self.publisher1,
+            amount=70,
+            date=timezone.now(),
+        )
+
+        # paid=False should still include the publisher (the payout was emailed but not paid).
+        list_response = self.client.get(url + "?paid=False")
+        self.assertEqual(list_response.status_code, 200)
+        self.assertContains(list_response, f"<span>{self.publisher1.name}</span>")
+
+        # paid=True should NOT include the publisher (not yet paid).
+        list_response = self.client.get(url + "?paid=True")
+        self.assertEqual(list_response.status_code, 200)
+        self.assertNotContains(list_response, f"<span>{self.publisher1.name}</span>")
+
     @override_settings(
         # Use the memory email backend instead of front for testing
         FRONT_BACKEND="django.core.mail.backends.locmem.EmailBackend",


### PR DESCRIPTION
The paid filter previously checked whether any payout existed for the
current month, which meant a publisher was treated as 'paid' as soon as
the payout email was sent (status=emailed). It should only count
status=paid as paid, so emailed-but-unfinished payouts remain visible
under paid=False.