### PR TITLE
Add ability to ratelimit ASNs

### DIFF
--- a/adserver/middleware.py
+++ b/adserver/middleware.py
@@ -7,6 +7,7 @@ import socket
 from django.conf import settings
 
 from .utils import GeolocationData
+from .utils import force_int
 from .utils import get_geoipdb_geolocation
 
 
@@ -187,6 +188,9 @@ class CloudflareGeoIpMiddleware(GeoIpMiddleware):
     LATITUDE_HEADER = "X-Cloudflare-Geo-Lat"  # ip.src.lat
     LONGITUDE_HEADER = "X-Cloudflare-Geo-Lon"  # ip.src.lon
 
+    # https://developers.cloudflare.com/ruleset-engine/rules-language/fields/reference/ip.src.asnum/
+    ASN_HEADER = "X-Cloudflare-Geo-ASNum"  # ip.src.asn
+
     def get_geoip(self, request):
         geo = super().get_geoip(request)
 
@@ -204,6 +208,7 @@ class CloudflareGeoIpMiddleware(GeoIpMiddleware):
         geo.continent = request.headers.get(self.CONTINENT_HEADER, None)
         geo.lat = request.headers.get(self.LATITUDE_HEADER, None)
         geo.lng = request.headers.get(self.LONGITUDE_HEADER, None)
+        geo.asn = force_int(request.headers.get(self.ASN_HEADER, None))
 
         return geo
 

--- a/adserver/tests/test_api.py
+++ b/adserver/tests/test_api.py
@@ -2020,6 +2020,34 @@ class TestProxyViews(BaseApiTest):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp["X-Adserver-Reason"], "Ratelimited view impression")
 
+    @override_settings(
+        ADSERVER_ASNS_TO_RATELIMIT=[13335],
+        ADSERVER_ASN_RATELIMITS=["1/m"],
+    )
+    def test_view_tracking_asn_ratelimit(self):
+        with self.modify_settings(
+            MIDDLEWARE={
+                "append": "adserver.middleware.CloudflareGeoIpMiddleware",
+            }
+        ):
+            headers = {"x-cloudflare-geo-asnum": "13335"}
+            resp = self.client.get(self.url, headers=headers)
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp["X-Adserver-Reason"], "Billed view")
+
+            # View the ad again with a new nonce from the same ASN
+            offer = self.ad.offer_ad(
+                request=self.request,
+                publisher=self.publisher,
+                ad_type_slug=self.ad_type.slug,
+                div_id="foo",
+                keywords=None,
+            )
+            view_url = offer["view_url"]
+            resp = self.client.get(view_url, headers=headers)
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp["X-Adserver-Reason"], "ASN Ratelimited impression")
+
     def test_click_tracking_variable_expansion(self):
         self.ad.link = "http://example.com?utm_source=${publisher}&ad=${advertisement}"
         self.ad.save()

--- a/adserver/tests/test_utils.py
+++ b/adserver/tests/test_utils.py
@@ -4,11 +4,14 @@ from unittest import mock
 
 import pytz
 from django.contrib.gis.geoip2 import GeoIP2Exception
+from django.core.cache import cache
 from django.test import TestCase
+from django.test import override_settings
 from django.test.client import RequestFactory
 from django.utils import timezone
 from geoip2.errors import AddressNotFoundError
 
+from ..utils import GeolocationData
 from ..utils import anonymize_ip_address
 from ..utils import anonymize_user_agent
 from ..utils import build_blocked_ip_set
@@ -27,6 +30,7 @@ from ..utils import get_geoipdb_geolocation
 from ..utils import get_geolocation
 from ..utils import get_ipproxy_db
 from ..utils import is_allowed_domain
+from ..utils import is_asn_ratelimited
 from ..utils import is_blocklisted_ip
 from ..utils import is_blocklisted_referrer
 from ..utils import is_blocklisted_user_agent
@@ -39,6 +43,7 @@ from ..utils import parse_date_string
 
 class UtilsTest(TestCase):
     def setUp(self):
+        cache.clear()
         self.factory = RequestFactory()
         self.request = self.factory.get("/")
 
@@ -141,6 +146,39 @@ class UtilsTest(TestCase):
         self.assertFalse(is_view_ratelimited(request, ratelimits))
         self.assertFalse(is_view_ratelimited(request, ratelimits))
         self.assertTrue(is_view_ratelimited(request, ratelimits))
+
+    @override_settings(ADSERVER_ASNS_TO_RATELIMIT=[13335])
+    def test_asn_ratelimited(self):
+        factory = RequestFactory()
+        request = factory.get("/")
+
+        # No request.geo set
+        self.assertFalse(is_asn_ratelimited(request))
+
+        # request.geo set but no asn
+        request.geo = GeolocationData()
+        self.assertFalse(is_asn_ratelimited(request))
+
+        # ASN not in ADSERVER_ASNS_TO_RATELIMIT
+        request.geo.asn = 20473
+        self.assertFalse(is_asn_ratelimited(request))
+
+        # ASN in ADSERVER_ASNS_TO_RATELIMIT (string)
+        request.geo.asn = 13335
+        ratelimits = ["1/m"]
+        self.assertFalse(is_asn_ratelimited(request, ratelimits))
+        self.assertTrue(is_asn_ratelimited(request, ratelimits))
+
+    @override_settings(ADSERVER_ASNS_TO_RATELIMIT=[13335])
+    def test_asn_ratelimited_int_asn(self):
+        factory = RequestFactory()
+        request = factory.get("/")
+
+        # ASN as integer in geo and settings
+        request.geo = GeolocationData(asn=13335)
+        ratelimits = ["1/m"]
+        self.assertFalse(is_asn_ratelimited(request, ratelimits))
+        self.assertTrue(is_asn_ratelimited(request, ratelimits))
 
     def test_generate_client_id(self):
         hexdigest1 = generate_client_id("8.8.8.8", "Mac OS, Safari, 10.x.x")

--- a/adserver/utils.py
+++ b/adserver/utils.py
@@ -89,6 +89,15 @@ class GeolocationData:
     lat: float = None
     lng: float = None
     continent: str = None
+    asn: int = None
+
+
+def force_int(value) -> int | None:
+    """Force a value to an integer, returning None if it can't be converted."""
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
 
 
 def get_ad_day():
@@ -279,6 +288,37 @@ def is_click_ratelimited(request, ratelimits=None):
     return False
 
 
+def is_asn_ratelimited(request, ratelimits=None) -> bool:
+    """Returns ``True`` if this user is rate limited by ASN and ``False`` otherwise."""
+    if ratelimits is None:
+        # Explicitly set the rate limits ONLY if the parameter is `None`
+        # If it is an empty list, there's simply no rate limiting
+        ratelimits = settings.ADSERVER_ASN_RATELIMITS
+
+    geo = get_geolocation(request)
+    if not geo or not geo.asn:
+        return False
+
+    asn_int = force_int(geo.asn)
+    if asn_int is None:
+        return False
+
+    if asn_int not in settings.ADSERVER_ASNS_TO_RATELIMIT:
+        return False
+
+    for rate in ratelimits:
+        if is_ratelimited(
+            request,
+            group="ad.asn",
+            key=lambda _, req: str(req.geo.asn),
+            rate=rate,
+            increment=True,
+        ):
+            return True
+
+    return False
+
+
 def is_blocklisted_user_agent(user_agent, blocklist_regexes=None):
     """Returns ``True`` if the UA is blocklisted and ``False`` otherwise."""
     if blocklist_regexes is None:
@@ -343,7 +383,7 @@ def is_allowed_domain(url, allowed_domains):
     return False
 
 
-def get_geolocation(request, force=False):
+def get_geolocation(request, force=False) -> GeolocationData:
     """Gets the geolocation for this IP address."""
     if force:
         return get_geoipdb_geolocation(request)
@@ -357,7 +397,7 @@ def get_geolocation(request, force=False):
     return GeolocationData()
 
 
-def get_geoipdb_geolocation(request):
+def get_geoipdb_geolocation(request) -> GeolocationData:
     """Get geolocation using a GeoIP database (such as MaxMind)."""
     geolocation = GeolocationData()
     ip_address = get_client_ip(request)

--- a/adserver/views.py
+++ b/adserver/views.py
@@ -128,6 +128,7 @@ from .utils import get_client_ip
 from .utils import get_client_user_agent
 from .utils import get_geolocation
 from .utils import is_allowed_domain
+from .utils import is_asn_ratelimited
 from .utils import is_blocklisted_ip
 from .utils import is_blocklisted_referrer
 from .utils import is_blocklisted_user_agent
@@ -1206,6 +1207,14 @@ class BaseProxyView(View):
                 geo_data.metro,
             )
             reason = "Invalid targeting impression"
+        elif is_asn_ratelimited(request):
+            log.log(
+                self.log_security_level,
+                "Too many requests from this ASN, Publisher: [%s], ASN: [%s]",
+                offer.publisher,
+                request.geo.asn,
+            )
+            reason = "ASN Ratelimited impression"
         elif self.impression_type == CLICKS and is_click_ratelimited(request):
             log.log(
                 self.log_level,

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -601,6 +601,12 @@ ADSERVER_BLOCKLISTED_USER_AGENTS = env.list(
     "ADSERVER_BLOCKLISTED_USER_AGENTS", default=[]
 )
 ADSERVER_BLOCKLISTED_REFERRERS = env.list("ADSERVER_BLOCKLISTED_REFERRERS", default=[])
+# Ratelimit certain problematic ASNs
+ADSERVER_ASNS_TO_RATELIMIT = {
+    int(x) for x in env.list("ADSERVER_ASNS_TO_RATELIMIT", default=[])
+}
+ADSERVER_ASN_RATELIMITS = env.list("ADSERVER_ASN_RATELIMITS", default=[])
+
 ADSERVER_MINIMUM_PAYOUT = env.int("ADSERVER_MINIMUM_PAYOUT", default=50)
 # Recording views is highly discouraged in production but useful in development
 ADSERVER_RECORD_VIEWS = True


### PR DESCRIPTION
This allows us to add ratelimits to selected ASNs with a setting/envvar. Cloudflare is already sending ASN down to the application.