### PR TITLE
Link the dashboard back to the API docs and website (settings-driven)

### DIFF
--- a/adserver/templates/adserver/accounts/api-token.html
+++ b/adserver/templates/adserver/accounts/api-token.html
@@ -22,6 +22,10 @@
 
 <p>{% trans 'API tokens allow you to use the ad server API to download reports.' %}</p>
 
+{% if adserver_api_documentation_url %}
+  <p>{% blocktrans %}See the <a href="{{ adserver_api_documentation_url }}" target="_blank">API documentation</a> for the available endpoints and usage details.{% endblocktrans %}</p>
+{% endif %}
+
 {% if not object_list %}
   <form method="post" action="{% url 'api_token_create' %}">
     {% csrf_token %}

--- a/adserver/templates/adserver/base.html
+++ b/adserver/templates/adserver/base.html
@@ -316,6 +316,16 @@
             <a href="{% url 'support' %}" target="_blank">{% trans 'Support' %}</a>
           </li>
         {% endif %}
+        {% if adserver_api_documentation_url %}
+          <li class="list-inline-item small">
+            <a href="{{ adserver_api_documentation_url }}" target="_blank">{% trans 'API' %}</a>
+          </li>
+        {% endif %}
+        {% if adserver_website_url %}
+          <li class="list-inline-item small">
+            <a href="{{ adserver_website_url }}" target="_blank">{% trans 'Website' %}</a>
+          </li>
+        {% endif %}
         {% if adserver_privacy_policy %}
           <li class="list-inline-item small">
             <a href="{{ adserver_privacy_policy }}" target="_blank">{% trans 'Privacy Policy' %}</a>

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -12,6 +12,8 @@ def settings_processor(request):
         "adserver_ethicalads_branding": settings.ADSERVER_ETHICALADS_BRANDING,
         "adserver_privacy_policy": settings.ADSERVER_PRIVACY_POLICY_URL,
         "adserver_publisher_policy": settings.ADSERVER_PUBLISHER_POLICY_URL,
+        "adserver_api_documentation_url": settings.ADSERVER_API_DOCUMENTATION_URL,
+        "adserver_website_url": settings.ADSERVER_WEBSITE_URL,
         "adserver_version": settings.ADSERVER_VERSION,
         "adserver_etl": "ethicalads_ext.etl" in settings.INSTALLED_APPS,
         "metabase_enabled": settings.METABASE_ENABLED,

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -584,8 +584,17 @@ if ADSERVER_EXT:
 ADSERVER_DO_NOT_TRACK = False
 
 ADSERVER_ANALYTICS_ID = env("ADSERVER_ANALYTICS_ID", default=None)
+# Links from the dashboard back to external resources (policies, the API
+# reference, and the marketing website). These are configurable so self-hosted
+# instances can point them at their own resources (or unset them to hide the
+# links entirely).
 ADSERVER_PRIVACY_POLICY_URL = env("ADSERVER_PRIVACY_POLICY_URL", default=None)
 ADSERVER_PUBLISHER_POLICY_URL = env("ADSERVER_PUBLISHER_POLICY_URL", default=None)
+ADSERVER_API_DOCUMENTATION_URL = env(
+    "ADSERVER_API_DOCUMENTATION_URL",
+    default="https://ethical-ad-server.readthedocs.io/en/latest/user-guide/api.html",
+)
+ADSERVER_WEBSITE_URL = env("ADSERVER_WEBSITE_URL", default=None)
 ADSERVER_CLICK_RATELIMITS = []
 ADSERVER_VIEW_RATELIMITS = []
 ADSERVER_BLOCKLISTED_USER_AGENTS = env.list(


### PR DESCRIPTION
Human summary: I found a few places where linking to the website / API docs would be useful. Had AI through together a quick PR. 

Follow up: Need to add the ENV on deploy to get the website link. 

## What

Adds links from the dashboard back to the API reference and marketing website "where reasonable," and makes those URLs settings-driven so self-hosted instances can point them at their own resources (or leave them unset to hide the links).

## Why

The dashboard only linked back to external resources in a few ad-hoc, hardcoded places. The clearest gap was the API token page, which explains tokens are used to access the API but never linked to the API docs.

The readthedocs site is API/developer documentation rather than end-user help, so the links are scoped to the "API folks" audience — there's no general "Documentation" link on the user-facing dashboard.

## Changes

**New settings** (in `config/settings/base.py`, exposed via the existing settings context processor):

| Setting | Default |
|---|---|
| `ADSERVER_API_DOCUMENTATION_URL` | `…/en/latest/user-guide/api.html` |
| `ADSERVER_WEBSITE_URL` | unset (link hidden) |

**Where the links appear:**
- **Footer** — API and Website links, each rendered only when its URL is configured (mirrors the existing privacy/publisher-policy footer links). `ADSERVER_WEBSITE_URL` is unset by default, so the website link only appears once the env var is set on deploy.
- **API token page** — links to the API documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)